### PR TITLE
feat: add CHROME_DEVTOOLS_AXI_AUTO_CONNECT for Chrome 144+

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -229,10 +229,15 @@ function writeReadySignal(): void {
 export function buildTransportArgs(): string[] {
   const args = ["-y", "chrome-devtools-mcp@latest"];
 
+  const autoConnect = process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT === "1";
   const browserUrl = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
   const userDataDir = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
 
-  if (browserUrl) {
+  if (autoConnect) {
+    // Chrome 144+ built-in remote debugging via chrome://inspect/#remote-debugging.
+    // Connects to the user's running Chrome — no separate browser launched.
+    args.push("--autoConnect");
+  } else if (browserUrl) {
     // Connect to an existing Chrome instance — skip --isolated and --headless
     // since the user manages the browser lifecycle externally.
     args.push(`--browserUrl=${browserUrl}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,9 @@ flags[2]:
   --help, -v/-V/--version
 
 environment:
+  CHROME_DEVTOOLS_AXI_AUTO_CONNECT  Set to 1 to connect to the user's running Chrome (144+)
+                                    via chrome://inspect/#remote-debugging instead of launching
+                                    a new browser. Requires remote debugging enabled in Chrome.
   CHROME_DEVTOOLS_AXI_HEADED        Set to 1 to run Chrome in headed (visible) mode
   CHROME_DEVTOOLS_AXI_CHROME_ARGS   Whitespace-separated Chrome flags forwarded to the browser
                                     (no shell-style quoting; flags with spaces are not supported)

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -53,10 +53,12 @@ describe("buildTransportArgs", () => {
     savedEnv.CHROME_DEVTOOLS_AXI_CHROME_ARGS = process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     savedEnv.CHROME_DEVTOOLS_AXI_BROWSER_URL = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
     delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     delete process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
   });
 
   afterEach(() => {
@@ -64,6 +66,7 @@ describe("buildTransportArgs", () => {
     process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS = savedEnv.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = savedEnv.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
   });
 
   it("defaults to headless and isolated", () => {
@@ -139,6 +142,31 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).toContain("--browserUrl=http://127.0.0.1:9222");
     expect(args).not.toContain("--userDataDir=/path/to/.chrome-profile");
+  });
+
+  it("uses --autoConnect when CHROME_DEVTOOLS_AXI_AUTO_CONNECT=1", () => {
+    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = "1";
+    const args = buildTransportArgs();
+    expect(args).toContain("--autoConnect");
+    expect(args).not.toContain("--isolated");
+    expect(args).not.toContain("--headless");
+  });
+
+  it("--autoConnect takes precedence over --browserUrl and --userDataDir", () => {
+    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = "1";
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+    process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = "/path/to/.chrome-profile";
+    const args = buildTransportArgs();
+    expect(args).toContain("--autoConnect");
+    expect(args).not.toContain("--browserUrl=http://127.0.0.1:9222");
+    expect(args).not.toContain("--userDataDir=/path/to/.chrome-profile");
+  });
+
+  it("ignores AUTO_CONNECT when not set to '1'", () => {
+    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = "true";
+    const args = buildTransportArgs();
+    expect(args).not.toContain("--autoConnect");
+    expect(args).toContain("--isolated");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds support for Chrome 144+'s built-in remote debugging (`chrome://inspect/#remote-debugging`) via a new environment variable:

```bash
export CHROME_DEVTOOLS_AXI_AUTO_CONNECT=1
```

When set to `"1"`, the bridge passes `--autoConnect` to `chrome-devtools-mcp` instead of launching a new browser. This lets agents interact with the user's actual browser session — tabs, cookies, logins, extensions and all.

**Precedence:** `AUTO_CONNECT` > `BROWSER_URL` > `USER_DATA_DIR` > default (isolated headless).

## Changes

- **`src/bridge.ts`** — read `CHROME_DEVTOOLS_AXI_AUTO_CONNECT` and push `--autoConnect` when set
- **`src/cli.ts`** — document the new env var in `--help` output
- **`test/bridge.test.ts`** — 3 new tests (basic, precedence, strict `"1"` check)

## Motivation

`chrome-devtools-mcp` added `--autoConnect` for Chrome 144+ but there was no way to activate it through `chrome-devtools-axi`. Users had to fall back to `--browserUrl` with `--remote-debugging-port`, which requires restarting Chrome with special flags. With `--autoConnect`, Chrome's built-in remote debugging just works — no restart, no flags.

Related: #32