### PR TITLE
fix: trim no-session help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ snapshot:
 **Tell your agent:**
 
 ```
-Execute `npm i -g chrome-devtools-axi` and run `chrome-devtools-axi` for browser automation.
+Execute `npx -y chrome-devtools-axi` to get browser automation tools.
 ```
 
 ## How It Works

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1362,8 +1362,6 @@ async function handleHome(full: boolean): Promise<string> {
     blocks.push(
       renderHelp([
         "Run `chrome-devtools-axi open <url>` to start browsing",
-        "Run `chrome-devtools-axi run <<'EOF'\\n...\\nEOF` to execute a multi-step script",
-        "Run `chrome-devtools-axi run --help` for the script API",
       ]),
     );
     return renderOutput(blocks);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1360,9 +1360,7 @@ async function handleHome(full: boolean): Promise<string> {
   if (!result) {
     const blocks = [encode({ browser: "no active session" })];
     blocks.push(
-      renderHelp([
-        "Run `chrome-devtools-axi open <url>` to start browsing",
-      ]),
+      renderHelp(["Run `chrome-devtools-axi open <url>` to start browsing"]),
     );
     return renderOutput(blocks);
   }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -56,7 +56,9 @@ describe("no-args output", () => {
     await main([]);
 
     const output = String(write.mock.calls[0]?.[0]);
-    expect(output).toContain("Run `chrome-devtools-axi open <url>` to start browsing");
+    expect(output).toContain(
+      "Run `chrome-devtools-axi open <url>` to start browsing",
+    );
     expect(output).toContain("help[1]:");
     expect(output).not.toContain("chrome-devtools-axi run");
   });

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
 // --- 1. No-args output teaches `run` ---
 
 describe("no-args output", () => {
-  it("mentions run in the no-session output", async () => {
+  it("only suggests open in the no-session output", async () => {
     const { getSessionSnapshotIfRunning } = await import("../src/client.js");
     (
       getSessionSnapshotIfRunning as ReturnType<typeof vi.fn>
@@ -56,7 +56,9 @@ describe("no-args output", () => {
     await main([]);
 
     const output = String(write.mock.calls[0]?.[0]);
-    expect(output).toContain("run");
+    expect(output).toContain("Run `chrome-devtools-axi open <url>` to start browsing");
+    expect(output).toContain("help[1]:");
+    expect(output).not.toContain("chrome-devtools-axi run");
   });
 });
 


### PR DESCRIPTION
## Summary
The change narrows the CLI's no-session help output so the default `chrome-devtools-axi` response only tells users how to start a browsing session with `open <url>`. It removes `run` scripting hints from that state, keeping the help text aligned with the immediate next step when no browser snapshot exists.

**Risk Assessment:** 🟡 Medium — the change is small and well-tested, but it introduces user-facing UX inconsistencies around `run` discovery and `npx`-based invocation.

## Architecture
```mermaid
flowchart TD
  subgraph cli_flow["CLI No-Session Flow"]
    direction TB
    cli_entry["CLI entry with no args (unchanged)"]
    no_session_state["No active browser session (unchanged)"]
    home_handler["handleHome help rendering (updated)"]
    open_help["Open command hint (updated)"]
    run_help["Run command hints (removed)"]

    cli_entry -->|"routes to"| home_handler
    no_session_state -->|"activates"| home_handler
    home_handler -->|"renders"| open_help
    home_handler -->|"no longer renders"| run_help
  end

  subgraph docs_tests["Docs And Verification"]
    direction TB
    no_session_test["No-session output test (updated)"]
    readme_usage["README agent usage text (updated)"]

    no_session_test -->|"asserts presence of"| open_help
    no_session_test -->|"asserts absence of"| run_help
    readme_usage -->|"documents how to invoke"| cli_entry
  end
```

## Key changes made
- Updated `handleHome` so the no-active-session branch renders only the `open <url>` help line.
- Revised the regression test to assert the no-session output includes the `open` guidance and explicitly omits `chrome-devtools-axi run`.
- Adjusted the README example to recommend `npx -y chrome-devtools-axi` instead of a global install command.

## How was this tested
- Compared the diff from `0adfa89b9c63373ee16edd6736a46d9826f8cfeb` to `0405aea9e265430f415b7decfddee3a3f7936536`. Ran `npm test` in the repo root: all 14 test files passed, 183 tests passed. Also ran `npm run dev --` to exercise the no-session CLI path manually; output was `browser: no active session` with `help[1]` and only the `chrome-devtools-axi open <url>` suggestion, with no `run` guidance present.
- All checks passed.
