### PR TITLE
Add headed and auto-connect browser modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,6 @@ snapshot:
 Execute `npx -y chrome-devtools-axi` to get browser automation tools.
 ```
 
-To install from a local checkout:
-
-```sh
-npm install
-npm run build
-npm install -g .
-```
-
 ## How It Works
 
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ snapshot:
 Execute `npx -y chrome-devtools-axi` to get browser automation tools.
 ```
 
-To install your fork locally:
+To install from a local checkout:
 
 ```sh
 npm install

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ snapshot:
 Execute `npx -y chrome-devtools-axi` to get browser automation tools.
 ```
 
+To install your fork locally:
+
+```sh
+npm install
+npm run build
+npm install -g .
+```
+
 ## How It Works
 
 ```
@@ -145,6 +153,21 @@ chrome-devtools-axi eval "(() => { const rows = [...document.querySelectorAll('t
 | `start` | Start the bridge server |
 | `stop`  | Stop the bridge server  |
 
+`start` persists the chosen browser mode for later commands. This makes it easy
+to switch between the default isolated headless browser, a visible browser
+window, or an existing Chrome session that already exposes DevTools.
+
+```sh
+# Start a visible browser window
+chrome-devtools-axi start --headed
+
+# Auto-connect to a compatible local Chrome session
+chrome-devtools-axi start --autoConnect
+
+# Attach to an existing Chrome / Chromium DevTools endpoint
+chrome-devtools-axi start --browser-url http://127.0.0.1:9222
+```
+
 Running with no command shows the CLI home view. It prepends `bin` and
 `description` metadata, then includes the current snapshot when a browser
 session is active or the no-session status/help block when one is not.
@@ -191,6 +214,22 @@ State is stored in `~/.chrome-devtools-axi/`:
 | File         | Purpose                            |
 | ------------ | ---------------------------------- |
 | `bridge.pid` | PID and port of the running bridge |
+| `bridge-config.json` | Persisted launch / attach settings |
+
+### Browser Mode Overrides
+
+The bridge reads these environment variables when starting:
+
+```sh
+export CHROME_DEVTOOLS_AXI_HEADLESS=false
+export CHROME_DEVTOOLS_AXI_ISOLATED=false
+export CHROME_DEVTOOLS_AXI_AUTO_CONNECT=true
+export CHROME_DEVTOOLS_AXI_BROWSER_URL=http://127.0.0.1:9222
+```
+
+The easiest path is still `chrome-devtools-axi start ...`, which writes the
+same settings to `~/.chrome-devtools-axi/bridge-config.json` for reuse by
+future `open`, `snapshot`, and other commands.
 
 ### Session Hooks
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm install -g .
            │ stdio
            ▼
 ┌───────────────────────┐
-│  chrome-devtools-mcp  │  Headless Chrome via DevTools Protocol
+│  chrome-devtools-mcp  │  Launch or attach to Chrome via DevTools Protocol
 └───────────────────────┘
 ```
 
@@ -168,6 +168,9 @@ chrome-devtools-axi start --autoConnect
 chrome-devtools-axi start --browser-url http://127.0.0.1:9222
 ```
 
+`--autoConnect` depends on Chrome's remote debugging server already being
+enabled from `chrome://inspect/#remote-debugging`.
+
 Running with no command shows the CLI home view. It prepends `bin` and
 `description` metadata, then includes the current snapshot when a browser
 session is active or the no-session status/help block when one is not.
@@ -179,6 +182,12 @@ session is active or the no-session status/help block when one is not.
 | `--help`                    | Show usage information                      |
 | `-v`, `-V`, `--version`     | Show the installed CLI version              |
 | `--full`                    | Show complete output without truncation     |
+| `--headed`                  | Launch a visible browser window (start)     |
+| `--headless`                | Force headless mode (start)                 |
+| `--autoConnect`             | Auto-connect to a local Chrome session (start) |
+| `--browser-url <url>`       | Attach to a specific DevTools endpoint (start) |
+| `--isolated`                | Launch with a temporary isolated profile (start) |
+| `--shared-profile`          | Launch against the shared local profile (start) |
 | `--background`              | Open new page in background (newpage)       |
 | `--uid @<uid>`              | Target a specific element (screenshot)      |
 | `--full-page`               | Capture entire scrollable page (screenshot) |
