### PR TITLE
chore: bump axi-sdk-js to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@toon-format/toon": "^2.1.0",
-        "axi-sdk-js": "^0.1.4"
+        "axi-sdk-js": "^0.1.5"
       },
       "bin": {
         "chrome-devtools-axi": "dist/bin/chrome-devtools-axi.js"
@@ -1090,9 +1090,9 @@
       }
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.4.tgz",
-      "integrity": "sha512-FCIxUuNSixwuxdxqg5wgsnh8Rb19NVw/+drHb4j3LTXnqJtSIEqZgj/75469FxSd5JBDEpMmwq8eYUc4QrqTxQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.5.tgz",
+      "integrity": "sha512-IOmKj+Wuw1wz4wu1TP5unlnVR0aW/lzp+XIU1NQxvWSqoxsH5J9IgPdC3hOAo5UX/EYk7XQpzq9BJDU1k/Ekrg==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@toon-format/toon": "^2.1.0",
-    "axi-sdk-js": "^0.1.4"
+    "axi-sdk-js": "^0.1.5"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- Update the JavaScript dependency metadata to use `axi-sdk-js` 0.1.5.
- Refresh `package-lock.json` so the lockfile matches the new SDK version.

## Risk Assessment

✅ Low: The branch only updates axi-sdk-js from 0.1.4 to 0.1.5 in package metadata and lockfile, and the published diff is a narrow hook portability change with no substantiated regressions in the changed code.

## Testing

- Summary: Exercised the direct axi-sdk-js integration points first, then the full Vitest suite against the installed 0.1.5 package; all relevant tests passed.
- `PATH="$NVM_BIN:$PATH" npm test -- test/client.test.ts test/cli-runtime.test.ts test/hooks.test.ts`
- `PATH="$NVM_BIN:$PATH" npm test`
- Outcome: ✅ passed across 1 run (1m57s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `PATH="$NVM_BIN:$PATH" npm test -- test/client.test.ts test/cli-runtime.test.ts test/hooks.test.ts`
- `PATH="$NVM_BIN:$PATH" npm test`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
