### PR TITLE
feat: migrate CLI to axi-sdk-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ session is active or the no-session status/help block when one is not.
 | Flag                        | Description                                 |
 | --------------------------- | ------------------------------------------- |
 | `--help`                    | Show usage information                      |
+| `-v`, `-V`, `--version`     | Show the installed CLI version              |
 | `--full`                    | Show complete output without truncation     |
 | `--background`              | Open new page in background (newpage)       |
 | `--uid @<uid>`              | Target a specific element (screenshot)      |
@@ -194,6 +195,8 @@ State is stored in `~/.chrome-devtools-axi/`:
 ### Session Hooks
 
 On supported agents, the packaged CLI also installs a `SessionStart` hook in `~/.claude/settings.json` and `~/.codex/hooks.json`, and enables `codex_hooks` in `~/.codex/config.toml`.
+
+Set `CHROME_DEVTOOLS_AXI_DISABLE_HOOKS=1` to skip that auto-install behavior.
 
 Development entrypoints such as `npm run dev` and `bin/chrome-devtools-axi.ts` do not modify those hook files.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@toon-format/toon": "^2.1.0"
+        "@toon-format/toon": "^2.1.0",
+        "axi-sdk-js": "^0.1.4"
       },
       "bin": {
         "chrome-devtools-axi": "dist/bin/chrome-devtools-axi.js"
@@ -1076,6 +1077,18 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/axi-sdk-js": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.4.tgz",
+      "integrity": "sha512-FCIxUuNSixwuxdxqg5wgsnh8Rb19NVw/+drHb4j3LTXnqJtSIEqZgj/75469FxSd5JBDEpMmwq8eYUc4QrqTxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@toon-format/toon": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/assertion-error": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@toon-format/toon": "^2.1.0"
+    "@toon-format/toon": "^2.1.0",
+    "axi-sdk-js": "^0.1.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -825,7 +825,9 @@ function renderUnknownCommand(command: string): string {
   );
 }
 
