### PR TITLE
feat: add headed mode, custom Chrome args, and GPU docs

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -227,10 +227,19 @@ function writeReadySignal(): void {
 }
 
 function createTransport(): StdioClientTransport {
-  return new StdioClientTransport({
-    command: "npx",
-    args: ["-y", "chrome-devtools-mcp@latest", "--headless", "--isolated"],
-  });
+  const args = ["-y", "chrome-devtools-mcp@latest", "--isolated"];
+  if (process.env.CHROME_DEVTOOLS_AXI_HEADED !== "1") {
+    args.push("--headless");
+  }
+
+  const extraChromeArgs = process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
+  if (extraChromeArgs) {
+    for (const arg of extraChromeArgs.split(" ").filter(Boolean)) {
+      args.push(`--chrome-arg=${arg}`);
+    }
+  }
+
+  return new StdioClientTransport({ command: "npx", args });
 }
 
 function createBridgeClient(): Client {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -226,7 +226,7 @@ function writeReadySignal(): void {
   process.stdout.write("READY\n");
 }
 
-function createTransport(): StdioClientTransport {
+export function buildTransportArgs(): string[] {
   const args = ["-y", "chrome-devtools-mcp@latest", "--isolated"];
   if (process.env.CHROME_DEVTOOLS_AXI_HEADED !== "1") {
     args.push("--headless");
@@ -234,12 +234,16 @@ function createTransport(): StdioClientTransport {
 
   const extraChromeArgs = process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
   if (extraChromeArgs) {
-    for (const arg of extraChromeArgs.split(" ").filter(Boolean)) {
+    for (const arg of extraChromeArgs.trim().split(/\s+/)) {
       args.push(`--chrome-arg=${arg}`);
     }
   }
 
-  return new StdioClientTransport({ command: "npx", args });
+  return args;
+}
+
+function createTransport(): StdioClientTransport {
+  return new StdioClientTransport({ command: "npx", args: buildTransportArgs() });
 }
 
 function createBridgeClient(): Client {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,7 +48,8 @@ flags[2]:
 
 environment:
   CHROME_DEVTOOLS_AXI_HEADED        Set to 1 to run Chrome in headed (visible) mode
-  CHROME_DEVTOOLS_AXI_CHROME_ARGS   Space-separated Chrome flags forwarded to the browser
+  CHROME_DEVTOOLS_AXI_CHROME_ARGS   Whitespace-separated Chrome flags forwarded to the browser
+                                    (no shell-style quoting; flags with spaces are not supported)
                                     e.g. "--enable-gpu --ignore-gpu-blocklist"
   CHROME_DEVTOOLS_AXI_PORT          Bridge server port (default: 9224)
   CHROME_DEVTOOLS_AXI_DISABLE_HOOKS Set to 1 to skip auto-installing session hooks

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,21 @@ commands[34]:
 flags[2]:
   --help, -v/-V/--version
 
+environment:
+  CHROME_DEVTOOLS_AXI_HEADED        Set to 1 to run Chrome in headed (visible) mode
+  CHROME_DEVTOOLS_AXI_CHROME_ARGS   Space-separated Chrome flags forwarded to the browser
+                                    e.g. "--enable-gpu --ignore-gpu-blocklist"
+  CHROME_DEVTOOLS_AXI_PORT          Bridge server port (default: 9224)
+  CHROME_DEVTOOLS_AXI_DISABLE_HOOKS Set to 1 to skip auto-installing session hooks
+
+gpu:
+  Headless Chrome cannot access hardware GPU on most Linux systems.
+  For GPU-accelerated WebGL, use headed mode with GPU flags:
+    CHROME_DEVTOOLS_AXI_HEADED=1
+    CHROME_DEVTOOLS_AXI_CHROME_ARGS="--enable-gpu --ignore-gpu-blocklist"
+  For WebGPU, Vulkan must also be enabled (required for the Dawn backend):
+    CHROME_DEVTOOLS_AXI_CHROME_ARGS="--enable-gpu --ignore-gpu-blocklist --enable-unsafe-webgpu --enable-features=Vulkan"
+
 tips:
   Pipe output through grep/head to extract specific data from large pages.
 `;

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { extractToolText, getErrorMessage, isBridgeClientConnected, parseBridgeCallPayload, resolveBridgeScript } from "../src/bridge.js";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { buildTransportArgs, extractToolText, getErrorMessage, isBridgeClientConnected, parseBridgeCallPayload, resolveBridgeScript } from "../src/bridge.js";
 
 describe("extractToolText", () => {
   it("joins text blocks and ignores non-text content", () => {
@@ -42,6 +42,57 @@ describe("getErrorMessage", () => {
 describe("resolveBridgeScript", () => {
   it("prefers the TypeScript bridge entrypoint in the repo checkout", () => {
     expect(resolveBridgeScript(import.meta.dirname)).toMatch(/bin\/chrome-devtools-axi-bridge\.ts$/);
+  });
+});
+
+describe("buildTransportArgs", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.CHROME_DEVTOOLS_AXI_HEADED = process.env.CHROME_DEVTOOLS_AXI_HEADED;
+    savedEnv.CHROME_DEVTOOLS_AXI_CHROME_ARGS = process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
+    delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
+    delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
+  });
+
+  afterEach(() => {
+    process.env.CHROME_DEVTOOLS_AXI_HEADED = savedEnv.CHROME_DEVTOOLS_AXI_HEADED;
+    process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS = savedEnv.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
+  });
+
+  it("defaults to headless and isolated", () => {
+    const args = buildTransportArgs();
+    expect(args).toEqual(["-y", "chrome-devtools-mcp@latest", "--isolated", "--headless"]);
+  });
+
+  it("omits --headless when CHROME_DEVTOOLS_AXI_HEADED=1", () => {
+    process.env.CHROME_DEVTOOLS_AXI_HEADED = "1";
+    const args = buildTransportArgs();
+    expect(args).toEqual(["-y", "chrome-devtools-mcp@latest", "--isolated"]);
+  });
+
+  it("forwards chrome args via --chrome-arg=", () => {
+    process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS = "--enable-gpu --ignore-gpu-blocklist";
+    const args = buildTransportArgs();
+    expect(args).toContain("--chrome-arg=--enable-gpu");
+    expect(args).toContain("--chrome-arg=--ignore-gpu-blocklist");
+  });
+
+  it("handles tabs, newlines, and extra whitespace in chrome args", () => {
+    process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS = "  --flag-a\t--flag-b\n--flag-c  ";
+    const args = buildTransportArgs();
+    expect(args).toContain("--chrome-arg=--flag-a");
+    expect(args).toContain("--chrome-arg=--flag-b");
+    expect(args).toContain("--chrome-arg=--flag-c");
+    expect(args.filter((a) => a.startsWith("--chrome-arg="))).toHaveLength(3);
+  });
+
+  it("combines headed mode with chrome args", () => {
+    process.env.CHROME_DEVTOOLS_AXI_HEADED = "1";
+    process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS = "--enable-unsafe-webgpu";
+    const args = buildTransportArgs();
+    expect(args).not.toContain("--headless");
+    expect(args).toContain("--chrome-arg=--enable-unsafe-webgpu");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `CHROME_DEVTOOLS_AXI_HEADED=1` env var to run Chrome in headed (visible) mode instead of headless
- Adds `CHROME_DEVTOOLS_AXI_CHROME_ARGS` env var to forward arbitrary Chrome flags via `--chrome-arg=<flag>` to chrome-devtools-mcp
- Documents all environment variables and GPU usage in `--help` output, including tested flags for WebGL and WebGPU on Linux

## Context

Headless Chrome on Linux cannot access hardware GPU, so WebGL falls back to SwiftShader (~3-5 FPS for 3D content). Headed mode with `--enable-gpu --ignore-gpu-blocklist` gives full GPU acceleration (~60 FPS).

For WebGPU, Vulkan must also be enabled (`--enable-features=Vulkan`) because Chrome's Dawn backend requires it — without Vulkan, `navigator.gpu.requestAdapter()` returns null even with `--enable-unsafe-webgpu`.

These flags were tested on Chrome 146 with an NVIDIA RTX 4090 on Ubuntu 24.04.

## Test plan
- [x] `chrome-devtools-axi --help` shows new environment and gpu sections
- [x] `CHROME_DEVTOOLS_AXI_HEADED=1 chrome-devtools-axi open <url>` launches a visible Chrome window
- [x] `CHROME_DEVTOOLS_AXI_CHROME_ARGS="--enable-gpu --ignore-gpu-blocklist"` flags appear in `chrome://gpu` command line
- [x] WebGPU demos load with `--enable-unsafe-webgpu --enable-features=Vulkan` on systems with Vulkan support

🤖 Generated with [Claude Code](https://claude.com/claude-code)