### PR TITLE
feat(run-cmd): add script runner command

### DIFF
--- a/.airlock/lint.sh
+++ b/.airlock/lint.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compute changed files between base and head SHAs
+base="${AIRLOCK_BASE_SHA:-HEAD~1}"
+head="${AIRLOCK_HEAD_SHA:-HEAD}"
+
+# Get committed changes between SHAs
+changed_files=$(git diff --name-only --diff-filter=ACMR "$base" "$head" 2>/dev/null || true)
+
+# Also include uncommitted changes (staged + unstaged) if any
+uncommitted=$(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null || true)
+staged=$(git diff --name-only --diff-filter=ACMR --cached 2>/dev/null || true)
+
+# Merge and deduplicate all changed files
+changed_files=$(printf '%s\n%s\n%s' "$changed_files" "$uncommitted" "$staged" | sort -u | sed '/^$/d')
+
+if [ -z "$changed_files" ]; then
+  echo "No changed files detected."
+  exit 0
+fi
+
+# Filter to TypeScript files
+ts_files=()
+while IFS= read -r file; do
+  if [[ "$file" == *.ts || "$file" == *.tsx ]]; then
+    # Only include files that still exist (not deleted)
+    if [ -f "$file" ]; then
+      ts_files+=("$file")
+    fi
+  fi
+done <<< "$changed_files"
+
+if [ ${#ts_files[@]} -eq 0 ]; then
+  echo "No TypeScript files changed — nothing to lint."
+  exit 0
+fi
+
+echo "Linting ${#ts_files[@]} changed TypeScript file(s):"
+printf '  %s\n' "${ts_files[@]}"
+echo ""
+
+errors=0
+
+# Step 1: Auto-fix formatting with Prettier
+echo "==> Prettier --write (auto-fix)"
+if npx prettier --write "${ts_files[@]}" 2>&1; then
+  echo "    Prettier auto-fix done."
+else
+  echo "    Prettier auto-fix encountered issues."
+fi
+echo ""
+
+# Step 2: Verify formatting is clean
+echo "==> Prettier --check (verify)"
+if npx prettier --check "${ts_files[@]}" 2>&1; then
+  echo "    Prettier check passed."
+else
+  echo "    Prettier check FAILED — formatting issues remain."
+  errors=1
+fi
+echo ""
+
+# Step 3: TypeScript type-check (whole project, since types are interconnected)
+echo "==> tsc --noEmit (type-check)"
+if npx tsc --noEmit 2>&1; then
+  echo "    TypeScript check passed."
+else
+  echo "    TypeScript check FAILED."
+  errors=1
+fi
+echo ""
+
+if [ "$errors" -ne 0 ]; then
+  echo "FAIL: Some checks did not pass."
+  exit 1
+fi
+
+echo "All checks passed."
+exit 0

--- a/.airlock/workflows/main.yml
+++ b/.airlock/workflows/main.yml
@@ -1,0 +1,66 @@
+# Airlock workflow configuration
+# Documentation: https://github.com/airlock-hq/airlock
+
+name: Main Pipeline
+
+on:
+  push:
+    branches: ['**']
+
+jobs:
+  rebase:
+    name: Rebase
+    steps:
+      - name: rebase
+        uses: airlock-hq/airlock/defaults/rebase@main
+
+  critique:
+    name: Critique
+    needs: rebase
+    steps:
+      - name: critique
+        uses: airlock-hq/airlock/defaults/critique@main
+
+  test:
+    name: Test
+    needs: rebase
+    steps:
+      - name: test
+        uses: airlock-hq/airlock/defaults/test@main
+
+  gate:
+    name: Review Gate
+    needs: [critique, test]
+    steps:
+      - name: review
+        uses: airlock-hq/airlock/defaults/gate@main
+        env:
+          # Change to never, low, medium, or high to control when human approval is required.
+          AIRLOCK_RISK_THRESHOLD: medium
+
+  describe:
+    name: Describe
+    needs: gate
+    steps:
+      - name: describe
+        uses: airlock-hq/airlock/defaults/describe@main
+
+  document:
+    name: Document
+    needs: gate
+    steps:
+      - name: document
+        uses: airlock-hq/airlock/defaults/document@main
+        apply-patch: true
+
+  deploy:
+    name: Lint & Push
+    needs: [describe, document]
+    steps:
+      - name: lint
+        uses: airlock-hq/airlock/defaults/lint@main
+        apply-patch: true
+      - name: push
+        uses: airlock-hq/airlock/defaults/push@main
+      - name: create-pr
+        uses: airlock-hq/airlock/defaults/create-pr@main

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Execute `npm i -g chrome-devtools-axi` and run `chrome-devtools-axi` for browser
 | `back`            | Navigate back                       |
 | `wait <ms\|text>` | Wait for time or text to appear     |
 | `eval <js>`       | Evaluate JavaScript in page context |
+| `run`             | Execute a multi-step script from stdin |
 
 ### Interaction
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,15 @@
 import { encode } from "@toon-format/toon";
 import { CdpError, callTool, ensureBridge, getSessionSnapshotIfRunning, stopBridge } from "./client.js";
 import { installHooks } from "./hooks.js";
+import { readStdin, runScript } from "./run.js";
 import { countRefs, extractTitle, truncateSnapshot } from "./snapshot.js";
 import { getSuggestions } from "./suggestions.js";
 
 const HELP = `usage: chrome-devtools-axi <command> [args]
-commands[33]:
+commands[34]:
   open <url>, snapshot, screenshot <path>, click @<uid>, fill @<uid> <text>,
   type <text>, press <key>, scroll <dir>, back, wait <ms|text>, eval <js>,
+  run,
   hover @<uid>, drag @<from> @<to>, fillform @<uid>=<val>..., dialog <action>,
   upload @<uid> <path>, pages, newpage <url>, selectpage <id>, closepage <id>,
   resize <w> <h>, emulate, console, console-get <id>, network,
@@ -151,6 +153,49 @@ args:
 examples:
   chrome-devtools-axi eval "document.title"
   chrome-devtools-axi eval "document.querySelectorAll('a').length"`,
+
+  run: `usage: chrome-devtools-axi run <<'EOF'
+  ...script...
+  EOF
+
+Execute a JavaScript script from stdin against the current browser session.
+The script gets a global \`page\` object. Only the script's stdout is returned.
+Pipe a script via heredoc or stdin — no file path needed.
+
+script API (available as global \`page\`):
+  await page.open(url)              Navigate, returns { url, status }
+  await page.eval(jsOrFn)           Evaluate JS in the page, returns the value
+  await page.snapshot()             Get the accessibility tree as text
+  await page.wait(ms)               Wait by duration
+  await page.wait(selector)         Wait for CSS selector (30s timeout)
+  await page.wait(selector, ms)     Wait for CSS selector with timeout
+  await page.click("@uid")          Click an element by ref
+  await page.click(selector)        Click via CSS selector
+  await page.fill("@uid", text)     Fill a form field by ref
+  await page.fill(selector, text)   Fill via CSS selector
+  await page.type(text)             Type at the focused element
+  await page.press(key)             Press a keyboard key
+  await page.back()                 Navigate back
+
+click and fill accept either @uid refs (from snapshot) or CSS selectors.
+
+examples:
+  chrome-devtools-axi run <<'EOF'
+  await page.open("https://example.com");
+  console.log(await page.eval(() => document.title));
+  EOF
+
+  chrome-devtools-axi run <<'EOF'
+  await page.open("https://en.wikipedia.org/wiki/Ada_Lovelace");
+  await page.click("a[href='/wiki/Charles_Babbage']");
+  await page.wait(".mw-page-title-main");
+  console.log(await page.eval(() => document.title));
+  EOF
+
+  chrome-devtools-axi run <<'EOF'
+  const { status } = await page.open("https://httpbin.org/status/404");
+  console.log("status:", status);
+  EOF`,
 
   start: `usage: chrome-devtools-axi start
 Start the bridge server (launches headless Chrome).
@@ -1151,11 +1196,31 @@ async function handleHeap(args: string[]): Promise<string> {
   return encode({ heap: filePath });
 }
 
+async function handleRun(): Promise<string | undefined> {
+  if (process.stdin.isTTY) {
+    throw new CdpError("No script provided on stdin", "VALIDATION_ERROR", [
+      "Pipe a script: chrome-devtools-axi run <<'EOF'\\n...\\nEOF",
+    ]);
+  }
+  const content = await readStdin();
+  if (!content.trim()) {
+    throw new CdpError("Empty script on stdin", "VALIDATION_ERROR", [
+      "Pipe a script: chrome-devtools-axi run <<'EOF'\\n...\\nEOF",
+    ]);
+  }
+  const result = await runScript(content, callTool);
+  return result.stdout || undefined;
+}
+
 async function handleHome(full: boolean): Promise<string> {
   const result = await getSessionSnapshotIfRunning();
   if (!result) {
     const blocks = [encode({ browser: "no active session" })];
-    blocks.push(renderHelp(["Run `chrome-devtools-axi open <url>` to start browsing"]));
+    blocks.push(renderHelp([
+      "Run `chrome-devtools-axi open <url>` to start browsing",
+      "Run `chrome-devtools-axi run <<'EOF'\\n...\\nEOF` to execute a multi-step script",
+      "Run `chrome-devtools-axi run --help` for the script API",
+    ]));
     return renderOutput(blocks);
   }
   const snapshot = stripSnapshotHeader(result);
@@ -1225,6 +1290,14 @@ export async function main(argv: string[]): Promise<void> {
       case "eval":
         output = await handleEval(commandArgs);
         break;
+      case "run": {
+        const runOutput = await handleRun();
+        if (runOutput !== undefined) {
+          // Script already printed its output; write it raw (no trailing newline added)
+          process.stdout.write(runOutput);
+        }
+        return;
+      }
       case "hover":
         output = await handleHover(commandArgs, full);
         break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,11 @@
 import { encode } from "@toon-format/toon";
-import { CdpError, callTool, ensureBridge, getSessionSnapshotIfRunning, stopBridge } from "./client.js";
+import {
+  CdpError,
+  callTool,
+  ensureBridge,
+  getSessionSnapshotIfRunning,
+  stopBridge,
+} from "./client.js";
 import { installHooks } from "./hooks.js";
 import { readStdin, runScript } from "./run.js";
 import { countRefs, extractTitle, truncateSnapshot } from "./snapshot.js";
@@ -485,7 +491,9 @@ export function formatScreenshotOutput(filePath: string): string {
 }
 
 /** Parse MCP list_pages markdown into structured data. */
-export function parsePagesList(text: string): { id: number; url: string; selected: boolean }[] {
+export function parsePagesList(
+  text: string,
+): { id: number; url: string; selected: boolean }[] {
   const pages: { id: number; url: string; selected: boolean }[] = [];
   for (const line of text.split("\n")) {
     const m = line.match(/^(\d+):\s+(\S+)(\s+\[selected\])?/);
@@ -497,7 +505,11 @@ export function parsePagesList(text: string): { id: number; url: string; selecte
 }
 
 /** Format raw MCP text result as AXI output: labeled block + truncation + suggestions. */
-export function formatMcpResult(label: string, text: string, suggestions: string[]): string {
+export function formatMcpResult(
+  label: string,
+  text: string,
+  suggestions: string[],
+): string {
   const blocks: string[] = [];
   const tr = truncateSnapshot(text, false, 2000);
   blocks.push(`${label}:\n${tr.text.trimEnd()}`);
@@ -510,7 +522,9 @@ export function formatMcpResult(label: string, text: string, suggestions: string
   return renderOutput(blocks);
 }
 
-export function parseFillFormArgs(args: string[]): { entries: { uid: string; value: string }[] } {
+export function parseFillFormArgs(args: string[]): {
+  entries: { uid: string; value: string }[];
+} {
   const entries: { uid: string; value: string }[] = [];
   for (const arg of args) {
     if (arg === "--full") continue;
@@ -518,7 +532,10 @@ export function parseFillFormArgs(args: string[]): { entries: { uid: string; val
     if (!match) continue;
     const uid = match[1];
     let value = match[2];
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
       value = value.slice(1, -1);
     }
     entries.push({ uid, value });
@@ -546,9 +563,15 @@ export function parseEmulateArgs(args: string[]): EmulateArgs {
   let i = 0;
   while (i < args.length) {
     switch (args[i]) {
-      case "--viewport": result.viewport = args[++i]; break;
-      case "--color-scheme": result.colorScheme = args[++i]; break;
-      case "--network": result.networkConditions = args[++i]; break;
+      case "--viewport":
+        result.viewport = args[++i];
+        break;
+      case "--color-scheme":
+        result.colorScheme = args[++i];
+        break;
+      case "--network":
+        result.networkConditions = args[++i];
+        break;
       case "--cpu": {
         const cpuThrottlingRate = parseOptionalInteger(args[++i]);
         if (cpuThrottlingRate !== undefined) {
@@ -556,23 +579,31 @@ export function parseEmulateArgs(args: string[]): EmulateArgs {
         }
         break;
       }
-      case "--geolocation": result.geolocation = args[++i]; break;
-      case "--user-agent": result.userAgent = args[++i]; break;
+      case "--geolocation":
+        result.geolocation = args[++i];
+        break;
+      case "--user-agent":
+        result.userAgent = args[++i];
+        break;
     }
     i++;
   }
   return result;
 }
 
-export function parseConsoleArgs(args: string[]): { types?: string[]; pageSize?: number; pageIdx?: number } {
+export function parseConsoleArgs(args: string[]): {
+  types?: string[];
+  pageSize?: number;
+  pageIdx?: number;
+} {
   const result: { types?: string[]; pageSize?: number; pageIdx?: number } = {};
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--type" && i + 1 < args.length) { result.types = [args[++i]]; }
-    else if (args[i] === "--limit" && i + 1 < args.length) {
+    if (args[i] === "--type" && i + 1 < args.length) {
+      result.types = [args[++i]];
+    } else if (args[i] === "--limit" && i + 1 < args.length) {
       const pageSize = parseOptionalInteger(args[++i]);
       if (pageSize !== undefined) result.pageSize = pageSize;
-    }
-    else if (args[i] === "--page" && i + 1 < args.length) {
+    } else if (args[i] === "--page" && i + 1 < args.length) {
       const pageIdx = parseOptionalInteger(args[++i]);
       if (pageIdx !== undefined) result.pageIdx = pageIdx;
     }
@@ -580,15 +611,23 @@ export function parseConsoleArgs(args: string[]): { types?: string[]; pageSize?:
   return result;
 }
 
-export function parseNetworkArgs(args: string[]): { resourceTypes?: string[]; pageSize?: number; pageIdx?: number } {
-  const result: { resourceTypes?: string[]; pageSize?: number; pageIdx?: number } = {};
+export function parseNetworkArgs(args: string[]): {
+  resourceTypes?: string[];
+  pageSize?: number;
+  pageIdx?: number;
+} {
+  const result: {
+    resourceTypes?: string[];
+    pageSize?: number;
+    pageIdx?: number;
+  } = {};
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--type" && i + 1 < args.length) { result.resourceTypes = [args[++i]]; }
-    else if (args[i] === "--limit" && i + 1 < args.length) {
+    if (args[i] === "--type" && i + 1 < args.length) {
+      result.resourceTypes = [args[++i]];
+    } else if (args[i] === "--limit" && i + 1 < args.length) {
       const pageSize = parseOptionalInteger(args[++i]);
       if (pageSize !== undefined) result.pageSize = pageSize;
-    }
-    else if (args[i] === "--page" && i + 1 < args.length) {
+    } else if (args[i] === "--page" && i + 1 < args.length) {
       const pageIdx = parseOptionalInteger(args[++i]);
       if (pageIdx !== undefined) result.pageIdx = pageIdx;
     }
@@ -596,12 +635,22 @@ export function parseNetworkArgs(args: string[]): { resourceTypes?: string[]; pa
   return result;
 }
 
-export function parseNetworkGetArgs(args: string[]): { reqid?: number; responseFilePath?: string; requestFilePath?: string } {
-  const result: { reqid?: number; responseFilePath?: string; requestFilePath?: string } = {};
+export function parseNetworkGetArgs(args: string[]): {
+  reqid?: number;
+  responseFilePath?: string;
+  requestFilePath?: string;
+} {
+  const result: {
+    reqid?: number;
+    responseFilePath?: string;
+    requestFilePath?: string;
+  } = {};
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--response-file" && i + 1 < args.length) { result.responseFilePath = args[++i]; }
-    else if (args[i] === "--request-file" && i + 1 < args.length) { result.requestFilePath = args[++i]; }
-    else if (!args[i].startsWith("--")) {
+    if (args[i] === "--response-file" && i + 1 < args.length) {
+      result.responseFilePath = args[++i];
+    } else if (args[i] === "--request-file" && i + 1 < args.length) {
+      result.requestFilePath = args[++i];
+    } else if (!args[i].startsWith("--")) {
       const reqid = parseOptionalInteger(args[i]);
       if (reqid !== undefined) result.reqid = reqid;
     }
@@ -609,25 +658,46 @@ export function parseNetworkGetArgs(args: string[]): { reqid?: number; responseF
   return result;
 }
 
-export function parseLighthouseArgs(args: string[]): { device?: string; mode?: string; outputDirPath?: string } {
+export function parseLighthouseArgs(args: string[]): {
+  device?: string;
+  mode?: string;
+  outputDirPath?: string;
+} {
   const result: { device?: string; mode?: string; outputDirPath?: string } = {};
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
-      case "--device": result.device = args[++i]; break;
-      case "--mode": result.mode = args[++i]; break;
-      case "--output-dir": result.outputDirPath = args[++i]; break;
+      case "--device":
+        result.device = args[++i];
+        break;
+      case "--mode":
+        result.mode = args[++i];
+        break;
+      case "--output-dir":
+        result.outputDirPath = args[++i];
+        break;
     }
   }
   return result;
 }
 
-export function parsePerfStartArgs(args: string[]): { reload?: boolean; autoStop?: boolean; filePath?: string } {
-  const result: { reload?: boolean; autoStop?: boolean; filePath?: string } = {};
+export function parsePerfStartArgs(args: string[]): {
+  reload?: boolean;
+  autoStop?: boolean;
+  filePath?: string;
+} {
+  const result: { reload?: boolean; autoStop?: boolean; filePath?: string } =
+    {};
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
-      case "--no-reload": result.reload = false; break;
-      case "--no-auto-stop": result.autoStop = false; break;
-      case "--file": result.filePath = args[++i]; break;
+      case "--no-reload":
+        result.reload = false;
+        break;
+      case "--no-auto-stop":
+        result.autoStop = false;
+        break;
+      case "--file":
+        result.filePath = args[++i];
+        break;
     }
   }
   return result;
@@ -639,7 +709,11 @@ function renderHelp(lines: string[]): string {
   return `help[${lines.length}]:\n${indented}`;
 }
 
-function renderError(message: string, code: string, suggestions: string[] = []): string {
+function renderError(
+  message: string,
+  code: string,
+  suggestions: string[] = [],
+): string {
   const blocks = [encode({ error: message, code })];
   if (suggestions.length > 0) {
     blocks.push(renderHelp(suggestions));
@@ -664,11 +738,18 @@ function parseSnapshotFromResponse(response: string): string | null {
   const trimmed = after.replace(/^\s*\n/, "");
   // Snapshot ends at the next ## heading or end of text
   const nextHeading = trimmed.indexOf("\n## ");
-  return nextHeading === -1 ? trimmed.trimEnd() : trimmed.slice(0, nextHeading).trimEnd();
+  return nextHeading === -1
+    ? trimmed.trimEnd()
+    : trimmed.slice(0, nextHeading).trimEnd();
 }
 
 /** Format page metadata (TOON) + raw snapshot + suggestions. */
-function formatPageOutput(snapshot: string, command: string, url?: string, full = false): string {
+function formatPageOutput(
+  snapshot: string,
+  command: string,
+  url?: string,
+  full = false,
+): string {
   const title = extractTitle(snapshot);
   const refs = countRefs(snapshot);
 
@@ -692,7 +773,9 @@ function formatPageOutput(snapshot: string, command: string, url?: string, full 
   // Contextual suggestions
   const suggestions = getSuggestions({ command, url, snapshot });
   if (tr.truncated) {
-    suggestions.push(`Run \`chrome-devtools-axi ${command}${url ? " " + url : ""} --full\` to see complete snapshot`);
+    suggestions.push(
+      `Run \`chrome-devtools-axi ${command}${url ? " " + url : ""} --full\` to see complete snapshot`,
+    );
   }
   if (suggestions.length > 0) {
     blocks.push(renderHelp(suggestions));
@@ -719,7 +802,9 @@ function parseUid(arg: string): string {
 function isRecoverableOpenError(error: unknown): error is CdpError {
   if (!(error instanceof CdpError)) return false;
   if (error.code !== "BROWSER_ERROR") return false;
-  return /not connected|session (?:closed|not found)|no page/i.test(error.message);
+  return /not connected|session (?:closed|not found)|no page/i.test(
+    error.message,
+  );
 }
 
 /**
@@ -812,7 +897,10 @@ async function handleFill(args: string[], full: boolean): Promise<string> {
     ]);
   }
 
-  const snapshot = await callWithSnapshot("fill", { uid: parseUid(uid), value });
+  const snapshot = await callWithSnapshot("fill", {
+    uid: parseUid(uid),
+    value,
+  });
   return formatPageOutput(snapshot, "fill", undefined, full);
 }
 
@@ -864,10 +952,14 @@ async function handleBack(full: boolean): Promise<string> {
 async function handleWait(args: string[]): Promise<string> {
   const target = args[0];
   if (!target) {
-    throw new CdpError("Missing wait target (milliseconds or text)", "VALIDATION_ERROR", [
-      "Run `chrome-devtools-axi wait 2000` to wait 2 seconds",
-      'Run `chrome-devtools-axi wait "Submit"` to wait for text to appear',
-    ]);
+    throw new CdpError(
+      "Missing wait target (milliseconds or text)",
+      "VALIDATION_ERROR",
+      [
+        "Run `chrome-devtools-axi wait 2000` to wait 2 seconds",
+        'Run `chrome-devtools-axi wait "Submit"` to wait for text to appear',
+      ],
+    );
   }
 
   const isNumeric = /^\d+$/.test(target);
@@ -898,7 +990,8 @@ function parseEvalResult(output: string): string {
   if (jsonBlock) return jsonBlock[1].trim();
   // Fallback: strip the preamble if present
   const preamble = "Script ran on page and returned:";
-  if (output.includes(preamble)) return output.slice(output.indexOf(preamble) + preamble.length).trim();
+  if (output.includes(preamble))
+    return output.slice(output.indexOf(preamble) + preamble.length).trim();
   return output.trim();
 }
 
@@ -910,7 +1003,9 @@ async function handleEval(args: string[]): Promise<string> {
     ]);
   }
 
-  const output = await callTool("evaluate_script", { function: wrapJsExpression(js) });
+  const output = await callTool("evaluate_script", {
+    function: wrapJsExpression(js),
+  });
 
   const blocks: string[] = [];
   blocks.push(encode({ result: parseEvalResult(output) }));
@@ -945,10 +1040,12 @@ async function handlePages(): Promise<string> {
   const header = `pages[${pages.length}]{id,url,selected}:`;
   const rows = pages.map((p) => `  ${p.id},${p.url},${p.selected}`);
   blocks.push(`${header}\n${rows.join("\n")}`);
-  blocks.push(renderHelp([
-    "Run `chrome-devtools-axi selectpage <id>` to switch tabs",
-    "Run `chrome-devtools-axi newpage <url>` to open a new tab",
-  ]));
+  blocks.push(
+    renderHelp([
+      "Run `chrome-devtools-axi selectpage <id>` to switch tabs",
+      "Run `chrome-devtools-axi newpage <url>` to open a new tab",
+    ]),
+  );
   return renderOutput(blocks);
 }
 
@@ -967,7 +1064,10 @@ async function handleNewPage(args: string[], full: boolean): Promise<string> {
   return formatPageOutput(snapshot, "newpage", url, full);
 }
 
-async function handleSelectPage(args: string[], full: boolean): Promise<string> {
+async function handleSelectPage(
+  args: string[],
+  full: boolean,
+): Promise<string> {
   const id = args[0];
   if (!id) {
     throw new CdpError("Missing page ID", "VALIDATION_ERROR", [
@@ -1002,11 +1102,15 @@ async function handleClosePage(args: string[]): Promise<string> {
   const beforeResult = await callTool("list_pages");
   const pagesBefore = parsePagesList(beforeResult);
   if (pagesBefore.length <= 1) {
-    const blocks = [encode({ status: "cannot close the last open page (no-op)" })];
-    blocks.push(renderHelp([
-      "Run `chrome-devtools-axi newpage <url>` to open another tab first",
-      "Run `chrome-devtools-axi stop` to shut down the browser entirely",
-    ]));
+    const blocks = [
+      encode({ status: "cannot close the last open page (no-op)" }),
+    ];
+    blocks.push(
+      renderHelp([
+        "Run `chrome-devtools-axi newpage <url>` to open another tab first",
+        "Run `chrome-devtools-axi stop` to shut down the browser entirely",
+      ]),
+    );
     return renderOutput(blocks);
   }
   await callTool("close_page", { pageId });
@@ -1052,7 +1156,10 @@ async function handleDrag(args: string[], full: boolean): Promise<string> {
       "Run `chrome-devtools-axi drag @<from> @<to>` — get uids from snapshot",
     ]);
   }
-  const snapshot = await callWithSnapshot("drag", { from_uid: parseUid(from), to_uid: parseUid(to) });
+  const snapshot = await callWithSnapshot("drag", {
+    from_uid: parseUid(from),
+    to_uid: parseUid(to),
+  });
   return formatPageOutput(snapshot, "drag", undefined, full);
 }
 
@@ -1094,7 +1201,10 @@ async function handleUpload(args: string[], full: boolean): Promise<string> {
       "Run `chrome-devtools-axi upload @<uid> /path/to/file` to upload a file",
     ]);
   }
-  const snapshot = await callWithSnapshot("upload_file", { uid: parseUid(uid), filePath });
+  const snapshot = await callWithSnapshot("upload_file", {
+    uid: parseUid(uid),
+    filePath,
+  });
   return formatPageOutput(snapshot, "upload", undefined, full);
 }
 
@@ -1126,9 +1236,11 @@ async function handleConsoleGet(args: string[]): Promise<string> {
   }
   const msgid = parseOptionalInteger(id);
   if (msgid === undefined) {
-    throw new CdpError(`Invalid console message id: ${id}`, "VALIDATION_ERROR", [
-      "Run `chrome-devtools-axi console` to list available message ids",
-    ]);
+    throw new CdpError(
+      `Invalid console message id: ${id}`,
+      "VALIDATION_ERROR",
+      ["Run `chrome-devtools-axi console` to list available message ids"],
+    );
   }
   const result = await callTool("get_console_message", { msgid });
   return formatMcpResult("message", result, []);
@@ -1181,7 +1293,10 @@ async function handlePerfInsight(args: string[]): Promise<string> {
       "Run `chrome-devtools-axi perf-insight <set-id> <insight-name>` to analyze an insight",
     ]);
   }
-  const result = await callTool("performance_analyze_insight", { insightSetId: setId, insightName });
+  const result = await callTool("performance_analyze_insight", {
+    insightSetId: setId,
+    insightName,
+  });
   return formatMcpResult("insight", result, []);
 }
 
@@ -1216,11 +1331,13 @@ async function handleHome(full: boolean): Promise<string> {
   const result = await getSessionSnapshotIfRunning();
   if (!result) {
     const blocks = [encode({ browser: "no active session" })];
-    blocks.push(renderHelp([
-      "Run `chrome-devtools-axi open <url>` to start browsing",
-      "Run `chrome-devtools-axi run <<'EOF'\\n...\\nEOF` to execute a multi-step script",
-      "Run `chrome-devtools-axi run --help` for the script API",
-    ]));
+    blocks.push(
+      renderHelp([
+        "Run `chrome-devtools-axi open <url>` to start browsing",
+        "Run `chrome-devtools-axi run <<'EOF'\\n...\\nEOF` to execute a multi-step script",
+        "Run `chrome-devtools-axi run --help` for the script API",
+      ]),
+    );
     return renderOutput(blocks);
   }
   const snapshot = stripSnapshotHeader(result);
@@ -1229,7 +1346,11 @@ async function handleHome(full: boolean): Promise<string> {
 
 export async function main(argv: string[]): Promise<void> {
   // Best-effort hook installation on every invocation
-  try { installHooks(); } catch { /* silent */ }
+  try {
+    installHooks();
+  } catch {
+    /* silent */
+  }
 
   const args = [...argv];
 
@@ -1239,7 +1360,10 @@ export async function main(argv: string[]): Promise<void> {
   const commandArgs = filteredArgs.slice(1);
 
   // Per-subcommand help: `chrome-devtools-axi open --help`
-  if (command && (commandArgs.includes("--help") || commandArgs.includes("-h"))) {
+  if (
+    command &&
+    (commandArgs.includes("--help") || commandArgs.includes("-h"))
+  ) {
     const help = getCommandHelp(command);
     if (help) {
       process.stdout.write(help + "\n");
@@ -1381,7 +1505,9 @@ export async function main(argv: string[]): Promise<void> {
     process.stdout.write(output + "\n");
   } catch (err) {
     if (err instanceof CdpError) {
-      process.stdout.write(renderError(err.message, err.code, err.suggestions) + "\n");
+      process.stdout.write(
+        renderError(err.message, err.code, err.suggestions) + "\n",
+      );
     } else {
       const message = err instanceof Error ? err.message : String(err);
       process.stdout.write(renderError(message, "UNKNOWN") + "\n");

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,7 +10,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CdpError } from "./client.js";
 
-type CallTool = (name: string, args?: Record<string, unknown>) => Promise<string>;
+type CallTool = (
+  name: string,
+  args?: Record<string, unknown>,
+) => Promise<string>;
 
 // --- Value parsing ---
 
@@ -27,7 +30,11 @@ export function parseEvalOutput(output: string): unknown {
   const preamble = "Script ran on page and returned:";
   if (output.includes(preamble)) {
     const raw = output.slice(output.indexOf(preamble) + preamble.length).trim();
-    try { return JSON.parse(raw); } catch { return raw; }
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
   }
   return output.trim();
 }
@@ -49,7 +56,9 @@ function parseUid(ref: string): string {
 function isRecoverableOpenError(error: unknown): boolean {
   if (!(error instanceof CdpError)) return false;
   if (error.code !== "BROWSER_ERROR") return false;
-  return /not connected|session (?:closed|not found)|no page/i.test(error.message);
+  return /not connected|session (?:closed|not found)|no page/i.test(
+    error.message,
+  );
 }
 
 // --- Selector detection ---
@@ -113,7 +122,9 @@ export function createPageHelper(callTool: CallTool): PageHelper {
       };
     },
 
-    async eval(jsOrFn: string | ((...args: unknown[]) => unknown)): Promise<unknown> {
+    async eval(
+      jsOrFn: string | ((...args: unknown[]) => unknown),
+    ): Promise<unknown> {
       const fn =
         typeof jsOrFn === "function"
           ? String(jsOrFn)
@@ -257,7 +268,12 @@ export async function runScript(
       (globalThis as Record<string, unknown>).page = prevPage;
     }
     // Clean up temp file
-    try { unlinkSync(tmpFile); rmdirSync(tmpDir); } catch { /* best effort */ }
+    try {
+      unlinkSync(tmpFile);
+      rmdirSync(tmpDir);
+    } catch {
+      /* best effort */
+    }
   }
 
   const stdout = lines.length > 0 ? lines.join("\n") + "\n" : "";

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,265 @@
+/**
+ * Script runner for `chrome-devtools-axi run`.
+ *
+ * Reads a script from stdin, provides a minimal `page` global, and executes it.
+ * Only the script's own console.log output is visible to the caller.
+ */
+
+import { mkdtempSync, writeFileSync, unlinkSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CdpError } from "./client.js";
+
+type CallTool = (name: string, args?: Record<string, unknown>) => Promise<string>;
+
+// --- Value parsing ---
+
+/** Extract the actual JS value from MCP evaluate_script response wrapper. */
+export function parseEvalOutput(output: string): unknown {
+  const jsonBlock = output.match(/```json\n([\s\S]*?)\n```/);
+  if (jsonBlock) {
+    try {
+      return JSON.parse(jsonBlock[1].trim());
+    } catch {
+      return jsonBlock[1].trim();
+    }
+  }
+  const preamble = "Script ran on page and returned:";
+  if (output.includes(preamble)) {
+    const raw = output.slice(output.indexOf(preamble) + preamble.length).trim();
+    try { return JSON.parse(raw); } catch { return raw; }
+  }
+  return output.trim();
+}
+
+/** Strip MCP preamble/headers from snapshot text, returning just the accessibility tree. */
+function stripSnapshotHeader(text: string): string {
+  const lines = text.split("\n");
+  const treeStart = lines.findIndex((l) => /\bRootWebArea\b|\buid=/.test(l));
+  if (treeStart > 0) return lines.slice(treeStart).join("\n");
+  return text.replace(/^[\s\S]*?##\s+Latest page snapshot\s*\n/, "");
+}
+
+/** Strip leading @ from uid ref string. */
+function parseUid(ref: string): string {
+  return ref.startsWith("@") ? ref.slice(1) : ref;
+}
+
+/** Check if an open error is recoverable by falling back to new_page. */
+function isRecoverableOpenError(error: unknown): boolean {
+  if (!(error instanceof CdpError)) return false;
+  if (error.code !== "BROWSER_ERROR") return false;
+  return /not connected|session (?:closed|not found)|no page/i.test(error.message);
+}
+
+// --- Selector detection ---
+
+const UID_RE = /^@?\d[\d_]*$/;
+
+/** Returns true when the string looks like a @uid ref (e.g. "@12", "26_181"). */
+export function isUidRef(s: string): boolean {
+  return UID_RE.test(s);
+}
+
+const DEFAULT_WAIT_TIMEOUT = 30_000;
+
+// --- Page helper ---
+
+export interface OpenResult {
+  url: string;
+  status: number | null;
+}
+
+export interface PageHelper {
+  open(url: string): Promise<OpenResult>;
+  eval(jsOrFn: string | ((...args: unknown[]) => unknown)): Promise<unknown>;
+  wait(ms: number): Promise<void>;
+  wait(selector: string, timeout?: number): Promise<void>;
+  snapshot(): Promise<string>;
+  click(refOrSelector: string): Promise<void>;
+  fill(refOrSelector: string, text: string): Promise<void>;
+  type(text: string): Promise<void>;
+  press(key: string): Promise<void>;
+  back(): Promise<void>;
+}
+
+export function createPageHelper(callTool: CallTool): PageHelper {
+  /** Run JS in the page and return the parsed value. */
+  async function evalJs(code: string): Promise<unknown> {
+    const output = await callTool("evaluate_script", { function: code });
+    return parseEvalOutput(output);
+  }
+
+  return {
+    async open(url: string): Promise<OpenResult> {
+      if (!url) {
+        throw new CdpError("Missing URL", "VALIDATION_ERROR", [
+          'Start with `await page.open("https://example.com")`',
+        ]);
+      }
+      try {
+        await callTool("navigate_page", { type: "url", url });
+      } catch (error) {
+        if (!isRecoverableOpenError(error)) throw error;
+        await callTool("new_page", { url });
+      }
+      const info = await evalJs(
+        `() => ({ url: location.href, status: performance.getEntriesByType('navigation').pop()?.responseStatus ?? null })`,
+      );
+      const result = info as Record<string, unknown>;
+      return {
+        url: String(result?.url ?? url),
+        status: typeof result?.status === "number" ? result.status : null,
+      };
+    },
+
+    async eval(jsOrFn: string | ((...args: unknown[]) => unknown)): Promise<unknown> {
+      const fn =
+        typeof jsOrFn === "function"
+          ? String(jsOrFn)
+          : `() => (${jsOrFn.trim()})`;
+      return evalJs(fn);
+    },
+
+    async wait(msOrSelector: number | string, timeout?: number): Promise<void> {
+      if (typeof msOrSelector === "number") {
+        await callTool("evaluate_script", {
+          function: `new Promise(r => setTimeout(r, ${msOrSelector}))`,
+        });
+      } else {
+        const ms = timeout ?? DEFAULT_WAIT_TIMEOUT;
+        const sel = JSON.stringify(msOrSelector);
+        await callTool("evaluate_script", {
+          function: `new Promise((resolve, reject) => {
+  const sel = ${sel};
+  if (document.querySelector(sel)) { resolve(); return; }
+  const observer = new MutationObserver(() => {
+    if (document.querySelector(sel)) {
+      observer.disconnect();
+      clearTimeout(timer);
+      resolve();
+    }
+  });
+  const timer = setTimeout(() => {
+    observer.disconnect();
+    reject(new Error('Timeout waiting for: ' + sel));
+  }, ${ms});
+  observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+})`,
+        });
+      }
+    },
+
+    async snapshot(): Promise<string> {
+      const result = await callTool("take_snapshot");
+      return stripSnapshotHeader(result);
+    },
+
+    async click(refOrSelector: string): Promise<void> {
+      if (isUidRef(refOrSelector)) {
+        await callTool("click", { uid: parseUid(refOrSelector) });
+      } else {
+        const sel = JSON.stringify(refOrSelector);
+        await callTool("evaluate_script", {
+          function: `(() => {
+  const el = document.querySelector(${sel});
+  if (!el) throw new Error('Element not found: ' + ${sel});
+  el.scrollIntoView({ block: 'center' });
+  el.click();
+})()`,
+        });
+      }
+    },
+
+    async fill(refOrSelector: string, text: string): Promise<void> {
+      if (isUidRef(refOrSelector)) {
+        await callTool("fill", { uid: parseUid(refOrSelector), value: text });
+      } else {
+        const sel = JSON.stringify(refOrSelector);
+        const val = JSON.stringify(text);
+        await callTool("evaluate_script", {
+          function: `(() => {
+  const el = document.querySelector(${sel});
+  if (!el) throw new Error('Element not found: ' + ${sel});
+  el.focus();
+  el.value = ${val};
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  el.dispatchEvent(new Event('change', { bubbles: true }));
+})()`,
+        });
+      }
+    },
+
+    async type(text: string): Promise<void> {
+      await callTool("type_text", { text });
+    },
+
+    async press(key: string): Promise<void> {
+      await callTool("press_key", { key });
+    },
+
+    async back(): Promise<void> {
+      await callTool("navigate_page", { type: "back" });
+    },
+  };
+}
+
+// --- Script runner ---
+
+export interface RunResult {
+  stdout: string;
+}
+
+/** Read all of stdin into a string. */
+export async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function runScript(
+  content: string,
+  callTool: CallTool,
+): Promise<RunResult> {
+  const page = createPageHelper(callTool);
+
+  // Write to a temp .mjs so dynamic import supports top-level await
+  const tmpDir = mkdtempSync(join(tmpdir(), "cda-run-"));
+  const tmpFile = join(tmpDir, "script.mjs");
+  writeFileSync(tmpFile, content, "utf-8");
+
+  // Capture console.log output from the script
+  const lines: string[] = [];
+  const origLog = console.log;
+  const captureLog = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+
+  // Inject page global and capture console
+  const prevPage = (globalThis as Record<string, unknown>).page;
+  (globalThis as Record<string, unknown>).page = page;
+  console.log = captureLog;
+
+  try {
+    const mod = await import(tmpFile);
+
+    // Support optional default export function
+    if (typeof mod.default === "function") {
+      await mod.default();
+    }
+  } finally {
+    console.log = origLog;
+    if (prevPage === undefined) {
+      delete (globalThis as Record<string, unknown>).page;
+    } else {
+      (globalThis as Record<string, unknown>).page = prevPage;
+    }
+    // Clean up temp file
+    try { unlinkSync(tmpFile); rmdirSync(tmpDir); } catch { /* best effort */ }
+  }
+
+  const stdout = lines.length > 0 ? lines.join("\n") + "\n" : "";
+  return { stdout };
+}

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -24,10 +24,16 @@ vi.mock("../src/client.js", () => ({
 
 import { main, getCommandHelp } from "../src/cli.js";
 import { CdpError } from "../src/client.js";
-import { createPageHelper, isUidRef, parseEvalOutput, runScript } from "../src/run.js";
+import {
+  createPageHelper,
+  isUidRef,
+  parseEvalOutput,
+  runScript,
+} from "../src/run.js";
 
 /** Mock response for the evaluate_script call that page.open() makes to read url+status. */
-const OPEN_INFO_RESPONSE = 'Script ran on page and returned:\n```json\n{"url":"https://example.com","status":200}\n```';
+const OPEN_INFO_RESPONSE =
+  'Script ran on page and returned:\n```json\n{"url":"https://example.com","status":200}\n```';
 
 afterEach(() => {
   callTool.mockReset();
@@ -40,9 +46,13 @@ afterEach(() => {
 describe("no-args output", () => {
   it("mentions run in the no-session output", async () => {
     const { getSessionSnapshotIfRunning } = await import("../src/client.js");
-    (getSessionSnapshotIfRunning as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    (
+      getSessionSnapshotIfRunning as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(null);
 
-    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
     await main([]);
 
     const output = String(write.mock.calls[0]?.[0]);
@@ -78,7 +88,7 @@ describe("parseEvalOutput", () => {
   });
 
   it("extracts numeric value", () => {
-    const output = 'Script ran on page and returned:\n```json\n42\n```';
+    const output = "Script ran on page and returned:\n```json\n42\n```";
     expect(parseEvalOutput(output)).toBe(42);
   });
 
@@ -88,7 +98,7 @@ describe("parseEvalOutput", () => {
   });
 
   it("extracts null", () => {
-    const output = 'Script ran on page and returned:\n```json\nnull\n```';
+    const output = "Script ran on page and returned:\n```json\nnull\n```";
     expect(parseEvalOutput(output)).toBeNull();
   });
 
@@ -109,8 +119,13 @@ describe("createPageHelper", () => {
     const page = createPageHelper(callTool);
     const result = await page.open("https://example.com");
 
-    expect(callTool).toHaveBeenCalledWith("navigate_page", { type: "url", url: "https://example.com" });
-    expect(callTool).toHaveBeenCalledWith("new_page", { url: "https://example.com" });
+    expect(callTool).toHaveBeenCalledWith("navigate_page", {
+      type: "url",
+      url: "https://example.com",
+    });
+    expect(callTool).toHaveBeenCalledWith("new_page", {
+      url: "https://example.com",
+    });
     expect(result).toEqual({ url: "https://example.com", status: 200 });
   });
 
@@ -122,23 +137,32 @@ describe("createPageHelper", () => {
     const page = createPageHelper(callTool);
     const result = await page.open("https://example.com");
 
-    expect(callTool).toHaveBeenCalledWith("navigate_page", { type: "url", url: "https://example.com" });
+    expect(callTool).toHaveBeenCalledWith("navigate_page", {
+      type: "url",
+      url: "https://example.com",
+    });
     expect(result.url).toBe("https://example.com");
     expect(result.status).toBe(200);
   });
 
   it("page.eval with string expression", async () => {
-    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\n"Example Domain"\n```');
+    callTool.mockResolvedValueOnce(
+      'Script ran on page and returned:\n```json\n"Example Domain"\n```',
+    );
 
     const page = createPageHelper(callTool);
     const result = await page.eval("document.title");
 
-    expect(callTool).toHaveBeenCalledWith("evaluate_script", { function: "() => (document.title)" });
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: "() => (document.title)",
+    });
     expect(result).toBe("Example Domain");
   });
 
   it("page.eval with function", async () => {
-    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\n3\n```');
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\n3\n```",
+    );
 
     const page = createPageHelper(callTool);
     const result = await page.eval(() => 1 + 2);
@@ -294,13 +318,19 @@ describe("createPageHelper", () => {
 
 describe("runScript", () => {
   it("captures script console.log output", async () => {
-    const result = await runScript(`console.log("hello from script");`, callTool);
+    const result = await runScript(
+      `console.log("hello from script");`,
+      callTool,
+    );
 
     expect(result.stdout).toBe("hello from script\n");
   });
 
   it("captures multiple console.log lines", async () => {
-    const result = await runScript(`console.log("line1"); console.log("line2");`, callTool);
+    const result = await runScript(
+      `console.log("line1"); console.log("line2");`,
+      callTool,
+    );
 
     expect(result.stdout).toBe("line1\nline2\n");
   });
@@ -309,13 +339,18 @@ describe("runScript", () => {
     callTool
       .mockResolvedValueOnce("") // navigate_page
       .mockResolvedValueOnce(OPEN_INFO_RESPONSE) // evaluate_script for url+status
-      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n"Example Domain"\n```');
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n"Example Domain"\n```',
+      );
 
-    const result = await runScript(`
+    const result = await runScript(
+      `
 await page.open("https://example.com");
 const result = await page.eval("document.title");
 console.log(result);
-`, callTool);
+`,
+      callTool,
+    );
 
     expect(result.stdout).toBe("Example Domain\n");
   });
@@ -340,12 +375,20 @@ console.log(result);
 
 describe("run command validation", () => {
   it("errors when stdin is a TTY (no script piped)", async () => {
-    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
 
     await main(["run"]);
 
-    Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: undefined,
+      configurable: true,
+    });
     const output = String(write.mock.calls[0]?.[0]);
     expect(output).toContain("No script provided");
     expect(output).toContain("VALIDATION_ERROR");
@@ -360,19 +403,25 @@ describe("page.open fallback", () => {
     callTool
       .mockRejectedValueOnce(new CdpError("session closed", "BROWSER_ERROR"))
       .mockResolvedValueOnce("")
-      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://test.com","status":200}\n```');
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"url":"https://test.com","status":200}\n```',
+      );
 
     const page = createPageHelper(callTool);
     await page.open("https://test.com");
 
-    expect(callTool).toHaveBeenCalledWith("new_page", { url: "https://test.com" });
+    expect(callTool).toHaveBeenCalledWith("new_page", {
+      url: "https://test.com",
+    });
   });
 
   it("does not fall back on non-recoverable errors", async () => {
     callTool.mockRejectedValueOnce(new CdpError("some other error", "TIMEOUT"));
 
     const page = createPageHelper(callTool);
-    await expect(page.open("https://test.com")).rejects.toThrow("some other error");
+    await expect(page.open("https://test.com")).rejects.toThrow(
+      "some other error",
+    );
   });
 });
 
@@ -397,16 +446,22 @@ describe("page.snapshot header stripping", () => {
 
 describe("page.eval variants", () => {
   it("wraps string expression in arrow function", async () => {
-    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\ntrue\n```');
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\ntrue\n```",
+    );
 
     const page = createPageHelper(callTool);
     await page.eval("true");
 
-    expect(callTool).toHaveBeenCalledWith("evaluate_script", { function: "() => (true)" });
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: "() => (true)",
+    });
   });
 
   it("serializes function argument", async () => {
-    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\n[]\n```');
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\n[]\n```",
+    );
 
     const page = createPageHelper(callTool);
     await page.eval(() => []);
@@ -446,7 +501,9 @@ describe("page.open return value", () => {
   it("returns url and status from navigation", async () => {
     callTool
       .mockResolvedValueOnce("") // navigate_page
-      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://example.com/","status":200}\n```');
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"url":"https://example.com/","status":200}\n```',
+      );
 
     const page = createPageHelper(callTool);
     const result = await page.open("https://example.com");
@@ -458,7 +515,9 @@ describe("page.open return value", () => {
   it("returns 404 status", async () => {
     callTool
       .mockResolvedValueOnce("")
-      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://httpbin.org/status/404","status":404}\n```');
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"url":"https://httpbin.org/status/404","status":404}\n```',
+      );
 
     const page = createPageHelper(callTool);
     const result = await page.open("https://httpbin.org/status/404");
@@ -469,7 +528,9 @@ describe("page.open return value", () => {
   it("returns null status when performance API unavailable", async () => {
     callTool
       .mockResolvedValueOnce("")
-      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://example.com","status":null}\n```');
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"url":"https://example.com","status":null}\n```',
+      );
 
     const page = createPageHelper(callTool);
     const result = await page.open("https://example.com");

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,0 +1,479 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// --- Mock the client layer ---
+
+const { callTool } = vi.hoisted(() => ({
+  callTool: vi.fn(),
+}));
+
+vi.mock("../src/client.js", () => ({
+  CdpError: class CdpError extends Error {
+    constructor(
+      message: string,
+      public readonly code: string,
+      public readonly suggestions: string[] = [],
+    ) {
+      super(message);
+    }
+  },
+  callTool,
+  ensureBridge: vi.fn(),
+  getSessionSnapshotIfRunning: vi.fn(),
+  stopBridge: vi.fn(),
+}));
+
+import { main, getCommandHelp } from "../src/cli.js";
+import { CdpError } from "../src/client.js";
+import { createPageHelper, isUidRef, parseEvalOutput, runScript } from "../src/run.js";
+
+/** Mock response for the evaluate_script call that page.open() makes to read url+status. */
+const OPEN_INFO_RESPONSE = 'Script ran on page and returned:\n```json\n{"url":"https://example.com","status":200}\n```';
+
+afterEach(() => {
+  callTool.mockReset();
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+});
+
+// --- 1. No-args output teaches `run` ---
+
+describe("no-args output", () => {
+  it("mentions run in the no-session output", async () => {
+    const { getSessionSnapshotIfRunning } = await import("../src/client.js");
+    (getSessionSnapshotIfRunning as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await main([]);
+
+    const output = String(write.mock.calls[0]?.[0]);
+    expect(output).toContain("run");
+  });
+});
+
+// --- 2. `run --help` documents the script API ---
+
+describe("run --help", () => {
+  it("documents the compact script API", () => {
+    const help = getCommandHelp("run");
+    expect(help).not.toBeNull();
+    expect(help).toContain("page.open");
+    expect(help).toContain("page.eval");
+    expect(help).toContain("page.snapshot");
+    expect(help).toContain("page.click");
+    expect(help).toContain("page.fill");
+    expect(help).toContain("page.wait");
+    expect(help).toContain("page.type");
+    expect(help).toContain("page.press");
+    expect(help).toContain("page.back");
+    expect(help).toContain("example");
+  });
+});
+
+// --- 3. Eval result parser unwraps remote tool output ---
+
+describe("parseEvalOutput", () => {
+  it("extracts JSON value from MCP wrapper", () => {
+    const output = 'Script ran on page and returned:\n```json\n"hello"\n```';
+    expect(parseEvalOutput(output)).toBe("hello");
+  });
+
+  it("extracts numeric value", () => {
+    const output = 'Script ran on page and returned:\n```json\n42\n```';
+    expect(parseEvalOutput(output)).toBe(42);
+  });
+
+  it("extracts object value", () => {
+    const output = 'Script ran on page and returned:\n```json\n{"a":1}\n```';
+    expect(parseEvalOutput(output)).toEqual({ a: 1 });
+  });
+
+  it("extracts null", () => {
+    const output = 'Script ran on page and returned:\n```json\nnull\n```';
+    expect(parseEvalOutput(output)).toBeNull();
+  });
+
+  it("falls back to raw trimmed string when no JSON block", () => {
+    expect(parseEvalOutput("just text")).toBe("just text");
+  });
+});
+
+// --- 4. Script helper object maps commands to bridge calls ---
+
+describe("createPageHelper", () => {
+  it("page.open calls navigate_page, falls back to new_page, returns { url, status }", async () => {
+    callTool
+      .mockRejectedValueOnce(new CdpError("not connected", "BROWSER_ERROR"))
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(OPEN_INFO_RESPONSE);
+
+    const page = createPageHelper(callTool);
+    const result = await page.open("https://example.com");
+
+    expect(callTool).toHaveBeenCalledWith("navigate_page", { type: "url", url: "https://example.com" });
+    expect(callTool).toHaveBeenCalledWith("new_page", { url: "https://example.com" });
+    expect(result).toEqual({ url: "https://example.com", status: 200 });
+  });
+
+  it("page.open succeeds on first try when page exists", async () => {
+    callTool
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(OPEN_INFO_RESPONSE);
+
+    const page = createPageHelper(callTool);
+    const result = await page.open("https://example.com");
+
+    expect(callTool).toHaveBeenCalledWith("navigate_page", { type: "url", url: "https://example.com" });
+    expect(result.url).toBe("https://example.com");
+    expect(result.status).toBe(200);
+  });
+
+  it("page.eval with string expression", async () => {
+    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\n"Example Domain"\n```');
+
+    const page = createPageHelper(callTool);
+    const result = await page.eval("document.title");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", { function: "() => (document.title)" });
+    expect(result).toBe("Example Domain");
+  });
+
+  it("page.eval with function", async () => {
+    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\n3\n```');
+
+    const page = createPageHelper(callTool);
+    const result = await page.eval(() => 1 + 2);
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: expect.stringContaining("() => 1 + 2"),
+    });
+    expect(result).toBe(3);
+  });
+
+  it("page.snapshot strips header", async () => {
+    callTool.mockResolvedValueOnce(
+      '## Latest page snapshot\nRootWebArea "Title"\n  uid=1 link "Home"',
+    );
+
+    const page = createPageHelper(callTool);
+    const snap = await page.snapshot();
+
+    expect(callTool).toHaveBeenCalledWith("take_snapshot");
+    expect(snap).toContain("RootWebArea");
+    expect(snap).not.toContain("## Latest");
+  });
+
+  it("page.wait with number waits by duration", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.wait(500);
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: "new Promise(r => setTimeout(r, 500))",
+    });
+  });
+
+  it("page.wait with string waits for CSS selector via evaluate_script", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.wait(".results");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: expect.stringContaining(".results"),
+    });
+    // Default 30s timeout
+    expect(callTool.mock.calls[0][1].function).toContain("30000");
+  });
+
+  it("page.wait with selector and custom timeout", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.wait("#loaded", 5000);
+
+    const fn = callTool.mock.calls[0][1].function;
+    expect(fn).toContain("#loaded");
+    expect(fn).toContain("5000");
+  });
+
+  it("page.click calls click with parsed uid", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.click("@12");
+
+    expect(callTool).toHaveBeenCalledWith("click", { uid: "12" });
+  });
+
+  it("page.click accepts uid without @", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.click("5");
+
+    expect(callTool).toHaveBeenCalledWith("click", { uid: "5" });
+  });
+
+  it("page.click with CSS selector uses evaluate_script", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.click("a[href='/wiki/Charles_Babbage']");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: expect.stringContaining("a[href='/wiki/Charles_Babbage']"),
+    });
+    expect(callTool).not.toHaveBeenCalledWith("click", expect.anything());
+  });
+
+  it("page.click with CSS class selector uses evaluate_script", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.click(".submit-btn");
+
+    const fn = callTool.mock.calls[0][1].function;
+    expect(fn).toContain(".submit-btn");
+    expect(fn).toContain("scrollIntoView");
+    expect(fn).toContain(".click()");
+  });
+
+  it("page.fill calls fill with uid and value", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.fill("@3", "hello");
+
+    expect(callTool).toHaveBeenCalledWith("fill", { uid: "3", value: "hello" });
+  });
+
+  it("page.fill with CSS selector uses evaluate_script", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.fill("input[name='search']", "query");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: expect.stringContaining("input[name='search']"),
+    });
+    const fn = callTool.mock.calls[0][1].function;
+    expect(fn).toContain("query");
+    expect(fn).toContain("dispatchEvent");
+  });
+
+  it("page.type calls type_text", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.type("hello");
+
+    expect(callTool).toHaveBeenCalledWith("type_text", { text: "hello" });
+  });
+
+  it("page.press calls press_key", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.press("Enter");
+
+    expect(callTool).toHaveBeenCalledWith("press_key", { key: "Enter" });
+  });
+
+  it("page.back calls navigate_page with back", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.back();
+
+    expect(callTool).toHaveBeenCalledWith("navigate_page", { type: "back" });
+  });
+});
+
+// --- 5. Script runner executes script content and only exposes script stdout ---
+
+describe("runScript", () => {
+  it("captures script console.log output", async () => {
+    const result = await runScript(`console.log("hello from script");`, callTool);
+
+    expect(result.stdout).toBe("hello from script\n");
+  });
+
+  it("captures multiple console.log lines", async () => {
+    const result = await runScript(`console.log("line1"); console.log("line2");`, callTool);
+
+    expect(result.stdout).toBe("line1\nline2\n");
+  });
+
+  it("supports top-level await", async () => {
+    callTool
+      .mockResolvedValueOnce("") // navigate_page
+      .mockResolvedValueOnce(OPEN_INFO_RESPONSE) // evaluate_script for url+status
+      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n"Example Domain"\n```');
+
+    const result = await runScript(`
+await page.open("https://example.com");
+const result = await page.eval("document.title");
+console.log(result);
+`, callTool);
+
+    expect(result.stdout).toBe("Example Domain\n");
+  });
+
+  it("supports default export function", async () => {
+    const result = await runScript(
+      `export default async function() { console.log("from export"); }`,
+      callTool,
+    );
+
+    expect(result.stdout).toBe("from export\n");
+  });
+
+  it("returns empty stdout when script prints nothing", async () => {
+    const result = await runScript(`const x = 1 + 2;`, callTool);
+
+    expect(result.stdout).toBe("");
+  });
+});
+
+// --- 6. Validation errors ---
+
+describe("run command validation", () => {
+  it("errors when stdin is a TTY (no script piped)", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+    await main(["run"]);
+
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+    const output = String(write.mock.calls[0]?.[0]);
+    expect(output).toContain("No script provided");
+    expect(output).toContain("VALIDATION_ERROR");
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+// --- 7. page.open falls back when no page/session ---
+
+describe("page.open fallback", () => {
+  it("falls back to new_page on session-closed error", async () => {
+    callTool
+      .mockRejectedValueOnce(new CdpError("session closed", "BROWSER_ERROR"))
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://test.com","status":200}\n```');
+
+    const page = createPageHelper(callTool);
+    await page.open("https://test.com");
+
+    expect(callTool).toHaveBeenCalledWith("new_page", { url: "https://test.com" });
+  });
+
+  it("does not fall back on non-recoverable errors", async () => {
+    callTool.mockRejectedValueOnce(new CdpError("some other error", "TIMEOUT"));
+
+    const page = createPageHelper(callTool);
+    await expect(page.open("https://test.com")).rejects.toThrow("some other error");
+  });
+});
+
+// --- 8. page.snapshot strips wrapper headers ---
+
+describe("page.snapshot header stripping", () => {
+  it("strips MCP preamble from snapshot", async () => {
+    callTool.mockResolvedValueOnce(
+      'Page snapshot captured.\n\n## Latest page snapshot\n\nRootWebArea "Hi"\n  uid=1 button "OK"',
+    );
+
+    const page = createPageHelper(callTool);
+    const snap = await page.snapshot();
+
+    expect(snap).toMatch(/^RootWebArea/);
+    expect(snap).not.toContain("Latest page snapshot");
+    expect(snap).not.toContain("Page snapshot captured");
+  });
+});
+
+// --- 9. page.eval string and function both work ---
+
+describe("page.eval variants", () => {
+  it("wraps string expression in arrow function", async () => {
+    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\ntrue\n```');
+
+    const page = createPageHelper(callTool);
+    await page.eval("true");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", { function: "() => (true)" });
+  });
+
+  it("serializes function argument", async () => {
+    callTool.mockResolvedValueOnce('Script ran on page and returned:\n```json\n[]\n```');
+
+    const page = createPageHelper(callTool);
+    await page.eval(() => []);
+
+    const fn = callTool.mock.calls[0][1].function;
+    expect(fn).toContain("() => []");
+  });
+});
+
+// --- 10. isUidRef detection ---
+
+describe("isUidRef", () => {
+  it("recognizes @-prefixed numeric refs", () => {
+    expect(isUidRef("@12")).toBe(true);
+    expect(isUidRef("@1_3")).toBe(true);
+    expect(isUidRef("@26_181")).toBe(true);
+  });
+
+  it("recognizes bare numeric refs", () => {
+    expect(isUidRef("5")).toBe(true);
+    expect(isUidRef("26_181")).toBe(true);
+  });
+
+  it("rejects CSS selectors", () => {
+    expect(isUidRef(".button")).toBe(false);
+    expect(isUidRef("#main")).toBe(false);
+    expect(isUidRef("a[href='/wiki']")).toBe(false);
+    expect(isUidRef("input[name='q']")).toBe(false);
+    expect(isUidRef("div > span")).toBe(false);
+    expect(isUidRef("button.primary")).toBe(false);
+  });
+});
+
+// --- 11. page.open returns { url, status } ---
+
+describe("page.open return value", () => {
+  it("returns url and status from navigation", async () => {
+    callTool
+      .mockResolvedValueOnce("") // navigate_page
+      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://example.com/","status":200}\n```');
+
+    const page = createPageHelper(callTool);
+    const result = await page.open("https://example.com");
+
+    expect(result.url).toBe("https://example.com/");
+    expect(result.status).toBe(200);
+  });
+
+  it("returns 404 status", async () => {
+    callTool
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://httpbin.org/status/404","status":404}\n```');
+
+    const page = createPageHelper(callTool);
+    const result = await page.open("https://httpbin.org/status/404");
+
+    expect(result.status).toBe(404);
+  });
+
+  it("returns null status when performance API unavailable", async () => {
+    callTool
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce('Script ran on page and returned:\n```json\n{"url":"https://example.com","status":null}\n```');
+
+    const page = createPageHelper(callTool);
+    const result = await page.open("https://example.com");
+
+    expect(result.status).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `run` command that lets users pipe multi-step browser automation scripts via stdin. Scripts get a global `page` object with an ergonomic API (`open`, `eval`, `click`, `fill`, `wait`, `snapshot`, etc.) that maps high-level operations to the existing CDP bridge. Only the script's `console.log` output is returned to the caller.

**Risk Assessment:** 🟢 Low — Well-tested additive feature with minor hygiene concerns that don't affect correctness or existing functionality.

## Architecture

```mermaid
flowchart TD
  cli["CLI main() (updated)"]
  handle_run["handleRun() (added)"]
  run_module["run.ts module (added)"]
  page_helper["PageHelper interface (added)"]
  run_script["runScript() (added)"]
  read_stdin["readStdin() (added)"]
  parse_eval["parseEvalOutput() (added)"]
  is_uid["isUidRef() (added)"]
  call_tool["callTool — CDP bridge (unchanged)"]
  run_tests["run.test.ts (added)"]
  workflow["Airlock workflow (added)"]

  cli -- "dispatches 'run' command" --> handle_run
  handle_run -- "reads script" --> read_stdin
  handle_run -- "executes script" --> run_script
  run_script -- "creates" --> page_helper
  page_helper -- "delegates all browser ops" --> call_tool
  page_helper -- "parses eval responses" --> parse_eval
  page_helper -- "detects @uid vs CSS" --> is_uid
  run_tests -- "tests" --> run_module
```

## Key changes

- **New `src/run.ts` module** — Implements `PageHelper` interface with 9 browser automation methods, a script runner that executes user scripts as dynamic ESM imports with top-level await support, and utilities for parsing eval output and distinguishing `@uid` refs from CSS selectors
- **Updated `src/cli.ts`** — Registers the `run` command with full help text documenting the script API, adds stdin validation in `handleRun()`, and updates the no-session output to surface the new command
- **New `test/run.test.ts`** — 479 lines of tests covering the page helper methods, script execution (console capture, top-level await, default exports), validation errors, open fallback logic, and selector detection
- **New `.airlock/workflows/main.yml`** — Adds Airlock CI/CD pipeline configuration

## How was this tested

- 41 new unit tests in `test/run.test.ts` covering page helper methods, script execution, console capture, top-level await, default exports, validation errors, open fallback logic, and selector detection
- All 173 tests pass