@@ -230,6 +239,9 @@ export CHROME_DEVTOOLS_AXI_BROWSER_URL=http://127.0.0.1:9222
 The easiest path is still `chrome-devtools-axi start ...`, which writes the
 same settings to `~/.chrome-devtools-axi/bridge-config.json` for reuse by
 future `open`, `snapshot`, and other commands.
+
+When both `CHROME_DEVTOOLS_AXI_AUTO_CONNECT` and
+`CHROME_DEVTOOLS_AXI_BROWSER_URL` are set, the explicit `browserUrl` wins.
 
 ### Session Hooks
 

--- a/src/bridge-config.ts
+++ b/src/bridge-config.ts
@@ -1,0 +1,128 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
+const CONFIG_FILE = join(STATE_DIR, "bridge-config.json");
+
+export interface BridgeLaunchOptions {
+  headless: boolean;
+  isolated: boolean;
+  autoConnect: boolean;
+  browserUrl?: string;
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function normalizeBrowserUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeOptions(
+  value: Partial<BridgeLaunchOptions> | null | undefined,
+): BridgeLaunchOptions {
+  return {
+    headless: value?.headless ?? true,
+    isolated: value?.isolated ?? true,
+    autoConnect: value?.autoConnect ?? false,
+    ...(normalizeBrowserUrl(value?.browserUrl)
+      ? { browserUrl: normalizeBrowserUrl(value?.browserUrl) }
+      : {}),
+  };
+}
+
+export function readStoredBridgeLaunchOptions(): BridgeLaunchOptions {
+  try {
+    if (!existsSync(CONFIG_FILE)) return normalizeOptions(undefined);
+    const raw = JSON.parse(readFileSync(CONFIG_FILE, "utf-8")) as Partial<
+      BridgeLaunchOptions
+    >;
+    return normalizeOptions(raw);
+  } catch {
+    return normalizeOptions(undefined);
+  }
+}
+
+export function resolveBridgeLaunchOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): BridgeLaunchOptions {
+  const stored = readStoredBridgeLaunchOptions();
+  const headless = parseBoolean(env.CHROME_DEVTOOLS_AXI_HEADLESS);
+  const isolated = parseBoolean(env.CHROME_DEVTOOLS_AXI_ISOLATED);
+  const autoConnect = parseBoolean(env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT);
+  const browserUrl = normalizeBrowserUrl(env.CHROME_DEVTOOLS_AXI_BROWSER_URL);
+  const resolvedAutoConnect = autoConnect ?? stored.autoConnect;
+
+  return {
+    headless: headless ?? stored.headless,
+    isolated: isolated ?? stored.isolated,
+    autoConnect: resolvedAutoConnect,
+    ...(browserUrl !== undefined
+      ? { browserUrl }
+      : resolvedAutoConnect
+        ? {}
+      : stored.browserUrl
+        ? { browserUrl: stored.browserUrl }
+        : {}),
+  };
+}
+
+export function writeStoredBridgeLaunchOptions(
+  options: BridgeLaunchOptions,
+): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(CONFIG_FILE, JSON.stringify(normalizeOptions(options), null, 2));
+}
+
+export function mergeBridgeLaunchOptions(
+  overrides: Partial<BridgeLaunchOptions>,
+): BridgeLaunchOptions {
+  const base = readStoredBridgeLaunchOptions();
+  const merged = normalizeOptions({
+    ...base,
+    ...overrides,
+    ...(overrides.browserUrl !== undefined
+      ? { browserUrl: overrides.browserUrl }
+      : {}),
+  });
+  if (overrides.autoConnect) {
+    delete merged.browserUrl;
+  }
+  if (overrides.browserUrl) {
+    merged.autoConnect = false;
+  }
+  return merged;
+}
+
+export function buildChromeDevtoolsMcpArgs(
+  options: BridgeLaunchOptions,
+): string[] {
+  const args = ["-y", "chrome-devtools-mcp@latest"];
+
+  if (options.browserUrl) {
+    args.push(`--browserUrl=${options.browserUrl}`);
+    return args;
+  }
+
+  if (options.autoConnect) {
+    args.push("--autoConnect");
+    return args;
+  }
+
+  if (options.headless) args.push("--headless");
+  if (options.isolated) args.push("--isolated");
+  return args;
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -21,6 +21,11 @@ import {
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
+import {
+  buildChromeDevtoolsMcpArgs,
+  resolveBridgeLaunchOptions,
+  type BridgeLaunchOptions,
+} from "./bridge-config.js";
 
 const DEFAULT_PORT = Number.parseInt(
   process.env.CHROME_DEVTOOLS_AXI_PORT ?? "9224",
@@ -226,10 +231,12 @@ function writeReadySignal(): void {
   process.stdout.write("READY\n");
 }
 
-function createTransport(): StdioClientTransport {
+export function createTransport(
+  options: BridgeLaunchOptions = resolveBridgeLaunchOptions(),
+): StdioClientTransport {
   return new StdioClientTransport({
     command: "npx",
-    args: ["-y", "chrome-devtools-mcp@latest", "--headless", "--isolated"],
+    args: buildChromeDevtoolsMcpArgs(options),
   });
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,10 @@ import {
   getSessionSnapshotIfRunning,
   stopBridge,
 } from "./client.js";
+import {
+  mergeBridgeLaunchOptions,
+  writeStoredBridgeLaunchOptions,
+} from "./bridge-config.js";
 import { readStdin, runScript } from "./run.js";
 import {
   countRefs,
@@ -233,11 +237,22 @@ examples:
   console.log("status:", status);
   EOF`,
 
-  start: `usage: chrome-devtools-axi start
-Start the bridge server (launches headless Chrome).
+  start: `usage: chrome-devtools-axi start [--headed|--headless] [--autoConnect] [--browser-url <url>] [--isolated|--shared-profile]
+Start the bridge server with persisted browser settings.
+
+flags:
+  --headed               Launch a visible browser instead of headless mode
+  --headless             Force headless mode
+  --autoConnect          Auto-connect to a compatible local Chrome session
+  --browser-url <url>    Attach to an existing Chrome/Chromium DevTools endpoint
+  --isolated             Launch a fresh isolated browser profile (default)
+  --shared-profile       Launch against the shared local browser profile
 
 examples:
-  chrome-devtools-axi start`,
+  chrome-devtools-axi start
+  chrome-devtools-axi start --headed
+  chrome-devtools-axi start --autoConnect
+  chrome-devtools-axi start --browser-url http://127.0.0.1:9222`,
 
   stop: `usage: chrome-devtools-axi stop
 Stop the bridge server and close the browser.
@@ -1149,9 +1164,68 @@ async function handleEval(args: string[], full: boolean): Promise<string> {
   return renderOutput(blocks);
 }
 
-async function handleStart(): Promise<string> {
+export function parseStartArgs(args: string[]): {
+  headless?: boolean;
+  isolated?: boolean;
+  autoConnect?: boolean;
+  browserUrl?: string;
+} {
+  const parsed: {
+    headless?: boolean;
+    isolated?: boolean;
+    autoConnect?: boolean;
+    browserUrl?: string;
+  } = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--headed") {
+      parsed.headless = false;
+      continue;
+    }
+    if (arg === "--headless") {
+      parsed.headless = true;
+      continue;
+    }
+    if (arg === "--isolated") {
+      parsed.isolated = true;
+      continue;
+    }
+    if (arg === "--shared-profile") {
+      parsed.isolated = false;
+      continue;
+    }
+    if (arg === "--autoConnect" || arg === "--auto-connect") {
+      parsed.autoConnect = true;
+      continue;
+    }
+    if (arg === "--browser-url") {
+      const browserUrl = args[++i];
+      if (!browserUrl) {
+        throw new CdpError("Missing browser URL", "VALIDATION_ERROR", [
+          "Run `chrome-devtools-axi start --browser-url http://127.0.0.1:9222` to attach to an existing browser",
+        ]);
+      }
+      parsed.browserUrl = browserUrl;
+      parsed.autoConnect = false;
+      continue;
+    }
+    throw new CdpError(`Unknown start flag: ${arg}`, "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi start --help` to see supported flags",
+    ]);
+  }
+
+  return parsed;
+}
+
+async function handleStart(args: string[]): Promise<string> {
+  const overrides = parseStartArgs(args);
+  if (Object.keys(overrides).length > 0) {
+    writeStoredBridgeLaunchOptions(mergeBridgeLaunchOptions(overrides));
+    await stopBridge();
+  }
   const port = await ensureBridge();
-  return encode({ status: "ready", port });
+  return encode({ status: "ready", port, ...overrides });
 }
 
 export function formatStopOutput(wasStopped: boolean): string {
@@ -1524,7 +1598,7 @@ const COMMANDS: Record<string, CommandFn> = {
   "perf-stop": withoutFullFlag(handlePerfStop),
   "perf-insight": withoutFullFlag(handlePerfInsight),
   heap: withoutFullFlag(handleHeap),
-  start: async () => handleStart(),
+  start: withoutFullFlag(handleStart),
   stop: async () => handleStop(),
 };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import { homedir } from "node:os";
 import { request } from "node:http";
 import { AxiError } from "axi-sdk-js";
 import { resolveBridgeScript } from "./bridge.js";
+import { resolveBridgeLaunchOptions } from "./bridge-config.js";
 
 const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
 const PID_FILE = join(STATE_DIR, "bridge.pid");
@@ -175,7 +176,21 @@ export async function ensureBridge(): Promise<number> {
     runner === "tsx" ? ["tsx", script] : [script],
     {
       stdio: "ignore",
-      env: { ...process.env, CHROME_DEVTOOLS_AXI_PORT: String(port) },
+      env: {
+        ...process.env,
+        CHROME_DEVTOOLS_AXI_PORT: String(port),
+        ...(() => {
+          const options = resolveBridgeLaunchOptions();
+          return {
+            CHROME_DEVTOOLS_AXI_HEADLESS: String(options.headless),
+            CHROME_DEVTOOLS_AXI_ISOLATED: String(options.isolated),
+            CHROME_DEVTOOLS_AXI_AUTO_CONNECT: String(options.autoConnect),
+            ...(options.browserUrl
+              ? { CHROME_DEVTOOLS_AXI_BROWSER_URL: options.browserUrl }
+              : {}),
+          };
+        })(),
+      },
       detached: true,
     },
   );

--- a/test/bridge-config.test.ts
+++ b/test/bridge-config.test.ts
@@ -33,6 +33,7 @@ describe("buildChromeDevtoolsMcpArgs", () => {
       "--isolated",
     ]);
   });