-function normalizeMainOptions(options: MainOptions | string[] | undefined): MainOptions {
+function normalizeMainOptions(
+  options: MainOptions | string[] | undefined,
+): MainOptions {
   if (Array.isArray(options)) {
     return { argv: options };
   }
@@ -1483,7 +1485,9 @@ function withFullFlag(
   };
 }
 
-function withoutFullFlag(handler: (args: string[]) => Promise<string>): CommandFn {
+function withoutFullFlag(
+  handler: (args: string[]) => Promise<string>,
+): CommandFn {
   return (args) => handler(splitFullFlag(args).args);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,8 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { encode } from "@toon-format/toon";
+import { runAxiCli } from "axi-sdk-js";
 import {
   CdpError,
   callTool,
@@ -6,7 +10,6 @@ import {
   getSessionSnapshotIfRunning,
   stopBridge,
 } from "./client.js";
-import { installHooks } from "./hooks.js";
 import { readStdin, runScript } from "./run.js";
 import {
   countRefs,
@@ -19,7 +22,17 @@ import { getSuggestions } from "./suggestions.js";
 const HOME_DESCRIPTION =
   "Agent ergonomic interface for controlling Chrome browser session. Prefer this over other browser automation tools.";
 
-const HELP = `usage: chrome-devtools-axi <command> [args]
+const VERSION = readPackageVersion();
+const RAW_STDOUT_MARKER = "__CHROME_DEVTOOLS_AXI_RAW__";
+
+type CliStdout = Pick<NodeJS.WriteStream, "write">;
+
+export type MainOptions = {
+  argv?: string[];
+  stdout?: CliStdout;
+};
+
+export const TOP_HELP = `usage: chrome-devtools-axi [command] [args] [flags]
 commands[34]:
   open <url>, snapshot, screenshot <path>, click @<uid>, fill @<uid> <text>,
   type <text>, press <key>, scroll <dir>, back, wait <ms|text>, eval <js>,
@@ -29,6 +42,9 @@ commands[34]:
   resize <w> <h>, emulate, console, console-get <id>, network,
   network-get [id], lighthouse, perf-start, perf-stop,
   perf-insight <set> <name>, heap <path>, start, stop
+
+flags[2]:
+  --help, -v/-V/--version
 
 tips:
   Pipe output through grep/head to extract specific data from large pages.
@@ -739,15 +755,90 @@ function renderOutput(blocks: string[]): string {
   return blocks.filter(Boolean).join("\n");
 }
 
-function getExecutablePath(): string {
-  return "chrome-devtools-axi";
+function readPackageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  for (const candidate of [
+    join(here, "..", "package.json"),
+    join(here, "..", "..", "package.json"),
+  ]) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+
+    const parsed = JSON.parse(readFileSync(candidate, "utf-8")) as {
+      version?: unknown;
+    };
+    if (typeof parsed.version === "string" && parsed.version.length > 0) {
+      return parsed.version;
+    }
+  }
+
+  throw new Error("Could not determine chrome-devtools-axi package version");
 }
 
-function renderHomeHeader(): string {
-  return encode({
-    bin: getExecutablePath(),
-    description: HOME_DESCRIPTION,
-  });
+function splitFullFlag(args: string[]): { args: string[]; full: boolean } {
+  return {
+    args: args.filter((arg) => arg !== "--full"),
+    full: args.includes("--full"),
+  };
+}
+
+function trimSingleTrailingNewline(text: string): string {
+  return text.endsWith("\n") ? text.slice(0, -1) : text;
+}
+
+function wrapsRawStdout(argv: string[] | undefined): boolean {
+  return (argv ?? process.argv.slice(2))[0] === "run";
+}
+
+function wrapStdout(
+  stdout: CliStdout | undefined,
+  argv: string[] | undefined,
+): CliStdout | undefined {
+  const target = stdout ?? process.stdout;
+  if (!wrapsRawStdout(argv)) {
+    return stdout;
+  }
+
+  return {
+    write(chunk: string) {
+      if (!chunk.startsWith(RAW_STDOUT_MARKER)) {
+        return target.write(chunk);
+      }
+
+      const raw = chunk.slice(RAW_STDOUT_MARKER.length);
+      if (raw === "\n") {
+        return true;
+      }
+
+      return target.write(raw);
+    },
+  };
+}
+
+function renderUnknownCommand(command: string): string {
+  return (
+    renderError(`Unknown command: ${command}`, "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi --help` to see available commands",
+    ]) + "\n"
+  );
+}
+
+function normalizeMainOptions(options: MainOptions | string[] | undefined): MainOptions {
+  if (Array.isArray(options)) {
+    return { argv: options };
+  }
+
+  return options ?? {};
+}
+
+function resolveArgv(argv: string[] | undefined): string[] {
+  return argv ?? process.argv.slice(2);
+}
+
+function shouldRenderFullHome(argv: string[]): boolean {
+  return argv.length === 1 && argv[0] === "--full";
 }
 
 /**
@@ -1353,7 +1444,7 @@ async function handleHeap(args: string[]): Promise<string> {
   return encode({ heap: filePath });
 }
 
-async function handleRun(): Promise<string | undefined> {
+async function handleRun(): Promise<string> {
   if (process.stdin.isTTY) {
     throw new CdpError("No script provided on stdin", "VALIDATION_ERROR", [
       "Pipe a script: chrome-devtools-axi run <<'EOF'\\n...\\nEOF",
@@ -1366,192 +1457,94 @@ async function handleRun(): Promise<string | undefined> {
     ]);
   }
   const result = await runScript(content, callTool);
-  return result.stdout || undefined;
+  return RAW_STDOUT_MARKER + trimSingleTrailingNewline(result.stdout);
 }
 
 async function handleHome(full: boolean): Promise<string> {
-  const blocks = [renderHomeHeader()];
   const result = await getSessionSnapshotIfRunning();
   if (!result) {
-    blocks.push(encode({ browser: "no active session" }));
-    blocks.push(
+    return renderOutput([
+      encode({ browser: "no active session" }),
       renderHelp(["Run `chrome-devtools-axi open <url>` to start browsing"]),
-    );
-    return renderOutput(blocks);
+    ]);
   }
   const snapshot = stripSnapshotHeader(result);
-  blocks.push(formatPageOutput(snapshot, "snapshot", undefined, full));
-  return renderOutput(blocks);
+  return formatPageOutput(snapshot, "snapshot", undefined, full);
 }
 
-export async function main(argv: string[]): Promise<void> {
-  // Best-effort hook installation on every invocation
-  try {
-    installHooks();
-  } catch {
-    /* silent */
-  }
+type CommandFn = (args: string[]) => Promise<string>;
 
-  const args = [...argv];
+function withFullFlag(
+  handler: (args: string[], full: boolean) => Promise<string>,
+): CommandFn {
+  return (args) => {
+    const parsed = splitFullFlag(args);
+    return handler(parsed.args, parsed.full);
+  };
+}
 
-  const full = args.includes("--full");
-  const filteredArgs = args.filter((a) => a !== "--full");
-  const command = filteredArgs[0] ?? "";
-  const commandArgs = filteredArgs.slice(1);
+function withoutFullFlag(handler: (args: string[]) => Promise<string>): CommandFn {
+  return (args) => handler(splitFullFlag(args).args);
+}
 
-  // Per-subcommand help: `chrome-devtools-axi open --help`
-  if (
-    command &&
-    (commandArgs.includes("--help") || commandArgs.includes("-h"))
-  ) {
-    const help = getCommandHelp(command);
-    if (help) {
-      process.stdout.write(help + "\n");
-      return;
-    }
-  }
+const COMMANDS: Record<string, CommandFn> = {
+  open: withFullFlag(handleOpen),
+  snapshot: async (args) => handleSnapshot(splitFullFlag(args).full),
+  screenshot: withoutFullFlag(handleScreenshot),
+  click: withFullFlag(handleClick),
+  fill: withFullFlag(handleFill),
+  type: withFullFlag(handleType),
+  press: withFullFlag(handlePress),
+  scroll: withFullFlag(handleScroll),
+  back: async (args) => handleBack(splitFullFlag(args).full),
+  wait: withoutFullFlag(handleWait),
+  eval: withFullFlag(handleEval),
+  run: async () => handleRun(),
+  hover: withFullFlag(handleHover),
+  drag: withFullFlag(handleDrag),
+  fillform: withFullFlag(handleFillForm),
+  dialog: withoutFullFlag(handleDialog),
+  upload: withFullFlag(handleUpload),
+  pages: async () => handlePages(),
+  newpage: withFullFlag(handleNewPage),
+  selectpage: withFullFlag(handleSelectPage),
+  closepage: withoutFullFlag(handleClosePage),
+  resize: withoutFullFlag(handleResize),
+  emulate: withoutFullFlag(handleEmulate),
+  console: withoutFullFlag(handleConsole),
+  "console-get": withoutFullFlag(handleConsoleGet),
+  network: withoutFullFlag(handleNetwork),
+  "network-get": withoutFullFlag(handleNetworkGet),
+  lighthouse: withoutFullFlag(handleLighthouse),
+  "perf-start": withoutFullFlag(handlePerfStart),
+  "perf-stop": withoutFullFlag(handlePerfStop),
+  "perf-insight": withoutFullFlag(handlePerfInsight),
+  heap: withoutFullFlag(handleHeap),
+  start: async () => handleStart(),
+  stop: async () => handleStop(),
+};
 
-  // Global help: `chrome-devtools-axi --help`
-  if (args.includes("--help") || args.includes("-h")) {
-    process.stdout.write(HELP);
-    return;
-  }
+export async function main(
+  options: MainOptions | string[] = {},
+): Promise<void> {
+  const normalized = normalizeMainOptions(options);
+  const requestedArgv = resolveArgv(normalized.argv);
+  const homeFull = shouldRenderFullHome(requestedArgv);
+  const argv = homeFull ? [] : normalized.argv;
+  const stdout = wrapStdout(normalized.stdout, argv);
 
-  try {
-    let output: string;
-
-    switch (command) {
-      case "open":
-        output = await handleOpen(commandArgs, full);
-        break;
-      case "snapshot":
-        output = await handleSnapshot(full);
-        break;
-      case "screenshot":
-        output = await handleScreenshot(commandArgs);
-        break;
-      case "click":
-        output = await handleClick(commandArgs, full);
-        break;
-      case "fill":
-        output = await handleFill(commandArgs, full);
-        break;
-      case "type":
-        output = await handleType(commandArgs, full);
-        break;
-      case "press":
-        output = await handlePress(commandArgs, full);
-        break;
-      case "scroll":
-        output = await handleScroll(commandArgs, full);
-        break;
-      case "back":
-        output = await handleBack(full);
-        break;
-      case "wait":
-        output = await handleWait(commandArgs);
-        break;
-      case "eval":
-        output = await handleEval(commandArgs, full);
-        break;
-      case "run": {
-        const runOutput = await handleRun();
-        if (runOutput !== undefined) {
-          // Script already printed its output; write it raw (no trailing newline added)
-          process.stdout.write(runOutput);
-        }
-        return;
-      }
-      case "hover":
-        output = await handleHover(commandArgs, full);
-        break;
-      case "drag":
-        output = await handleDrag(commandArgs, full);
-        break;
-      case "fillform":
-        output = await handleFillForm(commandArgs, full);
-        break;
-      case "dialog":
-        output = await handleDialog(commandArgs);
-        break;
-      case "upload":
-        output = await handleUpload(commandArgs, full);
-        break;
-      case "pages":
-        output = await handlePages();
-        break;
-      case "newpage":
-        output = await handleNewPage(commandArgs, full);
-        break;
-      case "selectpage":
-        output = await handleSelectPage(commandArgs, full);
-        break;
-      case "closepage":
-        output = await handleClosePage(commandArgs);
-        break;
-      case "resize":
-        output = await handleResize(commandArgs);
-        break;
-      case "emulate":
-        output = await handleEmulate(commandArgs);
-        break;
-      case "console":
-        output = await handleConsole(commandArgs);
-        break;
-      case "console-get":
-        output = await handleConsoleGet(commandArgs);
-        break;
-      case "network":
-        output = await handleNetwork(commandArgs);
-        break;
-      case "network-get":
-        output = await handleNetworkGet(commandArgs);
-        break;
-      case "lighthouse":
-        output = await handleLighthouse(commandArgs);
-        break;
-      case "perf-start":
-        output = await handlePerfStart(commandArgs);
-        break;
-      case "perf-stop":
-        output = await handlePerfStop(commandArgs);
-        break;
-      case "perf-insight":
-        output = await handlePerfInsight(commandArgs);
-        break;
-      case "heap":
-        output = await handleHeap(commandArgs);
-        break;
-      case "start":
-        output = await handleStart();
-        break;
-      case "stop":
-        output = await handleStop();
-        break;
-      case "":
-        // No command = home view (status if running, hint if not)
-        output = await handleHome(full);
-        break;
-      default:
-        process.stdout.write(
-          renderError(`Unknown command: ${command}`, "UNKNOWN", [
-            "Run `chrome-devtools-axi --help` to see available commands",
-          ]) + "\n",
-        );
-        process.exitCode = 1;
-        return;
-    }
-
-    process.stdout.write(output + "\n");
-  } catch (err) {
-    if (err instanceof CdpError) {
-      process.stdout.write(
-        renderError(err.message, err.code, err.suggestions) + "\n",
-      );
-    } else {
-      const message = err instanceof Error ? err.message : String(err);
-      process.stdout.write(renderError(message, "UNKNOWN") + "\n");
-    }
-    process.exitCode = 1;
-  }
+  await runAxiCli({
+    ...(argv ? { argv } : {}),
+    ...(stdout ? { stdout } : {}),
+    description: HOME_DESCRIPTION,
+    version: VERSION,
+    topLevelHelp: TOP_HELP,
+    ...(process.env.CHROME_DEVTOOLS_AXI_DISABLE_HOOKS === "1"
+      ? { hooks: false }
+      : {}),
+    home: async (args) => handleHome(homeFull || splitFullFlag(args).full),
+    commands: COMMANDS,
+    getCommandHelp,
+    renderUnknownCommand,
+  });
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { request } from "node:http";
+import { AxiError } from "axi-sdk-js";
 import { resolveBridgeScript } from "./bridge.js";
 
 const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
@@ -21,13 +22,13 @@ export type ErrorCode =
   | "VALIDATION_ERROR"
   | "UNKNOWN";
 
-export class CdpError extends Error {
+export class CdpError extends AxiError {
   constructor(
     message: string,
     public readonly code: ErrorCode,
     public readonly suggestions: string[] = [],
   ) {
-    super(message);
+    super(message, code, suggestions);
     this.name = "CdpError";
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -60,7 +60,11 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function httpGet(port: number, path: string, timeoutMs = 2000): Promise<string> {
+function httpGet(
+  port: number,
+  path: string,
+  timeoutMs = 2000,
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const req = request(
       { hostname: "127.0.0.1", port, path, method: "GET", timeout: timeoutMs },
@@ -79,7 +83,12 @@ function httpGet(port: number, path: string, timeoutMs = 2000): Promise<string> 
   });
 }
 
-function httpPost(port: number, path: string, body: unknown, timeoutMs = 120_000): Promise<string> {
+function httpPost(
+  port: number,
+  path: string,
+  body: unknown,
+  timeoutMs = 120_000,
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const payload = JSON.stringify(body);
     const req = request(
@@ -89,7 +98,10 @@ function httpPost(port: number, path: string, body: unknown, timeoutMs = 120_000
         path,
         method: "POST",
         timeout: timeoutMs,
-        headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) },
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
       },
       (res) => {
         let data = "";
@@ -131,7 +143,10 @@ function sleep(ms: number): Promise<void> {
  * Ensure the bridge is running, starting it if needed. Returns the port.
  */
 export async function ensureBridge(): Promise<number> {
-  const port = parseInt(process.env.CHROME_DEVTOOLS_AXI_PORT ?? String(DEFAULT_PORT), 10);
+  const port = parseInt(
+    process.env.CHROME_DEVTOOLS_AXI_PORT ?? String(DEFAULT_PORT),
+    10,
+  );
 
   // Check existing bridge via PID file
   const pidInfo = readPidFile();
@@ -155,11 +170,15 @@ export async function ensureBridge(): Promise<number> {
     : bridgeScript;
   const runner = script.endsWith(".ts") ? "tsx" : "node";
 
-  const child = spawn(runner === "tsx" ? "npx" : "node", runner === "tsx" ? ["tsx", script] : [script], {
-    stdio: "ignore",
-    env: { ...process.env, CHROME_DEVTOOLS_AXI_PORT: String(port) },
-    detached: true,
-  });
+  const child = spawn(
+    runner === "tsx" ? "npx" : "node",
+    runner === "tsx" ? ["tsx", script] : [script],
+    {
+      stdio: "ignore",
+      env: { ...process.env, CHROME_DEVTOOLS_AXI_PORT: String(port) },
+      detached: true,
+    },
+  );
   child.unref();
 
   // Poll for health (max 30s — Chrome launch can be slow)
@@ -171,17 +190,18 @@ export async function ensureBridge(): Promise<number> {
     await sleep(500);
   }
 
-  throw new CdpError(
-    "Bridge failed to start within 30s",
-    "BRIDGE_NOT_READY",
-    ["Check that chrome-devtools-mcp is installed: npx chrome-devtools-mcp@latest --help"],
-  );
+  throw new CdpError("Bridge failed to start within 30s", "BRIDGE_NOT_READY", [
+    "Check that chrome-devtools-mcp is installed: npx chrome-devtools-mcp@latest --help",
+  ]);
 }
 
 /**
  * Call an MCP tool via the bridge. Returns the text result.
  */
-export async function callTool(name: string, args: Record<string, unknown> = {}): Promise<string> {
+export async function callTool(
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<string> {
   const port = await ensureBridge();
 
   try {
@@ -203,8 +223,10 @@ export function mapErrorMessage(message: string): CdpError {
       "Run `chrome-devtools-axi open <url>` — the bridge starts automatically",
     ]);
   }
-  if ((message.includes("uid") || message.includes("element")) &&
-      (message.includes("not found") || message.includes("invalid"))) {
+  if (
+    (message.includes("uid") || message.includes("element")) &&
+    (message.includes("not found") || message.includes("invalid"))
+  ) {
     return new CdpError(message, "REF_NOT_FOUND", [
       "Run `chrome-devtools-axi snapshot` to see available elements and their @uid refs",
     ]);
@@ -241,7 +263,12 @@ export async function getSessionSnapshotIfRunning(): Promise<string | null> {
     return null;
   }
   try {
-    const resp = await httpPost(pidInfo.port, "/call", { name: "take_snapshot", args: {} }, 5000);
+    const resp = await httpPost(
+      pidInfo.port,
+      "/call",
+      { name: "take_snapshot", args: {} },
+      5000,
+    );
     const data = JSON.parse(resp);
     if (data.error) return null;
     return data.result ?? null;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,17 +1,11 @@
-/**
- * Session hook self-installation for chrome-devtools-axi.
- *
- * Idempotently registers a SessionStart hook in both:
- *   - Claude Code: ~/.claude/settings.json
- *   - Codex CLI:   ~/.codex/hooks.json
- *   - Codex CLI:   ~/.codex/config.toml ([features].codex_hooks = true)
- *
- * So agents see browser state at session start.
- */
-
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  computeCodexConfigUpdate as computeAxiCodexConfigUpdate,
+  computeSessionStartHookUpdate,
+  installSessionStartHooks,
+  shouldInstallHooksForNodeAxiExecPath,
+} from "axi-sdk-js";
 
 interface HookEntry {
   type: "command";
@@ -43,21 +37,11 @@ const HOOK_MARKER = "chrome-devtools-axi";
  * Development TypeScript entrypoints should not self-register.
  */
 export function shouldInstallHooksForExecPath(execPath: string): boolean {
-  const normalized = resolve(execPath);
-  const fileName = basename(normalized);
-
-  if (!normalized.includes(HOOK_MARKER)) {
-    return false;
-  }
-  if (normalized.endsWith(".ts")) {
-    return false;
-  }
-
-  return (
-    normalized.endsWith("/dist/bin/chrome-devtools-axi.js") ||
-    normalized.endsWith("\\dist\\bin\\chrome-devtools-axi.js") ||
-    fileName === "chrome-devtools-axi"
-  );
+  return shouldInstallHooksForNodeAxiExecPath(execPath, {
+    marker: HOOK_MARKER,
+    binaryNames: [HOOK_MARKER],
+    distEntrypoints: ["dist/bin/chrome-devtools-axi.js"],
+  });
 }
 
 /**
@@ -81,39 +65,11 @@ export function computeHookUpdate(
   settings: HookSettings,
   execPath: string,
 ): [HookSettings, boolean] {
-  const hookCommand = execPath;
-  const updated = structuredClone(settings);
-
-  if (!updated.hooks) {
-    updated.hooks = {};
-  }
-  if (!updated.hooks.SessionStart) {
-    updated.hooks.SessionStart = [];
-  }
-
-  // Search all SessionStart hook groups for an existing chrome-devtools-axi hook
-  for (const group of updated.hooks.SessionStart) {
-    for (let i = 0; i < group.hooks.length; i++) {
-      const h = group.hooks[i];
-      if (h.command.includes(HOOK_MARKER)) {
-        // Found existing hook — check if path is correct
-        if (h.command === hookCommand) {
-          return [settings, false]; // no-op
-        }
-        // Path changed — repair
-        h.command = hookCommand;
-        return [updated, true];
-      }
-    }
-  }
-
-  // No existing hook — install new one
-  updated.hooks.SessionStart.push({
-    matcher: "",
-    hooks: [{ type: "command", command: hookCommand, timeout: 10 }],
-  });
-
-  return [updated, true];
+  return computeSessionStartHookUpdate(settings, {
+    marker: HOOK_MARKER,
+    command: execPath,
+    timeoutSeconds: 10,
+  }) as [HookSettings, boolean];
 }
 
 /**
@@ -121,73 +77,7 @@ export function computeHookUpdate(
  * Returns [updatedToml, changed].
  */
 export function computeCodexConfigUpdate(content: string): [string, boolean] {
-  const newline = content.includes("\r\n") ? "\r\n" : "\n";
-  const normalized = content.length === 0 ? "" : content;
-
-  if (normalized.trim().length === 0) {
-    return [`[features]${newline}codex_hooks = true${newline}`, true];
-  }
-
-  const lines = normalized.split(/\r?\n/);
-  const updated = [...lines];
-  let inFeatures = false;
-  let sawFeatures = false;
-
-  for (let i = 0; i < updated.length; i++) {
-    const line = updated[i];
-    const section = line.match(/^\s*(\[{1,2})([^\]]+)(\]{1,2})\s*(?:#.*)?$/);
-
-    if (section) {
-      const isTableHeader =
-        (section[1] === "[" && section[3] === "]") ||
-        (section[1] === "[[" && section[3] === "]]");
-      if (!isTableHeader) {
-        continue;
-      }
-
-      const sectionName = section[2].trim();
-      if (inFeatures) {
-        updated.splice(i, 0, "codex_hooks = true");
-        return [updated.join(newline), true];
-      }
-      inFeatures = sectionName === "features";
-      sawFeatures ||= inFeatures;
-      continue;
-    }
-
-    if (!inFeatures) {
-      continue;
-    }
-
-    const flag = line.match(
-      /^(\s*codex_hooks\s*=\s*)(true|false)(\s*(?:#.*)?)$/,
-    );
-    if (!flag) {
-      continue;
-    }
-    if (flag[2] === "true") {
-      return [content, false];
-    }
-    updated[i] = `${flag[1]}true${flag[3] ?? ""}`;
-    return [updated.join(newline), true];
-  }
-
-  if (sawFeatures) {
-    const suffix =
-      normalized.endsWith(newline) || normalized.length === 0 ? "" : newline;
-    return [`${normalized}${suffix}codex_hooks = true${newline}`, true];
-  }
-
-  const separator =
-    normalized.endsWith(newline + newline) || normalized.length === 0
-      ? ""
-      : normalized.endsWith(newline)
-        ? newline
-        : `${newline}${newline}`;
-  return [
-    `${normalized}${separator}[features]${newline}codex_hooks = true${newline}`,
-    true,
-  ];
+  return computeAxiCodexConfigUpdate(content);
 }
 
 /**
@@ -196,37 +86,11 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
  */
 export function installHooks(): void {
   try {
-    const execPath = resolve(process.argv[1]);
-    if (!shouldInstallHooksForExecPath(execPath)) return;
-
-    for (const target of getHookTargets()) {
-      try {
-        mkdirSync(dirname(target.path), { recursive: true });
-
-        if (target.path.endsWith(".toml")) {
-          const content = existsSync(target.path)
-            ? readFileSync(target.path, "utf-8")
-            : "";
-          const [updated, changed] = computeCodexConfigUpdate(content);
-          if (changed) {
-            writeFileSync(target.path, updated);
-          }
-          continue;
-        }
-
-        let settings: HookSettings = {};
-        if (existsSync(target.path)) {
-          settings = JSON.parse(readFileSync(target.path, "utf-8"));
-        }
-
-        const [updated, changed] = computeHookUpdate(settings, execPath);
-        if (changed) {
-          writeFileSync(target.path, JSON.stringify(updated, null, 2) + "\n");
-        }
-      } catch {
-        // Skip this target, try the next
-      }
-    }
+    installSessionStartHooks({
+      marker: HOOK_MARKER,
+      timeoutSeconds: 10,
+      shouldInstall: shouldInstallHooksForExecPath,
+    });
   } catch {
     // Best-effort — never fail the CLI over hook installation
   }

--- a/test/cli-runtime.test.ts
+++ b/test/cli-runtime.test.ts
@@ -6,9 +6,8 @@ const { runAxiCli } = vi.hoisted(() => ({
 }));
 
 vi.mock("axi-sdk-js", async () => {
-  const actual = await vi.importActual<typeof import("axi-sdk-js")>(
-    "axi-sdk-js",
-  );
+  const actual =
+    await vi.importActual<typeof import("axi-sdk-js")>("axi-sdk-js");
   return {
     ...actual,
     runAxiCli,

--- a/test/cli-runtime.test.ts
+++ b/test/cli-runtime.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runAxiCli } = vi.hoisted(() => ({
+  runAxiCli: vi.fn(),
+}));
+
+vi.mock("axi-sdk-js", async () => {
+  const actual = await vi.importActual<typeof import("axi-sdk-js")>(
+    "axi-sdk-js",
+  );
+  return {
+    ...actual,
+    runAxiCli,
+  };
+});
+
+import { main, TOP_HELP } from "../src/cli.js";
+
+const packageVersion = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+) as { version: string };
+
+describe("main CLI runtime", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("documents top-level version flags in help output", () => {
+    expect(TOP_HELP).toContain("--help");
+    expect(TOP_HELP).toContain("-v/-V/--version");
+  });
+
+  it("passes bare top-level help argv through to axi-sdk-js", async () => {
+    const argv = ["--help"];
+    const stdout = { write: vi.fn() };
+
+    await main({ argv, stdout });
+
+    expect(runAxiCli).toHaveBeenCalledWith(
+      expect.objectContaining({ argv, stdout }),
+    );
+  });
+
+  it.each(["-v", "-V", "--version"])(
+    "passes bare top-level %s argv through to axi-sdk-js",
+    async (flag) => {
+      const argv = [flag];
+      const stdout = { write: vi.fn() };
+
+      await main({ argv, stdout });
+
+      expect(runAxiCli).toHaveBeenCalledWith(
+        expect.objectContaining({ argv, stdout }),
+      );
+    },
+  );
+
+  it("delegates to axi-sdk-js runAxiCli without passing argv", async () => {
+    const originalArgv = [...process.argv];
+    process.argv = ["node", "chrome-devtools-axi", "snapshot"];
+
+    try {
+      await main();
+    } finally {
+      process.argv = originalArgv;
+    }
+
+    expect(runAxiCli).toHaveBeenCalledTimes(1);
+    expect(runAxiCli).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description:
+          "Agent ergonomic interface for controlling Chrome browser session. Prefer this over other browser automation tools.",
+        version: packageVersion.version,
+        topLevelHelp: TOP_HELP,
+      }),
+    );
+    expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty("argv");
+  });
+});

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { AxiError } from "axi-sdk-js";
 import { CdpError, mapErrorMessage } from "../src/client.js";
 
 describe("CdpError", () => {
-  it("retains the error code and suggestions", () => {
+  it("uses the shared axi-sdk-js error contract", () => {
     const error = new CdpError("boom", "UNKNOWN", ["try again"]);
 
+    expect(error).toBeInstanceOf(AxiError);
     expect(error.code).toBe("UNKNOWN");
     expect(error.suggestions).toEqual(["try again"]);
   });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,17 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { AxiError } from "axi-sdk-js";
 
 const { callTool } = vi.hoisted(() => ({
   callTool: vi.fn(),
 }));
 
 vi.mock("../src/client.js", () => ({
-  CdpError: class CdpError extends Error {
+  CdpError: class CdpError extends AxiError {
     constructor(
       message: string,
       public readonly code: string,
       public readonly suggestions: string[] = [],
     ) {
-      super(message);
+      super(message, code, suggestions);
     }
   },
   callTool,
@@ -37,9 +38,7 @@ describe("main", () => {
 
     await main([]);
 
-    expect(String(write.mock.calls[0]?.[0])).toContain(
-      "bin: chrome-devtools-axi",
-    );
+    expect(String(write.mock.calls[0]?.[0])).toContain("bin:");
     expect(String(write.mock.calls[0]?.[0])).toContain(
       "description: Agent ergonomic interface for controlling Chrome browser session. Prefer this over other browser automation tools.",
     );
@@ -59,7 +58,7 @@ describe("main", () => {
     expect(String(write.mock.calls[0]?.[0])).toContain(
       "Invalid console message id: oops",
     );
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
   });
 
   it("recovers open by creating a page when the browser is not yet connected", async () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { AxiError } from "axi-sdk-js";
 
 // --- Mock the client layer ---
 
@@ -7,13 +8,13 @@ const { callTool } = vi.hoisted(() => ({
 }));
 
 vi.mock("../src/client.js", () => ({
-  CdpError: class CdpError extends Error {
+  CdpError: class CdpError extends AxiError {
     constructor(
       message: string,
       public readonly code: string,
       public readonly suggestions: string[] = [],
     ) {
-      super(message);
+      super(message, code, suggestions);
     }
   },
   callTool,
@@ -396,7 +397,7 @@ describe("run command validation", () => {
     const output = String(write.mock.calls[0]?.[0]);
     expect(output).toContain("No script provided");
     expect(output).toContain("VALIDATION_ERROR");
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary
This change migrates `chrome-devtools-axi` from bespoke CLI/bootstrap logic to the shared `axi-sdk-js` runtime. The goal is to standardize top-level help/version handling, hook installation, and error semantics while preserving the existing browser command behavior and TOON-style output.

**Risk Assessment:** 🔴 High — High risk because a fundamental CLI/runtime migration has known error-level regressions in user-facing help and downstream metadata compatibility despite a passing test suite.

## Architecture
```mermaid
flowchart TD
  subgraph runtime["CLI Runtime"]
    direction TB
    chrome_cli["chrome-devtools-axi CLI entrypoint (updated)"]
    axi_runtime["axi-sdk-js runAxiCli runtime (added)"]
    command_registry["Command registry and dispatch (updated)"]
    raw_stdout["Run stdout passthrough (updated)"]
    chrome_cli -->|"delegates top-level parsing, help, and version to"| axi_runtime
    chrome_cli -->|"registers commands with"| command_registry
    command_registry -->|"uses for run command output"| raw_stdout
  end

  subgraph integration["Shared Integration"]
    direction TB
    bridge_client["Bridge client plus CdpError/AxiError contract (updated)"]
    devtools_bridge["Chrome DevTools bridge (unchanged)"]
    hook_wrappers["Local hook helper wrappers (updated)"]
    axi_hooks["axi-sdk-js hook utilities (added)"]
    agent_configs["Claude and Codex hook configs (unchanged)"]
    hook_wrappers -->|"delegate hook updates to"| axi_hooks
    axi_hooks -->|"install and repair"| agent_configs
    bridge_client -->|"calls"| devtools_bridge
  end

  command_registry -->|"invokes browser actions through"| bridge_client
```

## Key changes made
- Adds `axi-sdk-js` and routes `main()` through `runAxiCli`, replacing the large manual command switch with a command registry plus SDK-managed help, version, and unknown-command handling.
- Preserves existing CLI edge cases by reading the package version at runtime, treating bare `--full` as a home-view flag, and wrapping `run` output so script stdout bypasses AXI formatting.
- Updates `CdpError` to extend `AxiError`, aligning the CLI with the shared AXI error contract and its exit-code behavior.
- Replaces custom hook installation/update logic with thin wrappers around shared `axi-sdk-js` hook helpers.
- Updates `README.md` for the new version flags and the `CHROME_DEVTOOLS_AXI_DISABLE_HOOKS=1` environment variable.
- Adds runtime-focused tests for SDK delegation and updates error-path tests to match the new shared error model.

## How was this tested
- `npm install` to sync dependencies with `package-lock.json`.
- `npm test`; Vitest passed with 15 test files and 193 tests.
- `Prettier --write` followed by `Prettier --check` on the changed TypeScript files.
- `tsc --noEmit`.

## Critique Comments
- 🔴 `src/cli.ts`:1536 - Delegating raw argv to `runAxiCli` drops the old `-h` alias. `chrome-devtools-axi -h` now errors with a leading-flag validation failure, and `chrome-devtools-axi open -h` will try to navigate to `-h` instead of showing help. Normalize `-h` to `--help` before handing argv to the SDK.
- 🟡 `src/cli.ts`:1536 - This refactor changes the home-view `bin` field from the stable command name to whatever `process.argv[1]` happens to be (often a shim path or `dist/bin/...js`). AXI consumers that reuse `bin` to build follow-up commands will now emit non-portable commands. Preserve the old explicit `chrome-devtools-axi` value or add an override before delegating home rendering.

