### PR TITLE
feat: add CHROME_DEVTOOLS_AXI_MCP_PATH + BRIDGE_TIMEOUT_MS to unblock slow npx bootstrap

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -289,8 +289,35 @@ export function buildTransportArgs(): string[] {
   return args;
 }
 
+/**
+ * Resolve the command + args used to spawn the chrome-devtools-mcp transport.
+ *
+ * By default uses `npx -y chrome-devtools-mcp@latest`, which on some systems
+ * (npm registry roundtrip, slow link, large global cache) can take 30s+ just
+ * to bootstrap — racing the bridge's readiness deadline.
+ *
+ * When `CHROME_DEVTOOLS_AXI_MCP_PATH` is set, the bridge spawns
+ * `node $MCP_PATH` directly. That skips npx and starts in ~1-2s.
+ * Recommended setup:
+ *   npm install -g chrome-devtools-mcp
+ *   export CHROME_DEVTOOLS_AXI_MCP_PATH="$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+ */
+export function resolveTransportSpec(): { command: string; args: string[] } {
+  const mcpArgs = buildTransportArgs();
+  const mcpPath = process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+  if (mcpPath && mcpPath.length > 0) {
+    // Strip the npx prefix `["-y", "chrome-devtools-mcp@latest"]` — direct
+    // node spawn doesn't need it.
+    return {
+      command: process.execPath,
+      args: [mcpPath, ...mcpArgs.slice(2)],
+    };
+  }
+  return { command: "npx", args: mcpArgs };
+}
+
 function createTransport(): StdioClientTransport {
-  return new StdioClientTransport({ command: "npx", args: buildTransportArgs() });
+  return new StdioClientTransport(resolveTransportSpec());
 }
 
 function createBridgeClient(): Client {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -12,6 +12,7 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { execSync } from "node:child_process";
 import {
   createServer,
   type IncomingMessage,
@@ -290,22 +291,76 @@ export function buildTransportArgs(): string[] {
 }
 
 /**
+ * Probe interface for {@link detectGlobalMcpPath}. Defaults to real `node:fs`
+ * + `npm prefix -g`; injectable for tests.
+ */
+export interface McpPathProbe {
+  existsSync: (path: string) => boolean;
+  getNpmPrefix: () => string | null;
+}
+
+const DEFAULT_MCP_PATH_PROBE: McpPathProbe = {
+  existsSync: (path) => existsSync(path),
+  getNpmPrefix: () => {
+    try {
+      return execSync("npm prefix -g", {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return null;
+    }
+  },
+};
+
+/**
+ * Auto-detect a globally-installed chrome-devtools-mcp by probing
+ * `$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js`.
+ *
+ * Returns the resolved path on success, or null if npm is unavailable or the
+ * package isn't installed. Used as the auto-fallback in
+ * {@link resolveTransportSpec} when `CHROME_DEVTOOLS_AXI_MCP_PATH` isn't set.
+ */
+export function detectGlobalMcpPath(
+  probe: McpPathProbe = DEFAULT_MCP_PATH_PROBE,
+): string | null {
+  const prefix = probe.getNpmPrefix();
+  if (!prefix || prefix.length === 0) return null;
+  const candidate = join(
+    prefix,
+    "lib",
+    "node_modules",
+    "chrome-devtools-mcp",
+    "build",
+    "src",
+    "bin",
+    "chrome-devtools-mcp.js",
+  );
+  return probe.existsSync(candidate) ? candidate : null;
+}
+
+/**
  * Resolve the command + args used to spawn the chrome-devtools-mcp transport.
  *
- * By default uses `npx -y chrome-devtools-mcp@latest`, which on some systems
- * (npm registry roundtrip, slow link, large global cache) can take 30s+ just
- * to bootstrap — racing the bridge's readiness deadline.
- *
- * When `CHROME_DEVTOOLS_AXI_MCP_PATH` is set, the bridge spawns
- * `node $MCP_PATH` directly. That skips npx and starts in ~1-2s.
- * Recommended setup:
- *   npm install -g chrome-devtools-mcp
- *   export CHROME_DEVTOOLS_AXI_MCP_PATH="$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+ * Resolution order (most → least specific):
+ *   1. `CHROME_DEVTOOLS_AXI_MCP_PATH` env var — explicit override, always wins.
+ *   2. Auto-detect: probe a globally-installed `chrome-devtools-mcp` via
+ *      `$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js`.
+ *      If found, spawn `node <path>` directly — starts in ~1-2s vs. the
+ *      30s+ npx-bootstrap path.
+ *   3. Fall back to `npx -y chrome-devtools-mcp@latest`. On systems with a
+ *      slow link or large global cache this can race the bridge's readiness
+ *      deadline; install the package globally to skip it:
+ *        npm install -g chrome-devtools-mcp
  */
-export function resolveTransportSpec(): { command: string; args: string[] } {
+export function resolveTransportSpec(
+  probe: McpPathProbe = DEFAULT_MCP_PATH_PROBE,
+): { command: string; args: string[] } {
   const mcpArgs = buildTransportArgs();
-  const mcpPath = process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
-  if (mcpPath && mcpPath.length > 0) {
+  const explicit = process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+  const mcpPath =
+    explicit && explicit.length > 0 ? explicit : detectGlobalMcpPath(probe);
+  if (mcpPath) {
     // Strip the npx prefix `["-y", "chrome-devtools-mcp@latest"]` — direct
     // node spawn doesn't need it.
     return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,14 @@ environment:
                                     e.g. '{"Authorization":"Bearer token"}'
   CHROME_DEVTOOLS_AXI_USER_DATA_DIR Persistent Chrome profile directory (skips --isolated mode)
                                     e.g. "/path/to/.chrome-profile"
+  CHROME_DEVTOOLS_AXI_MCP_PATH      Absolute path to a chrome-devtools-mcp script. When set, the
+                                    bridge spawns 'node \$MCP_PATH' directly instead of
+                                    'npx -y chrome-devtools-mcp@latest'. Avoids ~30s npx bootstrap
+                                    on slow/cold systems. Recommended:
+                                      npm install -g chrome-devtools-mcp
+                                      export CHROME_DEVTOOLS_AXI_MCP_PATH="\$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+  CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS
+                                    Bridge readiness deadline in ms (default: 30000, min: 1000)
   CHROME_DEVTOOLS_AXI_DISABLE_HOOKS Set to 1 to skip auto-installing session hooks
 
 gpu:

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,23 @@ import { resolveBridgeScript } from "./bridge.js";
 const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
 const PID_FILE = join(STATE_DIR, "bridge.pid");
 const DEFAULT_PORT = 9224;
+const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
+const MIN_BRIDGE_TIMEOUT_MS = 1_000;
+
+/**
+ * Resolve the bridge readiness deadline in milliseconds.
+ *
+ * Honors `CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS` for systems where npx
+ * bootstrap or Chrome launch is slow (>30s). Values below 1s are clamped to
+ * 1s to avoid pathological retries.
+ */
+export function resolveBridgeTimeoutMs(): number {
+  const raw = process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+  if (!raw) return DEFAULT_BRIDGE_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_BRIDGE_TIMEOUT_MS;
+  return Math.max(parsed, MIN_BRIDGE_TIMEOUT_MS);
+}
 
 export type ErrorCode =
   | "BRIDGE_NOT_READY"
@@ -181,8 +198,9 @@ export async function ensureBridge(): Promise<number> {
   );
   child.unref();
 
-  // Poll for health (max 30s — Chrome launch can be slow)
-  const deadline = Date.now() + 30_000;
+  // Poll for health — Chrome launch + npx bootstrap can be slow
+  const timeoutMs = resolveBridgeTimeoutMs();
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await checkBridgeHealth(port)) {
       return port;
@@ -190,9 +208,25 @@ export async function ensureBridge(): Promise<number> {
     await sleep(500);
   }
 
-  throw new CdpError("Bridge failed to start within 30s", "BRIDGE_NOT_READY", [
+  const seconds = Math.round(timeoutMs / 1000);
+  const usingNpx = !process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+  const suggestions = [
     "Check that chrome-devtools-mcp is installed: npx chrome-devtools-mcp@latest --help",
-  ]);
+  ];
+  if (usingNpx) {
+    suggestions.push(
+      "If `npx -y chrome-devtools-mcp@latest` is slow on this machine, install mcp globally and set:",
+      "  export CHROME_DEVTOOLS_AXI_MCP_PATH=\"$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js\"",
+    );
+  }
+  suggestions.push(
+    "Or extend the deadline: export CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS=60000",
+  );
+  throw new CdpError(
+    `Bridge failed to start within ${seconds}s`,
+    "BRIDGE_NOT_READY",
+    suggestions,
+  );
 }
 
 /**

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import {
   buildTransportArgs,
+  detectGlobalMcpPath,
   extractToolText,
   getErrorMessage,
   isBridgeClientConnected,
@@ -250,8 +251,14 @@ describe("resolveTransportSpec", () => {
     }
   });
 
-  it("defaults to spawning via npx when CHROME_DEVTOOLS_AXI_MCP_PATH is unset", () => {
-    const spec = resolveTransportSpec();
+  it("defaults to spawning via npx when MCP_PATH is unset and auto-detection finds nothing", () => {
+    // Inject a probe that simulates "no global chrome-devtools-mcp" so the
+    // test outcome doesn't depend on the host machine's npm install state.
+    const probe = {
+      existsSync: () => false,
+      getNpmPrefix: () => "/usr",
+    };
+    const spec = resolveTransportSpec(probe);
     expect(spec.command).toBe("npx");
     expect(spec.args[0]).toBe("-y");
     expect(spec.args[1]).toBe("chrome-devtools-mcp@latest");
@@ -285,8 +292,101 @@ describe("resolveTransportSpec", () => {
 
   it("treats an empty MCP_PATH as unset", () => {
     process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "";
-    const spec = resolveTransportSpec();
+    const probe = {
+      existsSync: () => false,
+      getNpmPrefix: () => null,
+    };
+    const spec = resolveTransportSpec(probe);
     expect(spec.command).toBe("npx");
+  });
+
+  it("auto-detects a globally-installed chrome-devtools-mcp when MCP_PATH is unset", () => {
+    const probe = {
+      existsSync: (path: string) =>
+        path ===
+        "/usr/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js",
+      getNpmPrefix: () => "/usr",
+    };
+    const spec = resolveTransportSpec(probe);
+    expect(spec.command).toBe(process.execPath);
+    expect(spec.args[0]).toBe(
+      "/usr/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js",
+    );
+    expect(spec.args).not.toContain("-y");
+    expect(spec.args).not.toContain("chrome-devtools-mcp@latest");
+    expect(spec.args).toContain("--isolated");
+  });
+
+  it("falls back to npx when auto-detection finds nothing", () => {
+    const probe = {
+      existsSync: () => false,
+      getNpmPrefix: () => "/usr",
+    };
+    const spec = resolveTransportSpec(probe);
+    expect(spec.command).toBe("npx");
+    expect(spec.args[0]).toBe("-y");
+  });
+
+  it("falls back to npx when npm prefix is unavailable", () => {
+    const probe = {
+      existsSync: () => true, // would match anything if asked
+      getNpmPrefix: () => null,
+    };
+    const spec = resolveTransportSpec(probe);
+    expect(spec.command).toBe("npx");
+  });
+
+  it("explicit MCP_PATH always wins over auto-detection", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "/explicit/override.js";
+    const probe = {
+      existsSync: () => true,
+      getNpmPrefix: () => "/usr",
+    };
+    const spec = resolveTransportSpec(probe);
+    expect(spec.command).toBe(process.execPath);
+    expect(spec.args[0]).toBe("/explicit/override.js");
+  });
+});
+
+describe("detectGlobalMcpPath", () => {
+  it("returns the canonical MCP path when npm prefix + the file both exist", () => {
+    const probe = {
+      existsSync: (path: string) =>
+        path ===
+        "/opt/npm/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js",
+      getNpmPrefix: () => "/opt/npm",
+    };
+
+    expect(detectGlobalMcpPath(probe)).toBe(
+      "/opt/npm/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js",
+    );
+  });
+
+  it("returns null when the file is missing", () => {
+    const probe = {
+      existsSync: () => false,
+      getNpmPrefix: () => "/opt/npm",
+    };
+
+    expect(detectGlobalMcpPath(probe)).toBeNull();
+  });
+
+  it("returns null when npm prefix is null (npm not installed)", () => {
+    const probe = {
+      existsSync: () => true,
+      getNpmPrefix: () => null,
+    };
+
+    expect(detectGlobalMcpPath(probe)).toBeNull();
+  });
+
+  it("returns null when npm prefix is the empty string", () => {
+    const probe = {
+      existsSync: () => true,
+      getNpmPrefix: () => "",
+    };
+
+    expect(detectGlobalMcpPath(probe)).toBeNull();
   });
 });
 

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { buildTransportArgs, extractToolText, getErrorMessage, isBridgeClientConnected, parseBridgeCallPayload, resolveBridgeScript } from "../src/bridge.js";
+import {
+  buildTransportArgs,
+  extractToolText,
+  getErrorMessage,
+  isBridgeClientConnected,
+  parseBridgeCallPayload,
+  resolveBridgeScript,
+  resolveTransportSpec,
+} from "../src/bridge.js";
 
 describe("extractToolText", () => {
   it("joins text blocks and ignores non-text content", () => {
@@ -216,6 +224,69 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).toContain("--browserUrl=http://127.0.0.1:9222");
     expect(args.some((a) => a.startsWith("--wsHeaders="))).toBe(false);
+  });
+});
+
+describe("resolveTransportSpec", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.CHROME_DEVTOOLS_AXI_MCP_PATH = process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+    savedEnv.CHROME_DEVTOOLS_AXI_HEADED = process.env.CHROME_DEVTOOLS_AXI_HEADED;
+    savedEnv.CHROME_DEVTOOLS_AXI_BROWSER_URL = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+    savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+    delete process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+    delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
+    delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+    delete process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("defaults to spawning via npx when CHROME_DEVTOOLS_AXI_MCP_PATH is unset", () => {
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe("npx");
+    expect(spec.args[0]).toBe("-y");
+    expect(spec.args[1]).toBe("chrome-devtools-mcp@latest");
+    // Default mcp args follow
+    expect(spec.args).toContain("--isolated");
+    expect(spec.args).toContain("--headless");
+  });
+
+  it("spawns node directly when CHROME_DEVTOOLS_AXI_MCP_PATH is set", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "/opt/mcp/build/src/bin/chrome-devtools-mcp.js";
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe(process.execPath);
+    expect(spec.args[0]).toBe("/opt/mcp/build/src/bin/chrome-devtools-mcp.js");
+    // Strips the npx-only `-y, chrome-devtools-mcp@latest` prefix
+    expect(spec.args).not.toContain("-y");
+    expect(spec.args).not.toContain("chrome-devtools-mcp@latest");
+    // Preserves the mcp-specific args
+    expect(spec.args).toContain("--isolated");
+    expect(spec.args).toContain("--headless");
+  });
+
+  it("preserves --browserUrl when MCP_PATH and BROWSER_URL are both set", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "/opt/mcp.js";
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe(process.execPath);
+    expect(spec.args[0]).toBe("/opt/mcp.js");
+    expect(spec.args).toContain("--browserUrl=http://127.0.0.1:9222");
+    expect(spec.args).not.toContain("--isolated");
+  });
+
+  it("treats an empty MCP_PATH as unset", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "";
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe("npx");
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { AxiError } from "axi-sdk-js";
-import { CdpError, mapErrorMessage } from "../src/client.js";
+import {
+  CdpError,
+  mapErrorMessage,
+  resolveBridgeTimeoutMs,
+} from "../src/client.js";
 
 describe("CdpError", () => {
   it("uses the shared axi-sdk-js error contract", () => {
@@ -31,5 +35,48 @@ describe("mapErrorMessage", () => {
 
     expect(error.code).toBe("BROWSER_ERROR");
     expect(error.message).toBe("Page crashed");
+  });
+});
+
+describe("resolveBridgeTimeoutMs", () => {
+  let savedTimeout: string | undefined;
+
+  beforeEach(() => {
+    savedTimeout = process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+    delete process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    if (savedTimeout === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = savedTimeout;
+    }
+  });
+
+  it("defaults to 30s when env var is unset", () => {
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
+  });
+
+  it("honors a numeric env value", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "60000";
+    expect(resolveBridgeTimeoutMs()).toBe(60_000);
+  });
+
+  it("clamps tiny values to a 1s floor (avoids pathological retries)", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "10";
+    expect(resolveBridgeTimeoutMs()).toBe(1_000);
+  });
+
+  it("falls back to default when value is non-numeric", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "soon";
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
+  });
+
+  it("falls back to default when value is zero or negative", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "0";
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "-100";
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
   });
 });


### PR DESCRIPTION
## Summary

Adds two new env vars that together unblock bridge cold-start on systems where `npx -y chrome-devtools-mcp@latest` is slow:

- **`CHROME_DEVTOOLS_AXI_MCP_PATH`** — absolute path to a chrome-devtools-mcp script. When set, the bridge spawns `node $MCP_PATH` directly instead of going through npx. Skips the 30s+ npx bootstrap.
- **`CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS`** — bridge readiness deadline in milliseconds (default 30000, min 1000). Lets users extend the timeout on slow machines without a code change.

When neither is set, behavior is **identical to before** (npx, 30s deadline). Backward compatible.

## Motivation

On some machines `npx -y chrome-devtools-mcp@latest --help` takes 30+ seconds — measured here:

```
$ time npx -y chrome-devtools-mcp@latest --help
... 30.12s total

$ time npx --prefer-offline -y chrome-devtools-mcp@latest --help
... 29.77s total

$ time npx --offline chrome-devtools-mcp@latest --help
... 30.12s total

$ time node /path/to/global/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js --browserUrl http://...
... 1.6s total
```

Even with `--offline` and `--prefer-offline`, npx burns ~30s on cold node startup + npm package-resolution overhead before chrome-devtools-mcp ever runs. That races the bridge's hardcoded 30s readiness deadline (`client.ts` `ensureBridge`) and yields `BRIDGE_NOT_READY` with no useful diagnostic — the surface error blames a missing mcp install when mcp is actually fine.

This is reproducible on at least: Ubuntu 25.10, Node 22.x, npm 10.x, after a fresh dev clone. I suspect any system with sufficient npm registry latency or a large global cache will hit it.

Direct-node spawn of the same binary completes in ~1.6s, eliminating the race.

## Changes

- **`src/bridge.ts`** — extracts `resolveTransportSpec()` returning `{command, args}`. Reads `CHROME_DEVTOOLS_AXI_MCP_PATH` to choose between `node $MCP_PATH` and `npx -y chrome-devtools-mcp@latest`. `buildTransportArgs()` is unchanged so existing tests stay green.
- **`src/client.ts`** — adds `resolveBridgeTimeoutMs()` honoring `CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS` (default 30000, min 1000, falls back to default on invalid input). The error message now points at the npx-skip workaround when the timeout fires and MCP_PATH is unset.
- **`src/cli.ts`** — documents both env vars in `TOP_HELP`.
- **`test/bridge.test.ts`** — 4 new tests for `resolveTransportSpec()` (default npx; direct-node when MCP_PATH set; preserves --browserUrl; treats empty string as unset).
- **`test/client.test.ts`** — 5 new tests for `resolveBridgeTimeoutMs()` (default; numeric override; clamps tiny values; falls back on non-numeric / zero / negative).

Stat: `5 files changed, 195 insertions(+), 8 deletions(-)`.

## Test plan

- [x] All 213 existing tests pass
- [x] 9 new tests pass (total 222)
- [x] End-to-end smoke: `CHROME_DEVTOOLS_AXI_MCP_PATH=$path CHROME_DEVTOOLS_AXI_BROWSER_URL=http://127.0.0.1:15106 chrome-devtools-axi open https://example.com` — full cold start in 13.2s (was 30s+ failure with default npx path on the same machine)
- [x] Backward compat: with neither env var set, transport is unchanged

## Recommended setup (for users hitting the slow path)

```bash
npm install -g chrome-devtools-mcp
export CHROME_DEVTOOLS_AXI_MCP_PATH="$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
```

## Notes

- This is **not** a fix for #43 (stale CDP after attached-target restart) — that's a different bug in MCP client lifecycle. Filing this separately to keep PRs focused.
- I noticed PR #30 added `BROWSER_URL` and `USER_DATA_DIR` env vars; this follows the same env-var pattern.