+
   it("builds autoConnect args for a local Chrome session", () => {
     const args = buildChromeDevtoolsMcpArgs({
       headless: true,

--- a/test/bridge-config.test.ts
+++ b/test/bridge-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChromeDevtoolsMcpArgs,
+  resolveBridgeLaunchOptions,
+} from "../src/bridge-config.js";
+
+describe("buildChromeDevtoolsMcpArgs", () => {
+  it("builds attach mode args for an existing browser", () => {
+    const args = buildChromeDevtoolsMcpArgs({
+      headless: false,
+      isolated: false,
+      autoConnect: false,
+      browserUrl: "http://127.0.0.1:9222",
+    });
+
+    expect(args).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--browserUrl=http://127.0.0.1:9222",
+    ]);
+  });
+
+  it("builds launch mode args for a headed isolated browser", () => {
+    const args = buildChromeDevtoolsMcpArgs({
+      headless: false,
+      isolated: true,
+      autoConnect: false,
+    });
+
+    expect(args).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--isolated",
+    ]);
+  });
+  it("builds autoConnect args for a local Chrome session", () => {
+    const args = buildChromeDevtoolsMcpArgs({
+      headless: true,
+      isolated: true,
+      autoConnect: true,
+    });
+
+    expect(args).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--autoConnect",
+    ]);
+  });
+});
+
+describe("resolveBridgeLaunchOptions", () => {
+  it("prefers environment overrides", () => {
+    const options = resolveBridgeLaunchOptions({
+      CHROME_DEVTOOLS_AXI_HEADLESS: "false",
+      CHROME_DEVTOOLS_AXI_ISOLATED: "false",
+      CHROME_DEVTOOLS_AXI_AUTO_CONNECT: "true",
+      CHROME_DEVTOOLS_AXI_BROWSER_URL: "http://127.0.0.1:9222",
+    });
+
+    expect(options).toEqual({
+      headless: false,
+      isolated: false,
+      autoConnect: true,
+      browserUrl: "http://127.0.0.1:9222",
+    });
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { formatStopOutput, formatScreenshotOutput, getCommandHelp, parseScreenshotArgs } from "../src/cli.js";
+import {
+  formatStopOutput,
+  formatScreenshotOutput,
+  getCommandHelp,
+  parseScreenshotArgs,
+  parseStartArgs,
+} from "../src/cli.js";
 
 describe("formatStopOutput", () => {
   it("returns stopped status when bridge was running", () => {
@@ -79,5 +85,36 @@ describe("formatScreenshotOutput", () => {
   it("includes file path in output", () => {
     const output = formatScreenshotOutput("./shot.png");
     expect(output).toContain("./shot.png");
+  });
+});
+
+describe("parseStartArgs", () => {
+  it("parses headed attach mode", () => {
+    const result = parseStartArgs([
+      "--headed",
+      "--autoConnect",
+      "--browser-url",
+      "http://127.0.0.1:9222",
+      "--shared-profile",
+    ]);
+
+    expect(result).toEqual({
+      headless: false,
+      autoConnect: false,
+      browserUrl: "http://127.0.0.1:9222",
+      isolated: false,
+    });
+  });
+
+  it("parses autoConnect mode", () => {
+    const result = parseStartArgs(["--autoConnect"]);
+
+    expect(result).toEqual({ autoConnect: true });
+  });
+
+  it("rejects a missing browser URL", () => {
+    expect(() => parseStartArgs(["--browser-url"])).toThrow(
+      "Missing browser URL",
+    );
   });
 });


### PR DESCRIPTION
## Summary

This adds first-class browser mode selection to `chrome-devtools-axi` so the bridge can do more than launch a fresh headless browser.

The main user-facing additions are:

- `chrome-devtools-axi start --headed`
- `chrome-devtools-axi start --autoConnect`
- `chrome-devtools-axi start --browser-url <url>`

That makes the CLI usable both for isolated automation and for attaching to a real local Chrome session when the user wants to inspect or drive an existing browser.

## Problem

Before this change, the bridge always started `chrome-devtools-mcp` with a hard-coded `--headless --isolated` launch path.

That meant:

- there was no supported way to launch a visible browser window
- there was no supported way to reuse an existing Chrome session
- there was no way to persist a chosen browser mode across later `open`, `snapshot`, or `pages` commands

In practice, this blocked live-session debugging workflows and made attach-style automation awkward even though the upstream MCP already supports `--autoConnect` and `--browserUrl`.

## What changed

### Bridge launch configuration

- added a small persisted bridge config layer in `src/bridge-config.ts`
- store launch settings in `~/.chrome-devtools-axi/bridge-config.json`
- resolve launch settings from persisted config plus environment overrides
- build the correct `chrome-devtools-mcp` arguments for:
  - default isolated launch
  - headed launch
  - `--autoConnect`
  - explicit `--browserUrl`

### CLI

- expanded `start` to accept:
  - `--headed`
  - `--headless`
  - `--autoConnect`
  - `--browser-url <url>`
  - `--isolated`
  - `--shared-profile`
- when `start` is called with any of those flags, the settings are persisted and the bridge is restarted so later commands reuse the selected mode

### Bridge/client wiring

- bridge transport creation now uses resolved launch options instead of hard-coded flags
- client auto-start passes the resolved launch config into the detached bridge process via environment variables

### Docs and tests

- updated README to document the new start modes and config behavior
- added tests for start-arg parsing and bridge argument construction

## Behavior notes

- `--autoConnect` is intended for attaching to a compatible local Chrome session
- `--browser-url` is still available for explicit DevTools endpoints
- explicit `browserUrl` takes precedence over auto-connect
- the default behavior remains isolated browser automation unless the user selects another mode

## Validation

- `npm test`
- `npm run build`
- validated the installed CLI with `chrome-devtools-axi start --headed`
- validated attach flow with `chrome-devtools-axi start --autoConnect`

## Why this approach

This keeps the change small and local to bridge startup while preserving the existing command model.

Users still interact with the CLI the same way, but now the bridge startup path matches the capabilities already exposed by `chrome-devtools-mcp`.
