### PR TITLE
feat: add CHROME_DEVTOOLS_AXI_SESSION for concurrent bridge isolation

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -19,15 +19,17 @@ import {
   type ServerResponse,
 } from "node:http";
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import {
+  defaultUserDataDirForSession,
+  resolveSessionName,
+  resolveSessionPidFile,
+  resolveSessionPort,
+} from "./sessions.js";
 
-const DEFAULT_PORT = Number.parseInt(
-  process.env.CHROME_DEVTOOLS_AXI_PORT ?? "9224",
-  10,
-);
-const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
-const PID_FILE = join(STATE_DIR, "bridge.pid");
+// NOTE: do not capture port at module load — it depends on env vars
+// (CHROME_DEVTOOLS_AXI_PORT, CHROME_DEVTOOLS_AXI_SESSION) that may be set
+// after import. runBridge() resolves it lazily on each call.
 
 export interface BridgeContentBlock {
   type: string;
@@ -65,13 +67,14 @@ export async function isBridgeClientConnected(
 }
 
 function writePidFile(port: number): void {
-  mkdirSync(STATE_DIR, { recursive: true });
-  writeFileSync(PID_FILE, JSON.stringify({ pid: process.pid, port }));
+  const pidFile = resolveSessionPidFile();
+  mkdirSync(dirname(pidFile), { recursive: true });
+  writeFileSync(pidFile, JSON.stringify({ pid: process.pid, port }));
 }
 
 function removePidFile(): void {
   try {
-    unlinkSync(PID_FILE);
+    unlinkSync(resolveSessionPidFile());
   } catch {
     // Already gone — fine
   }
@@ -268,9 +271,18 @@ export function buildTransportArgs(): string[] {
       args.push(`--browserUrl=${browserUrl}`);
     }
   } else {
+    // Resolution order for the local-launch profile:
+    //   1. CHROME_DEVTOOLS_AXI_USER_DATA_DIR (explicit override, any session)
+    //   2. Auto-derived per-session profile (named sessions only — keeps
+    //      auth state isolated by session)
+    //   3. --isolated (default session, no override → fresh profile each run)
+    const sessionDefaultProfile = defaultUserDataDirForSession(
+      resolveSessionName(),
+    );
     if (userDataDir) {
-      // Persistent profile — skip --isolated so the profile is preserved.
       args.push(`--userDataDir=${userDataDir}`);
+    } else if (sessionDefaultProfile) {
+      args.push(`--userDataDir=${sessionDefaultProfile}`);
     } else {
       args.push("--isolated");
     }
@@ -336,7 +348,7 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
-export async function runBridge(port = DEFAULT_PORT): Promise<void> {
+export async function runBridge(port = resolveSessionPort()): Promise<void> {
   const transport = createTransport();
   const client = createBridgeClient();
   await client.connect(transport);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -289,8 +289,35 @@ export function buildTransportArgs(): string[] {
   return args;
 }
 
+/**
+ * Resolve the command + args used to spawn the chrome-devtools-mcp transport.
+ *
+ * By default uses `npx -y chrome-devtools-mcp@latest`, which on some systems
+ * (npm registry roundtrip, slow link, large global cache) can take 30s+ just
+ * to bootstrap — racing the bridge's readiness deadline.
+ *
+ * When `CHROME_DEVTOOLS_AXI_MCP_PATH` is set, the bridge spawns
+ * `node $MCP_PATH` directly. That skips npx and starts in ~1-2s.
+ * Recommended setup:
+ *   npm install -g chrome-devtools-mcp
+ *   export CHROME_DEVTOOLS_AXI_MCP_PATH="$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+ */
+export function resolveTransportSpec(): { command: string; args: string[] } {
+  const mcpArgs = buildTransportArgs();
+  const mcpPath = process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+  if (mcpPath && mcpPath.length > 0) {
+    // Strip the npx prefix `["-y", "chrome-devtools-mcp@latest"]` — direct
+    // node spawn doesn't need it.
+    return {
+      command: process.execPath,
+      args: [mcpPath, ...mcpArgs.slice(2)],
+    };
+  }
+  return { command: "npx", args: mcpArgs };
+}
+
 function createTransport(): StdioClientTransport {
-  return new StdioClientTransport({ command: "npx", args: buildTransportArgs() });
+  return new StdioClientTransport(resolveTransportSpec());
 }
 
 function createBridgeClient(): Client {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,14 @@ environment:
                                     e.g. '{"Authorization":"Bearer token"}'
   CHROME_DEVTOOLS_AXI_USER_DATA_DIR Persistent Chrome profile directory (skips --isolated mode)
                                     e.g. "/path/to/.chrome-profile"
+  CHROME_DEVTOOLS_AXI_MCP_PATH      Absolute path to a chrome-devtools-mcp script. When set, the
+                                    bridge spawns 'node \$MCP_PATH' directly instead of
+                                    'npx -y chrome-devtools-mcp@latest'. Avoids ~30s npx bootstrap
+                                    on slow/cold systems. Recommended:
+                                      npm install -g chrome-devtools-mcp
+                                      export CHROME_DEVTOOLS_AXI_MCP_PATH="\$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+  CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS
+                                    Bridge readiness deadline in ms (default: 30000, min: 1000)
   CHROME_DEVTOOLS_AXI_DISABLE_HOOKS Set to 1 to skip auto-installing session hooks
 
 gpu:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,14 @@ environment:
                                       export CHROME_DEVTOOLS_AXI_MCP_PATH="\$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
   CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS
                                     Bridge readiness deadline in ms (default: 30000, min: 1000)
+  CHROME_DEVTOOLS_AXI_SESSION       Named session for concurrent isolation. Each session gets its
+                                    own bridge process, port (auto-allocated from name hash),
+                                    PID file, and persistent profile directory. Multiple
+                                    sessions can run at once without colliding.
+                                    Defaults to "default" (port 9224, --isolated profile).
+                                    e.g. CHROME_DEVTOOLS_AXI_SESSION=widecorp-ceo
+                                         CHROME_DEVTOOLS_AXI_SESSION=deb-admin
+                                    Use CHROME_DEVTOOLS_AXI_PORT to override the auto port.
   CHROME_DEVTOOLS_AXI_DISABLE_HOOKS Set to 1 to skip auto-installing session hooks
 
 gpu:

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,23 @@ import { resolveBridgeScript } from "./bridge.js";
 const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
 const PID_FILE = join(STATE_DIR, "bridge.pid");
 const DEFAULT_PORT = 9224;
+const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
+const MIN_BRIDGE_TIMEOUT_MS = 1_000;
+
+/**
+ * Resolve the bridge readiness deadline in milliseconds.
+ *
+ * Honors `CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS` for systems where npx
+ * bootstrap or Chrome launch is slow (>30s). Values below 1s are clamped to
+ * 1s to avoid pathological retries.
+ */
+export function resolveBridgeTimeoutMs(): number {
+  const raw = process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+  if (!raw) return DEFAULT_BRIDGE_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_BRIDGE_TIMEOUT_MS;
+  return Math.max(parsed, MIN_BRIDGE_TIMEOUT_MS);
+}
 
 export type ErrorCode =
   | "BRIDGE_NOT_READY"
@@ -181,8 +198,9 @@ export async function ensureBridge(): Promise<number> {
   );
   child.unref();
 
-  // Poll for health (max 30s — Chrome launch can be slow)
-  const deadline = Date.now() + 30_000;
+  // Poll for health — Chrome launch + npx bootstrap can be slow
+  const timeoutMs = resolveBridgeTimeoutMs();
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await checkBridgeHealth(port)) {
       return port;
@@ -190,9 +208,25 @@ export async function ensureBridge(): Promise<number> {
     await sleep(500);
   }
 
-  throw new CdpError("Bridge failed to start within 30s", "BRIDGE_NOT_READY", [
+  const seconds = Math.round(timeoutMs / 1000);
+  const usingNpx = !process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+  const suggestions = [
     "Check that chrome-devtools-mcp is installed: npx chrome-devtools-mcp@latest --help",
-  ]);
+  ];
+  if (usingNpx) {
+    suggestions.push(
+      "If `npx -y chrome-devtools-mcp@latest` is slow on this machine, install mcp globally and set:",
+      "  export CHROME_DEVTOOLS_AXI_MCP_PATH=\"$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js\"",
+    );
+  }
+  suggestions.push(
+    "Or extend the deadline: export CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS=60000",
+  );
+  throw new CdpError(
+    `Bridge failed to start within ${seconds}s`,
+    "BRIDGE_NOT_READY",
+    suggestions,
+  );
 }
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,15 +4,16 @@
 
 import { spawn } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
 import { request } from "node:http";
 import { AxiError } from "axi-sdk-js";
 import { resolveBridgeScript } from "./bridge.js";
+import {
+  resolveSessionName,
+  resolveSessionPidFile,
+  resolveSessionPort,
+  validateSessionName,
+} from "./sessions.js";
 
-const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
-const PID_FILE = join(STATE_DIR, "bridge.pid");
-const DEFAULT_PORT = 9224;
 const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
 const MIN_BRIDGE_TIMEOUT_MS = 1_000;
 
@@ -55,10 +56,10 @@ interface PidInfo {
   port: number;
 }
 
-function readPidFile(): PidInfo | null {
+function readPidFile(pidFile: string = resolveSessionPidFile()): PidInfo | null {
   try {
-    if (!existsSync(PID_FILE)) return null;
-    const data = JSON.parse(readFileSync(PID_FILE, "utf-8"));
+    if (!existsSync(pidFile)) return null;
+    const data = JSON.parse(readFileSync(pidFile, "utf-8"));
     if (typeof data.pid === "number" && typeof data.port === "number") {
       return data as PidInfo;
     }
@@ -158,15 +159,18 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Ensure the bridge is running, starting it if needed. Returns the port.
+ *
+ * Each named session (CHROME_DEVTOOLS_AXI_SESSION) has its own PID file,
+ * port, and bridge process — so multiple sessions can run concurrently.
  */
 export async function ensureBridge(): Promise<number> {
-  const port = parseInt(
-    process.env.CHROME_DEVTOOLS_AXI_PORT ?? String(DEFAULT_PORT),
-    10,
-  );
+  const sessionName = resolveSessionName();
+  validateSessionName(sessionName);
+  const port = resolveSessionPort(sessionName);
+  const pidFile = resolveSessionPidFile(sessionName);
 
   // Check existing bridge via PID file
-  const pidInfo = readPidFile();
+  const pidInfo = readPidFile(pidFile);
   if (pidInfo && isProcessAlive(pidInfo.pid)) {
     if (await checkBridgeHealth(pidInfo.port)) {
       return pidInfo.port;
@@ -192,7 +196,11 @@ export async function ensureBridge(): Promise<number> {
     runner === "tsx" ? ["tsx", script] : [script],
     {
       stdio: "ignore",
-      env: { ...process.env, CHROME_DEVTOOLS_AXI_PORT: String(port) },
+      env: {
+        ...process.env,
+        CHROME_DEVTOOLS_AXI_PORT: String(port),
+        CHROME_DEVTOOLS_AXI_SESSION: sessionName,
+      },
       detached: true,
     },
   );

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,0 +1,115 @@
+/**
+ * Named sessions — per-session bridge isolation.
+ *
+ * When `CHROME_DEVTOOLS_AXI_SESSION` is set to a non-default name, the bridge
+ * binds its PID file, default user data dir, and (auto-allocated) port to
+ * that name. This lets multiple bridges run concurrently — one per
+ * worktree, one per test user, one per Chrome profile, etc. — without
+ * stepping on each other.
+ *
+ *   CHROME_DEVTOOLS_AXI_SESSION=widecorp-ceo chrome-devtools-axi open ...
+ *   CHROME_DEVTOOLS_AXI_SESSION=deb-admin     chrome-devtools-axi open ...
+ *
+ * Each session above gets its own bridge process, port, and persistent
+ * profile dir. They do not share Chrome state.
+ *
+ * Env var precedence over auto-derived defaults:
+ *   port      — CHROME_DEVTOOLS_AXI_PORT > deterministic hash of session name
+ *   profile   — CHROME_DEVTOOLS_AXI_USER_DATA_DIR > session-default dir
+ *   pid file  — always derived from session name (no override needed)
+ *
+ * The default session name is "default", which preserves prior behavior:
+ * port 9224, ~/.chrome-devtools-axi/bridge.pid, no auto-profile.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export const DEFAULT_SESSION_NAME = "default";
+export const DEFAULT_BASE_PORT = 9224;
+
+const SESSION_PORT_RANGE = 100; // 9225..9324 reserved for named sessions
+const STATE_DIR_NAME = ".chrome-devtools-axi";
+const PROFILE_CACHE_DIR = ".cache/chrome-devtools-axi/sessions";
+
+/**
+ * Resolve the active session name from env. Returns DEFAULT_SESSION_NAME when
+ * unset, empty, or explicitly "default".
+ */
+export function resolveSessionName(): string {
+  const raw = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+  if (!raw) return DEFAULT_SESSION_NAME;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return DEFAULT_SESSION_NAME;
+  return trimmed;
+}
+
+/**
+ * Throw if the session name contains characters that aren't safe for filesystem
+ * paths or env var keys. We allow lowercase, digits, dash, underscore, dot.
+ */
+export function validateSessionName(name: string): void {
+  if (name === DEFAULT_SESSION_NAME) return;
+  if (!/^[a-z0-9._-]{1,64}$/i.test(name)) {
+    throw new Error(
+      `Invalid session name: "${name}". Use 1-64 chars from [a-zA-Z0-9._-]`,
+    );
+  }
+}
+
+/**
+ * Deterministic port allocation for a session name. Uses a simple FNV-1a-ish
+ * hash mod SESSION_PORT_RANGE, offset from DEFAULT_BASE_PORT+1 so the default
+ * session keeps port 9224.
+ *
+ * Two different names can collide on a port — that's a concurrency limit, not
+ * a correctness bug. If you hit a collision, set CHROME_DEVTOOLS_AXI_PORT.
+ */
+export function defaultPortForSession(name: string): number {
+  if (name === DEFAULT_SESSION_NAME) return DEFAULT_BASE_PORT;
+  let hash = 2166136261;
+  for (let i = 0; i < name.length; i++) {
+    hash ^= name.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  // Map signed int → [0, SESSION_PORT_RANGE)
+  const offset = (Math.abs(hash) % SESSION_PORT_RANGE) + 1;
+  return DEFAULT_BASE_PORT + offset;
+}
+
+/**
+ * Resolve the bridge port: explicit env var wins; otherwise session-derived.
+ */
+export function resolveSessionPort(name: string = resolveSessionName()): number {
+  const explicit = process.env.CHROME_DEVTOOLS_AXI_PORT;
+  if (explicit) {
+    const parsed = Number.parseInt(explicit, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return defaultPortForSession(name);
+}
+
+/**
+ * PID file path for a session. The default session keeps the legacy path
+ * (`~/.chrome-devtools-axi/bridge.pid`) so existing tools and prior versions
+ * don't get orphaned.
+ */
+export function resolveSessionPidFile(
+  name: string = resolveSessionName(),
+): string {
+  if (name === DEFAULT_SESSION_NAME) {
+    return join(homedir(), STATE_DIR_NAME, "bridge.pid");
+  }
+  return join(homedir(), STATE_DIR_NAME, "sessions", name, "bridge.pid");
+}
+
+/**
+ * Default user-data-dir for a session, used when neither
+ * CHROME_DEVTOOLS_AXI_USER_DATA_DIR nor BROWSER_URL nor AUTO_CONNECT is set
+ * AND we're on a non-default session. The default session retains
+ * --isolated behavior unless the user opts in via USER_DATA_DIR.
+ */
+export function defaultUserDataDirForSession(name: string): string | null {
+  if (name === DEFAULT_SESSION_NAME) return null;
+  return join(homedir(), PROFILE_CACHE_DIR, name);
+}

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -63,21 +63,21 @@ describe("buildTransportArgs", () => {
     savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
     savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS = process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
+    savedEnv.CHROME_DEVTOOLS_AXI_SESSION = process.env.CHROME_DEVTOOLS_AXI_SESSION;
     delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
     delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     delete process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
     delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     delete process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
+    delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
   });
 
   afterEach(() => {
-    process.env.CHROME_DEVTOOLS_AXI_HEADED = savedEnv.CHROME_DEVTOOLS_AXI_HEADED;
-    process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS = savedEnv.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
-    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = savedEnv.CHROME_DEVTOOLS_AXI_BROWSER_URL;
-    process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
-    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
-    process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS = savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS;
+    for (const key of Object.keys(savedEnv)) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
   });
 
   it("defaults to headless and isolated", () => {
@@ -224,6 +224,31 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).toContain("--browserUrl=http://127.0.0.1:9222");
     expect(args.some((a) => a.startsWith("--wsHeaders="))).toBe(false);
+  });
+
+  it("uses --isolated for the default session when no profile env is set", () => {
+    // CHROME_DEVTOOLS_AXI_SESSION unset by beforeEach
+    const args = buildTransportArgs();
+    expect(args).toContain("--isolated");
+    expect(args.some((a) => a.startsWith("--userDataDir="))).toBe(false);
+  });
+
+  it("auto-derives a per-session profile dir for named sessions", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "widecorp-ceo";
+    const args = buildTransportArgs();
+    expect(args).not.toContain("--isolated");
+    expect(args.some((a) =>
+      a.startsWith("--userDataDir=") &&
+      a.includes("/sessions/widecorp-ceo")
+    )).toBe(true);
+  });
+
+  it("respects explicit USER_DATA_DIR over the session default", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "widecorp-ceo";
+    process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = "/explicit/profile/dir";
+    const args = buildTransportArgs();
+    expect(args).toContain("--userDataDir=/explicit/profile/dir");
+    expect(args.some((a) => a.includes("/sessions/widecorp-ceo"))).toBe(false);
   });
 });
 

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { buildTransportArgs, extractToolText, getErrorMessage, isBridgeClientConnected, parseBridgeCallPayload, resolveBridgeScript } from "../src/bridge.js";
+import {
+  buildTransportArgs,
+  extractToolText,
+  getErrorMessage,
+  isBridgeClientConnected,
+  parseBridgeCallPayload,
+  resolveBridgeScript,
+  resolveTransportSpec,
+} from "../src/bridge.js";
 
 describe("extractToolText", () => {
   it("joins text blocks and ignores non-text content", () => {
@@ -216,6 +224,69 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).toContain("--browserUrl=http://127.0.0.1:9222");
     expect(args.some((a) => a.startsWith("--wsHeaders="))).toBe(false);
+  });
+});
+
+describe("resolveTransportSpec", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.CHROME_DEVTOOLS_AXI_MCP_PATH = process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+    savedEnv.CHROME_DEVTOOLS_AXI_HEADED = process.env.CHROME_DEVTOOLS_AXI_HEADED;
+    savedEnv.CHROME_DEVTOOLS_AXI_BROWSER_URL = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+    savedEnv.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+    delete process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+    delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
+    delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+    delete process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("defaults to spawning via npx when CHROME_DEVTOOLS_AXI_MCP_PATH is unset", () => {
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe("npx");
+    expect(spec.args[0]).toBe("-y");
+    expect(spec.args[1]).toBe("chrome-devtools-mcp@latest");
+    // Default mcp args follow
+    expect(spec.args).toContain("--isolated");
+    expect(spec.args).toContain("--headless");
+  });
+
+  it("spawns node directly when CHROME_DEVTOOLS_AXI_MCP_PATH is set", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "/opt/mcp/build/src/bin/chrome-devtools-mcp.js";
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe(process.execPath);
+    expect(spec.args[0]).toBe("/opt/mcp/build/src/bin/chrome-devtools-mcp.js");
+    // Strips the npx-only `-y, chrome-devtools-mcp@latest` prefix
+    expect(spec.args).not.toContain("-y");
+    expect(spec.args).not.toContain("chrome-devtools-mcp@latest");
+    // Preserves the mcp-specific args
+    expect(spec.args).toContain("--isolated");
+    expect(spec.args).toContain("--headless");
+  });
+
+  it("preserves --browserUrl when MCP_PATH and BROWSER_URL are both set", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "/opt/mcp.js";
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe(process.execPath);
+    expect(spec.args[0]).toBe("/opt/mcp.js");
+    expect(spec.args).toContain("--browserUrl=http://127.0.0.1:9222");
+    expect(spec.args).not.toContain("--isolated");
+  });
+
+  it("treats an empty MCP_PATH as unset", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "";
+    const spec = resolveTransportSpec();
+    expect(spec.command).toBe("npx");
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { AxiError } from "axi-sdk-js";
-import { CdpError, mapErrorMessage } from "../src/client.js";
+import {
+  CdpError,
+  mapErrorMessage,
+  resolveBridgeTimeoutMs,
+} from "../src/client.js";
 
 describe("CdpError", () => {
   it("uses the shared axi-sdk-js error contract", () => {
@@ -31,5 +35,48 @@ describe("mapErrorMessage", () => {
 
     expect(error.code).toBe("BROWSER_ERROR");
     expect(error.message).toBe("Page crashed");
+  });
+});
+
+describe("resolveBridgeTimeoutMs", () => {
+  let savedTimeout: string | undefined;
+
+  beforeEach(() => {
+    savedTimeout = process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+    delete process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    if (savedTimeout === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = savedTimeout;
+    }
+  });
+
+  it("defaults to 30s when env var is unset", () => {
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
+  });
+
+  it("honors a numeric env value", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "60000";
+    expect(resolveBridgeTimeoutMs()).toBe(60_000);
+  });
+
+  it("clamps tiny values to a 1s floor (avoids pathological retries)", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "10";
+    expect(resolveBridgeTimeoutMs()).toBe(1_000);
+  });
+
+  it("falls back to default when value is non-numeric", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "soon";
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
+  });
+
+  it("falls back to default when value is zero or negative", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "0";
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "-100";
+    expect(resolveBridgeTimeoutMs()).toBe(30_000);
   });
 });

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_BASE_PORT,
+  DEFAULT_SESSION_NAME,
+  defaultPortForSession,
+  defaultUserDataDirForSession,
+  resolveSessionName,
+  resolveSessionPidFile,
+  resolveSessionPort,
+  validateSessionName,
+} from "../src/sessions.js";
+
+describe("resolveSessionName", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.CHROME_DEVTOOLS_AXI_SESSION = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+  });
+
+  afterEach(() => {
+    if (savedEnv.CHROME_DEVTOOLS_AXI_SESSION === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_SESSION = savedEnv.CHROME_DEVTOOLS_AXI_SESSION;
+    }
+  });
+
+  it('returns "default" when env is unset', () => {
+    expect(resolveSessionName()).toBe(DEFAULT_SESSION_NAME);
+  });
+
+  it('returns "default" when env is empty', () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "";
+    expect(resolveSessionName()).toBe(DEFAULT_SESSION_NAME);
+  });
+
+  it('returns "default" when env is whitespace', () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "   ";
+    expect(resolveSessionName()).toBe(DEFAULT_SESSION_NAME);
+  });
+
+  it("returns trimmed name", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "  widecorp-ceo  ";
+    expect(resolveSessionName()).toBe("widecorp-ceo");
+  });
+});
+
+describe("validateSessionName", () => {
+  it('accepts "default"', () => {
+    expect(() => validateSessionName(DEFAULT_SESSION_NAME)).not.toThrow();
+  });
+
+  it("accepts safe names", () => {
+    expect(() => validateSessionName("widecorp-ceo")).not.toThrow();
+    expect(() => validateSessionName("deb.admin")).not.toThrow();
+    expect(() => validateSessionName("user_1")).not.toThrow();
+    expect(() => validateSessionName("a1b2c3")).not.toThrow();
+  });
+
+  it("rejects path-traversal attempts", () => {
+    expect(() => validateSessionName("../foo")).toThrow(/Invalid session name/);
+    expect(() => validateSessionName("a/b")).toThrow(/Invalid session name/);
+  });
+
+  it("rejects empty and overlong names", () => {
+    expect(() => validateSessionName("")).toThrow(/Invalid session name/);
+    expect(() => validateSessionName("x".repeat(65))).toThrow(/Invalid session name/);
+  });
+
+  it("rejects shell metachars and spaces", () => {
+    expect(() => validateSessionName("foo bar")).toThrow(/Invalid session name/);
+    expect(() => validateSessionName("foo;bar")).toThrow(/Invalid session name/);
+    expect(() => validateSessionName("foo$bar")).toThrow(/Invalid session name/);
+  });
+});
+
+describe("defaultPortForSession", () => {
+  it("returns base port (9224) for default session", () => {
+    expect(defaultPortForSession(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+  });
+
+  it("returns same port for same name (deterministic)", () => {
+    expect(defaultPortForSession("widecorp-ceo")).toBe(
+      defaultPortForSession("widecorp-ceo"),
+    );
+  });
+
+  it("returns a port within the named-session range (9225..9324)", () => {
+    const port = defaultPortForSession("anyname");
+    expect(port).toBeGreaterThanOrEqual(DEFAULT_BASE_PORT + 1);
+    expect(port).toBeLessThanOrEqual(DEFAULT_BASE_PORT + 100);
+  });
+
+  it("typically gives different ports for different names", () => {
+    // Deterministic hash-based allocation. Collisions in [9225..9324] are
+    // possible but rare for short distinct strings.
+    const a = defaultPortForSession("alice");
+    const b = defaultPortForSession("bob");
+    const c = defaultPortForSession("charlie");
+    const ports = new Set([a, b, c]);
+    expect(ports.size).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("resolveSessionPort", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.CHROME_DEVTOOLS_AXI_PORT = process.env.CHROME_DEVTOOLS_AXI_PORT;
+    savedEnv.CHROME_DEVTOOLS_AXI_SESSION = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+    delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("uses session-derived port when no explicit port", () => {
+    expect(resolveSessionPort(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+  });
+
+  it("honors CHROME_DEVTOOLS_AXI_PORT", () => {
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "9999";
+    expect(resolveSessionPort("anysession")).toBe(9999);
+  });
+
+  it("ignores invalid CHROME_DEVTOOLS_AXI_PORT", () => {
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "notanumber";
+    expect(resolveSessionPort(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+  });
+
+  it("ignores zero/negative CHROME_DEVTOOLS_AXI_PORT", () => {
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "0";
+    expect(resolveSessionPort(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+  });
+});
+
+describe("resolveSessionPidFile", () => {
+  it("returns legacy path for default session (backward compat)", () => {
+    expect(resolveSessionPidFile(DEFAULT_SESSION_NAME)).toBe(
+      join(homedir(), ".chrome-devtools-axi", "bridge.pid"),
+    );
+  });
+
+  it("returns session-scoped path for named sessions", () => {
+    expect(resolveSessionPidFile("widecorp-ceo")).toBe(
+      join(homedir(), ".chrome-devtools-axi", "sessions", "widecorp-ceo", "bridge.pid"),
+    );
+  });
+});
+
+describe("defaultUserDataDirForSession", () => {
+  it("returns null for default session (preserves --isolated)", () => {
+    expect(defaultUserDataDirForSession(DEFAULT_SESSION_NAME)).toBeNull();
+  });
+
+  it("returns a per-session profile path for named sessions", () => {
+    expect(defaultUserDataDirForSession("deb-admin")).toBe(
+      join(homedir(), ".cache/chrome-devtools-axi/sessions", "deb-admin"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds named-session support so multiple bridges can run concurrently — one per worktree, one per test user, one per Chrome profile, etc. — without stepping on each other.

```bash
CHROME_DEVTOOLS_AXI_SESSION=widecorp-ceo chrome-devtools-axi open https://...
CHROME_DEVTOOLS_AXI_SESSION=deb-admin     chrome-devtools-axi open https://...
```

Each named session gets its own:

- **Bridge process and port** — auto-allocated from name hash to `9225..9324`. Override with `CHROME_DEVTOOLS_AXI_PORT` if you hit a collision.
- **PID file** — `~/.chrome-devtools-axi/sessions/<name>/bridge.pid`.
- **Persistent profile dir** — `~/.cache/chrome-devtools-axi/sessions/<name>`. Auth state and cookies survive bridge restarts. Composes with the existing `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` override (explicit env wins over the per-session default).

**Backward compatible.** When `CHROME_DEVTOOLS_AXI_SESSION` is unset (or set to `"default"`), behavior is identical to before: port 9224, legacy `~/.chrome-devtools-axi/bridge.pid` path, `--isolated` profile.

## Motivation

Monorepos with many worktrees need per-worktree browser isolation so tools in different working directories don't share auth state or interfere with each other's bridges. Today a single global bridge means switching between worktrees clobbers state.

Named sessions solve that without forcing every worktree to manage `CHROME_DEVTOOLS_AXI_PORT` + `USER_DATA_DIR` + a custom PID file location by hand.

Also useful for:
- Parallel test runs (one session per test worker)
- Keeping multiple test-user sessions alive simultaneously (logged in as `ceo` and `deb-admin` in separate browsers, no re-login between agent calls)

## Changes

- **`src/sessions.ts`** (new) — single source of truth for session-scoped resources:
  - `resolveSessionName()` reads `CHROME_DEVTOOLS_AXI_SESSION`, defaults to `"default"`
  - `validateSessionName()` rejects path-traversal, shell metachars, overlong names (1-64 chars from `[a-zA-Z0-9._-]`)
  - `defaultPortForSession()` deterministic FNV-1a-ish hash → port in `[9225, 9324]`
  - `resolveSessionPort()` env override > session-derived
  - `resolveSessionPidFile()` legacy path for default, `sessions/<name>/` subdir otherwise
  - `defaultUserDataDirForSession()` returns `null` for default (preserves `--isolated`), per-session path otherwise
- **`src/bridge.ts`** — `writePidFile`/`removePidFile` use the session's PID file. `runBridge()` resolves the port lazily (was a module-load constant). `buildTransportArgs` falls back to the session's profile dir when no other profile env is set.
- **`src/client.ts`** — `ensureBridge()` is session-aware: validates name, resolves session port + PID file, propagates `CHROME_DEVTOOLS_AXI_SESSION` to the spawned bridge child so it uses the same paths. `readPidFile` accepts an optional path so call sites can pass session-specific paths if needed.
- **`src/cli.ts`** — documents `CHROME_DEVTOOLS_AXI_SESSION` in `TOP_HELP`.
- **`test/sessions.test.ts`** (new) — 21 tests covering name resolution, validation (rejects path-traversal / shell metachars / overlong / empty), port allocation, PID file paths, profile path defaults.
- **`test/bridge.test.ts`** — 3 new tests for the session-aware profile resolution: default session uses `--isolated`; named session auto-derives a profile dir; explicit `USER_DATA_DIR` overrides the session default.

Stat: `6 files changed, 370 insertions(+), 33 deletions(-)`.

## Test plan

- [x] All existing tests pass
- [x] 24 new tests pass (246 total)
- [x] Backward compat: `CHROME_DEVTOOLS_AXI_SESSION` unset → same code path / paths / port as before
- [x] Build: `npm run build` clean

## Stacked on #47

This branch builds on #47 (cold-start npx-bootstrap fix) — that's the first commit shown in the diff. The two PRs are independent in scope and reviewable separately. After #47 merges, I'll rebase this onto post-merge `main` so the diff cleanly shows only the named-session changes.

If you'd prefer this PR not depend on #47 at all, I can split out the lazy port-resolution change (the only `bridge.ts` overlap) into a precursor commit on `main`. Let me know.

## Notes

- Port collisions in `[9225, 9324]` are possible with deterministic hashing. Collision domain is small but real. If two named sessions hash to the same port, set `CHROME_DEVTOOLS_AXI_PORT` on one of them. Could add probe-and-allocate later if it becomes a common issue.
- A natural follow-up is a `--session <name>` CLI flag (in addition to the env var). Skipped here to keep this PR focused — same resolution can be added without breaking changes.
- Validation on the session name is strict (1-64 alphanumerics + `._-`) to keep filesystem paths safe and prevent injection through env var manipulation.