### PR TITLE
fix: skip hook install for dev entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ State is stored in `~/.chrome-devtools-axi/`:
 | ------------ | ---------------------------------- |
 | `bridge.pid` | PID and port of the running bridge |
 
+### Session Hooks
+
+On supported agents, the packaged CLI also installs a `SessionStart` hook in `~/.claude/settings.json` and `~/.codex/hooks.json`, and enables `codex_hooks` in `~/.codex/config.toml`.
+
+Development entrypoints such as `npm run dev` and `bin/chrome-devtools-axi.ts` do not modify those hook files.
+
 ## Development
 
 ```sh

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -38,6 +38,10 @@ export interface HookTarget {
 
 const HOOK_MARKER = "chrome-devtools-axi";
 
+/**
+ * Only install hooks from packaged or installed entrypoints.
+ * Development TypeScript entrypoints should not self-register.
+ */
 export function shouldInstallHooksForExecPath(execPath: string): boolean {
   const normalized = resolve(execPath);
   const fileName = basename(normalized);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -10,7 +10,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 interface HookEntry {
@@ -37,6 +37,24 @@ export interface HookTarget {
 }
 
 const HOOK_MARKER = "chrome-devtools-axi";
+
+export function shouldInstallHooksForExecPath(execPath: string): boolean {
+  const normalized = resolve(execPath);
+  const fileName = basename(normalized);
+
+  if (!normalized.includes(HOOK_MARKER)) {
+    return false;
+  }
+  if (normalized.endsWith(".ts")) {
+    return false;
+  }
+
+  return (
+    normalized.endsWith("/dist/bin/chrome-devtools-axi.js") ||
+    normalized.endsWith("\\dist\\bin\\chrome-devtools-axi.js") ||
+    fileName === "chrome-devtools-axi"
+  );
+}
 
 /**
  * Returns hook installation targets for supported agents.
@@ -175,7 +193,7 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
 export function installHooks(): void {
   try {
     const execPath = resolve(process.argv[1]);
-    if (!execPath.includes("chrome-devtools-axi")) return;
+    if (!shouldInstallHooksForExecPath(execPath)) return;
 
     for (const target of getHookTargets()) {
       try {

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -9,7 +9,10 @@ import {
 describe("computeHookUpdate", () => {
   it("installs hook when settings have no hooks", () => {
     const settings = {};
-    const [updated, changed] = computeHookUpdate(settings, "/usr/bin/chrome-devtools-axi");
+    const [updated, changed] = computeHookUpdate(
+      settings,
+      "/usr/bin/chrome-devtools-axi",
+    );
     expect(changed).toBe(true);
     expect(updated.hooks).toBeDefined();
     expect(updated.hooks!.SessionStart).toBeDefined();
@@ -22,11 +25,23 @@ describe("computeHookUpdate", () => {
     const settings = {
       hooks: {
         SessionStart: [
-          { matcher: "", hooks: [{ type: "command" as const, command: "other-tool status", timeout: 10 }] },
+          {
+            matcher: "",
+            hooks: [
+              {
+                type: "command" as const,
+                command: "other-tool status",
+                timeout: 10,
+              },
+            ],
+          },
         ],
       },
     };
-    const [updated, changed] = computeHookUpdate(settings, "/usr/bin/chrome-devtools-axi");
+    const [updated, changed] = computeHookUpdate(
+      settings,
+      "/usr/bin/chrome-devtools-axi",
+    );
     expect(changed).toBe(true);
     const str = JSON.stringify(updated);
     expect(str).toContain("other-tool status");
@@ -39,12 +54,21 @@ describe("computeHookUpdate", () => {
         SessionStart: [
           {
             matcher: "",
-            hooks: [{ type: "command" as const, command: "/usr/bin/chrome-devtools-axi", timeout: 10 }],
+            hooks: [
+              {
+                type: "command" as const,
+                command: "/usr/bin/chrome-devtools-axi",
+                timeout: 10,
+              },
+            ],
           },
         ],
       },
     };
-    const [, changed] = computeHookUpdate(settings, "/usr/bin/chrome-devtools-axi");
+    const [, changed] = computeHookUpdate(
+      settings,
+      "/usr/bin/chrome-devtools-axi",
+    );
     expect(changed).toBe(false);
   });
 
@@ -54,12 +78,21 @@ describe("computeHookUpdate", () => {
         SessionStart: [
           {
             matcher: "",
-            hooks: [{ type: "command" as const, command: "/old/path/chrome-devtools-axi", timeout: 10 }],
+            hooks: [
+              {
+                type: "command" as const,
+                command: "/old/path/chrome-devtools-axi",
+                timeout: 10,
+              },
+            ],
           },
         ],
       },
     };
-    const [updated, changed] = computeHookUpdate(settings, "/new/path/chrome-devtools-axi");
+    const [updated, changed] = computeHookUpdate(
+      settings,
+      "/new/path/chrome-devtools-axi",
+    );
     expect(changed).toBe(true);
     const str = JSON.stringify(updated);
     expect(str).toContain("/new/path/chrome-devtools-axi");
@@ -70,11 +103,23 @@ describe("computeHookUpdate", () => {
     const settings = {
       hooks: {
         SessionEnd: [
-          { matcher: "", hooks: [{ type: "command" as const, command: "cleanup-tool run", timeout: 5 }] },
+          {
+            matcher: "",
+            hooks: [
+              {
+                type: "command" as const,
+                command: "cleanup-tool run",
+                timeout: 5,
+              },
+            ],
+          },
         ],
       },
     };
-    const [updated, changed] = computeHookUpdate(settings, "/usr/bin/chrome-devtools-axi");
+    const [updated, changed] = computeHookUpdate(
+      settings,
+      "/usr/bin/chrome-devtools-axi",
+    );
     expect(changed).toBe(true);
     const str = JSON.stringify(updated);
     expect(str).toContain("cleanup-tool run");
@@ -87,7 +132,13 @@ describe("computeHookUpdate", () => {
         SessionStart: [
           {
             matcher: "",
-            hooks: [{ type: "command" as const, command: "/usr/local/bin/chrome-devtools-axi", timeout: 10 }],
+            hooks: [
+              {
+                type: "command" as const,
+                command: "/usr/local/bin/chrome-devtools-axi",
+                timeout: 10,
+              },
+            ],
           },
         ],
       },
@@ -126,8 +177,12 @@ describe("getHookTargets", () => {
     const targets = getHookTargets();
     expect(targets.length).toBe(3);
     expect(targets.some((t) => t.path.includes(".claude"))).toBe(true);
-    expect(targets.some((t) => t.path.includes(".codex/hooks.json"))).toBe(true);
-    expect(targets.some((t) => t.path.includes(".codex/config.toml"))).toBe(true);
+    expect(targets.some((t) => t.path.includes(".codex/hooks.json"))).toBe(
+      true,
+    );
+    expect(targets.some((t) => t.path.includes(".codex/config.toml"))).toBe(
+      true,
+    );
   });
 
   it("Claude target reads from settings.json", () => {
@@ -141,7 +196,9 @@ describe("getHookTargets", () => {
   });
 
   it("Codex config target reads from config.toml", () => {
-    const codex = getHookTargets().find((t) => t.path.includes(".codex/config.toml"));
+    const codex = getHookTargets().find((t) =>
+      t.path.includes(".codex/config.toml"),
+    );
     expect(codex!.path).toMatch(/config\.toml$/);
   });
 });
@@ -154,7 +211,9 @@ describe("computeCodexConfigUpdate", () => {
   });
 
   it("adds codex_hooks when features section exists", () => {
-    const [updated, changed] = computeCodexConfigUpdate("[features]\nother = true\n");
+    const [updated, changed] = computeCodexConfigUpdate(
+      "[features]\nother = true\n",
+    );
     expect(changed).toBe(true);
     expect(updated).toContain("[features]");
     expect(updated).toContain("other = true");
@@ -162,7 +221,9 @@ describe("computeCodexConfigUpdate", () => {
   });
 
   it("repairs codex_hooks when disabled", () => {
-    const [updated, changed] = computeCodexConfigUpdate("[features]\ncodex_hooks = false\n");
+    const [updated, changed] = computeCodexConfigUpdate(
+      "[features]\ncodex_hooks = false\n",
+    );
     expect(changed).toBe(true);
     expect(updated).toContain("codex_hooks = true");
     expect(updated).not.toContain("codex_hooks = false");
@@ -176,18 +237,22 @@ describe("computeCodexConfigUpdate", () => {
   });
 
   it("preserves unrelated sections while adding the flag", () => {
-    const [updated, changed] = computeCodexConfigUpdate("[model]\nname = \"gpt-5\"\n");
+    const [updated, changed] = computeCodexConfigUpdate(
+      '[model]\nname = "gpt-5"\n',
+    );
     expect(changed).toBe(true);
     expect(updated).toContain("[model]");
-    expect(updated).toContain("name = \"gpt-5\"");
+    expect(updated).toContain('name = "gpt-5"');
     expect(updated).toContain("[features]");
     expect(updated).toContain("codex_hooks = true");
   });
 
   it("inserts before a following array-of-tables header", () => {
-    const input = "[features]\nother = true\n[[profiles]]\nname = \"default\"\n";
+    const input = '[features]\nother = true\n[[profiles]]\nname = "default"\n';
     const [updated, changed] = computeCodexConfigUpdate(input);
     expect(changed).toBe(true);
-    expect(updated).toBe("[features]\nother = true\ncodex_hooks = true\n[[profiles]]\nname = \"default\"\n");
+    expect(updated).toBe(
+      '[features]\nother = true\ncodex_hooks = true\n[[profiles]]\nname = "default"\n',
+    );
   });
 });

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { computeCodexConfigUpdate, computeHookUpdate, getHookTargets } from "../src/hooks.js";
+import {
+  computeCodexConfigUpdate,
+  computeHookUpdate,
+  getHookTargets,
+  shouldInstallHooksForExecPath,
+} from "../src/hooks.js";
 
 describe("computeHookUpdate", () => {
   it("installs hook when settings have no hooks", () => {
@@ -74,6 +79,45 @@ describe("computeHookUpdate", () => {
     const str = JSON.stringify(updated);
     expect(str).toContain("cleanup-tool run");
     expect(str).toContain("chrome-devtools-axi");
+  });
+
+  it("repairs hooks regardless of whether the exec path is production-eligible", () => {
+    const settings = {
+      hooks: {
+        SessionStart: [
+          {
+            matcher: "",
+            hooks: [{ type: "command" as const, command: "/usr/local/bin/chrome-devtools-axi", timeout: 10 }],
+          },
+        ],
+      },
+    };
+    const [updated, changed] = computeHookUpdate(
+      settings,
+      "/Users/kunchen/.airlock/worktrees/bf2b16b1f6b6/pool-3/bin/chrome-devtools-axi.ts",
+    );
+    expect(changed).toBe(true);
+    expect(JSON.stringify(updated)).toContain(
+      "/Users/kunchen/.airlock/worktrees/bf2b16b1f6b6/pool-3/bin/chrome-devtools-axi.ts",
+    );
+  });
+});
+
+describe("shouldInstallHooksForExecPath", () => {
+  it("rejects non-production TypeScript entrypoints", () => {
+    expect(
+      shouldInstallHooksForExecPath(
+        "/Users/kunchen/.airlock/worktrees/bf2b16b1f6b6/pool-3/bin/chrome-devtools-axi.ts",
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts packaged dist entrypoints", () => {
+    expect(
+      shouldInstallHooksForExecPath(
+        "/Users/kunchen/github/kunchenguid/chrome-devtools-axi/dist/bin/chrome-devtools-axi.js",
+      ),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
Prevents automatic hook installation from running when `chrome-devtools-axi` is launched from non-production TypeScript/dev entrypoints, so local development and Airlock worktree runs do not rewrite user Claude/Codex hook configs.

**Risk Assessment:** 🟢 Low — Low risk because the change is narrowly bounded to hook-install gating, fully covered by passing targeted and full tests, and has no critique findings.

## Architecture
```mermaid
flowchart TD
  subgraph startup["CLI Startup"]
    direction TB
    cli_main["CLI main (unchanged)"]
    install_hooks["installHooks (updated)"]
    exec_guard["shouldInstallHooksForExecPath (added)"]
    prod_exec["Packaged CLI executable (unchanged)"]
    dev_exec["TypeScript dev entrypoint (unchanged)"]
    skip_writes["Hook files left untouched (unchanged)"]

    cli_main -->|"invokes on every run"| install_hooks
    install_hooks -->|"validates current exec path"| exec_guard
    prod_exec -->|"accepted"| exec_guard
    dev_exec -->|"rejected"| exec_guard
    exec_guard -->|"false skips installation"| skip_writes
  end

  subgraph config["Hook Configuration"]
    direction TB
    hook_update["computeHookUpdate (unchanged)"]
    codex_update["computeCodexConfigUpdate (unchanged)"]
    agent_hooks["Claude/Codex hook JSON files (unchanged)"]
    codex_features["Codex config.toml features flag (unchanged)"]

    hook_update -->|"writes SessionStart command"| agent_hooks
    codex_update -->|"enables codex_hooks"| codex_features
  end

  subgraph tests["Regression Coverage"]
    direction TB
    hook_tests["Hook installation tests (updated)"]
  end

  exec_guard -->|"true allows updates"| hook_update
  exec_guard -->|"true allows updates"| codex_update
  hook_tests -->|"verifies install-path filter"| exec_guard
  hook_tests -->|"verifies hook repair behavior"| hook_update
```

## Key changes made
- Added `shouldInstallHooksForExecPath()` to allow hook installation only for packaged `dist/bin/chrome-devtools-axi.js` paths or installed `chrome-devtools-axi` binaries, while rejecting `.ts` entrypoints.
- Updated `installHooks()` to gate all hook/config writes behind that exec-path eligibility check.
- Expanded hook tests to cover the new install gate and to confirm hook-path repair logic still works independently of production-install eligibility.
- Updated `README.md` and inline docs to clarify that development entrypoints do not auto-install hooks.

## How was this tested
- `npx vitest run test/hooks.test.ts`
- `npm test`
- `npx prettier --check src/hooks.ts test/hooks.test.ts`
- `npx tsc --noEmit`
