### PR TITLE
fix(ws): support websocket browser endpoints and validate ws headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 
 * add CHROME_DEVTOOLS_AXI_AUTO_CONNECT for Chrome 144+ autoConnect ([#33](https://github.com/kunchenguid/chrome-devtools-axi/issues/33)) ([542f176](https://github.com/kunchenguid/chrome-devtools-axi/commit/542f1762b8d63aacbfe19019c07c58758ab7517b))
+* support ws:// and wss:// browser URLs plus CHROME_DEVTOOLS_AXI_WS_HEADERS ([c8710d5](https://github.com/kunchenguid/chrome-devtools-axi/commit/c8710d5ca958e08985180e4e5cf48c7ba8db0530))
 
 ## [0.1.15](https://github.com/kunchenguid/chrome-devtools-axi/compare/chrome-devtools-axi-v0.1.14...chrome-devtools-axi-v0.1.15) (2026-04-11)
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ The bridge server port defaults to `9224`. Override it with an environment varia
 export CHROME_DEVTOOLS_AXI_PORT=9225
 ```
 
+Connect to an existing Chrome instance instead of launching one:
+
+```sh
+export CHROME_DEVTOOLS_AXI_BROWSER_URL=http://127.0.0.1:9222
+```
+
+`CHROME_DEVTOOLS_AXI_BROWSER_URL` accepts both `http://` or `https://` URLs and `ws://` or `wss://` endpoints:
+
+- `http(s)://` uses `--browserUrl` and fetches `/json/version` to discover the WebSocket URL.
+- `ws(s)://` uses `--wsEndpoint` directly.
+
+For authenticated `ws://` or `wss://` endpoints, pass JSON headers with `CHROME_DEVTOOLS_AXI_WS_HEADERS`:
+
+```sh
+export CHROME_DEVTOOLS_AXI_BROWSER_URL=wss://cluster.example/launch
+export CHROME_DEVTOOLS_AXI_WS_HEADERS='{"Authorization":"Bearer token"}'
+```
+
 State is stored in `~/.chrome-devtools-axi/`:
 
 | File         | Purpose                            |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,6 +1079,16 @@
         }
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axi-sdk-js": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.4.tgz",
@@ -1089,16 +1099,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/body-parser": {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -247,6 +247,21 @@ export function buildTransportArgs(): string[] {
       args.push(`--wsEndpoint=${browserUrl}`);
       const wsHeaders = process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
       if (wsHeaders) {
+        let parsedHeaders: unknown;
+        try {
+          parsedHeaders = JSON.parse(wsHeaders);
+        } catch {
+          throw new Error("CHROME_DEVTOOLS_AXI_WS_HEADERS must be valid JSON");
+        }
+        if (
+          parsedHeaders === null ||
+          typeof parsedHeaders !== "object" ||
+          Array.isArray(parsedHeaders)
+        ) {
+          throw new Error(
+            "CHROME_DEVTOOLS_AXI_WS_HEADERS must be a JSON object",
+          );
+        }
         args.push(`--wsHeaders=${wsHeaders}`);
       }
     } else {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -235,12 +235,23 @@ export function buildTransportArgs(): string[] {
 
   if (autoConnect) {
     // Chrome 144+ built-in remote debugging via chrome://inspect/#remote-debugging.
-    // Connects to the user's running Chrome — no separate browser launched.
+    // Connects to the user's running Chrome - no separate browser launched.
     args.push("--autoConnect");
   } else if (browserUrl) {
-    // Connect to an existing Chrome instance — skip --isolated and --headless
+    // Connect to an existing Chrome instance - skip --isolated and --headless
     // since the user manages the browser lifecycle externally.
-    args.push(`--browserUrl=${browserUrl}`);
+    // ws://|wss:// route to --wsEndpoint (direct WebSocket), http(s):// to --browserUrl
+    // (which fetches /json/version to discover the WebSocket URL).
+    const isWs = /^wss?:\/\//i.test(browserUrl);
+    if (isWs) {
+      args.push(`--wsEndpoint=${browserUrl}`);
+      const wsHeaders = process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
+      if (wsHeaders) {
+        args.push(`--wsHeaders=${wsHeaders}`);
+      }
+    } else {
+      args.push(`--browserUrl=${browserUrl}`);
+    }
   } else {
     if (userDataDir) {
       // Persistent profile — skip --isolated so the profile is preserved.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,8 +55,12 @@ environment:
                                     (no shell-style quoting; flags with spaces are not supported)
                                     e.g. "--enable-gpu --ignore-gpu-blocklist"
   CHROME_DEVTOOLS_AXI_PORT          Bridge server port (default: 9224)
-  CHROME_DEVTOOLS_AXI_BROWSER_URL   Connect to an existing Chrome instance instead of launching one
-                                    e.g. "http://127.0.0.1:9222"
+  CHROME_DEVTOOLS_AXI_BROWSER_URL   Connect to an existing Chrome instance instead of launching one.
+                                    http(s):// uses --browserUrl (fetches /json/version).
+                                    ws(s):// uses --wsEndpoint (direct WebSocket).
+                                    e.g. "http://127.0.0.1:9222" or "wss://cluster.example/launch"
+  CHROME_DEVTOOLS_AXI_WS_HEADERS    JSON headers for ws(s):// endpoints (only with BROWSER_URL=wss?://)
+                                    e.g. '{"Authorization":"Bearer token"}'
   CHROME_DEVTOOLS_AXI_USER_DATA_DIR Persistent Chrome profile directory (skips --isolated mode)
                                     e.g. "/path/to/.chrome-profile"
   CHROME_DEVTOOLS_AXI_DISABLE_HOOKS Set to 1 to skip auto-installing session hooks

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -203,6 +203,13 @@ describe("buildTransportArgs", () => {
     expect(() => buildTransportArgs()).toThrow("CHROME_DEVTOOLS_AXI_WS_HEADERS must be valid JSON");
   });
 
+  it("rejects ws headers JSON that is not an object", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "wss://our.cluster.io/launch";
+    process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = '["Authorization: Bearer token"]';
+
+    expect(() => buildTransportArgs()).toThrow("CHROME_DEVTOOLS_AXI_WS_HEADERS must be a JSON object");
+  });
+
   it("ignores --wsHeaders without a ws endpoint", () => {
     process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
     process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = '{"Authorization":"Bearer token"}';

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -196,6 +196,13 @@ describe("buildTransportArgs", () => {
     expect(args).toContain('--wsHeaders={"Authorization":"Bearer token"}');
   });
 
+  it("rejects malformed ws headers before launching the transport", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "wss://our.cluster.io/launch";
+    process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = "{";
+
+    expect(() => buildTransportArgs()).toThrow("CHROME_DEVTOOLS_AXI_WS_HEADERS must be valid JSON");
+  });
+
   it("ignores --wsHeaders without a ws endpoint", () => {
     process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
     process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = '{"Authorization":"Bearer token"}';

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -54,11 +54,13 @@ describe("buildTransportArgs", () => {
     savedEnv.CHROME_DEVTOOLS_AXI_BROWSER_URL = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
     savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+    savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS = process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
     delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     delete process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
     delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+    delete process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
   });
 
   afterEach(() => {
@@ -67,6 +69,7 @@ describe("buildTransportArgs", () => {
     process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = savedEnv.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
     process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+    process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS;
   });
 
   it("defaults to headless and isolated", () => {
@@ -167,6 +170,38 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).not.toContain("--autoConnect");
     expect(args).toContain("--isolated");
+  });
+
+  it("routes ws:// BROWSER_URL to --wsEndpoint", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "ws://127.0.0.1:9222/devtools/browser/abc123";
+    const args = buildTransportArgs();
+    expect(args).toContain("--wsEndpoint=ws://127.0.0.1:9222/devtools/browser/abc123");
+    expect(args).not.toContain("--browserUrl=ws://127.0.0.1:9222/devtools/browser/abc123");
+    expect(args).not.toContain("--isolated");
+    expect(args).not.toContain("--headless");
+  });
+
+  it("routes wss:// BROWSER_URL to --wsEndpoint", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "wss://our.cluster.io/launch";
+    const args = buildTransportArgs();
+    expect(args).toContain("--wsEndpoint=wss://our.cluster.io/launch");
+    expect(args).not.toContain("--browserUrl=wss://our.cluster.io/launch");
+  });
+
+  it("passes --wsHeaders when CHROME_DEVTOOLS_AXI_WS_HEADERS is set with ws endpoint", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "wss://our.cluster.io/launch";
+    process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = '{"Authorization":"Bearer token"}';
+    const args = buildTransportArgs();
+    expect(args).toContain("--wsEndpoint=wss://our.cluster.io/launch");
+    expect(args).toContain('--wsHeaders={"Authorization":"Bearer token"}');
+  });
+
+  it("ignores --wsHeaders without a ws endpoint", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+    process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = '{"Authorization":"Bearer token"}';
+    const args = buildTransportArgs();
+    expect(args).toContain("--browserUrl=http://127.0.0.1:9222");
+    expect(args.some((a) => a.startsWith("--wsHeaders="))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Allow `CHROME_DEVTOOLS_AXI_BROWSER_URL` to use `ws://` and `wss://` endpoints so the bridge can connect directly to existing browser WebSocket targets.
- Validate malformed `CHROME_DEVTOOLS_AXI_WS_HEADERS` earlier and add coverage for the new WebSocket connection path to avoid opaque startup failures.
- Document the new browser URL behavior and header configuration in `README.md`, and update the changelog to match the shipped WebSocket support.

## Risk Assessment

⚠️ Medium: The change is small and localized, but the new validation is still incomplete for malformed header payloads and can leave users with downstream runtime failures.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/bridge.ts:250` - `CHROME_DEVTOOLS_AXI_WS_HEADERS` is forwarded as `--wsHeaders=...` on the child process command line, which exposes bearer tokens in process listings and crash/debug tooling for the lifetime of the bridge. This new auth path should not ship without an explicit decision on that secret-handling tradeoff.
- ⚠️ `src/bridge.ts:248` - The new `CHROME_DEVTOOLS_AXI_WS_HEADERS` input is never validated before spawning `chrome-devtools-mcp`. A malformed JSON string will make the child fail to start, but this bridge hides child stderr and eventually reports only a generic 30s startup timeout, which is poor error handling for a newly introduced config surface.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/bridge.ts:256` - The new early validation only checks that `CHROME_DEVTOOLS_AXI_WS_HEADERS` parses to an object, so malformed header maps like `{&#34;Authorization&#34;:42}` or nested objects still pass through and fail later in `chrome-devtools-mcp` instead of producing the intended early config error. Validate each header value against the supported wire format here.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `README.md:181` - The configuration section does not document that `CHROME_DEVTOOLS_AXI_BROWSER_URL` now accepts both `http(s)://` and `ws(s)://` values, with different behavior (`--browserUrl` discovery vs direct `--wsEndpoint`). The README should be updated so users know how to connect to existing remote Chrome instances after this change.
- ⚠️ `README.md:181` - The README is missing documentation for the new `CHROME_DEVTOOLS_AXI_WS_HEADERS` environment variable. This change adds support for JSON WebSocket headers when `CHROME_DEVTOOLS_AXI_BROWSER_URL` points to a `ws(s)://` endpoint, so the configuration docs need an example and usage note.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `CHANGELOG.md:3` - The maintained changelog does not mention the new `ws://`/`wss://` handling for `CHROME_DEVTOOLS_AXI_BROWSER_URL` or the new `CHROME_DEVTOOLS_AXI_WS_HEADERS` environment variable added in this change range, so the release notes are stale relative to the shipped behavior.

**Round 3** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
