### PR TITLE
fix: recycle stale bridge processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Execute `npx -y chrome-devtools-axi` to get browser automation tools.
 ```
 
 - **Persistent bridge** — a detached process keeps the MCP session alive across commands, so Chrome doesn't restart every invocation
-- **Auto-lifecycle** — the bridge starts on first command and writes a PID file to `~/.chrome-devtools-axi/bridge.pid`
+- **Auto-lifecycle** — the bridge starts on first command, writes a PID file to `~/.chrome-devtools-axi/bridge.pid`, recycles stale CDP targets after a deep health check, and reaps child processes on stop
 - **Snapshot parsing** — accessibility tree snapshots are extracted and analyzed for interactive elements (`uid=` refs)
 - **TOON encoding** — structured metadata uses [TOON format](https://www.npmjs.com/package/@toon-format/toon) for compact, token-efficient output
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -65,6 +65,25 @@ export async function isBridgeClientConnected(
   }
 }
 
+/**
+ * Probe whether the bridge's underlying CDP target is reachable. Drives one
+ * round-trip MCP tool call (`list_pages`) that requires a live browser/CDP
+ * connection — `listTools()` alone only confirms the local MCP server is up,
+ * not that the attached browser is still alive. Used by `/health?deep=1` so
+ * `ensureBridge` can detect a stale bridge after the user kills + restarts
+ * the underlying Chrome/Electron target.
+ */
+export async function isBridgeTargetReachable(
+  client: BridgeClient,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  try {
+    await client.callTool({ name: "list_pages", arguments: {} });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: getErrorMessage(error) };
+  }
+}
+
 function writePidFile(port: number): void {
   mkdirSync(STATE_DIR, { recursive: true });
   writeFileSync(PID_FILE, JSON.stringify({ pid: process.pid, port }));
@@ -186,12 +205,27 @@ export async function handleBridgeRequest(
 ): Promise<void> {
   res.setHeader("Content-Type", "application/json");
 
-  if (req.method === "GET" && req.url === "/health") {
-    if (await isBridgeClientConnected(client)) {
-      writeJson(res, 200, { status: "ok" });
-    } else {
-      writeJson(res, 503, { error: "Not connected" });
+  if (
+    req.method === "GET" &&
+    (req.url === "/health" || req.url?.startsWith("/health?"))
+  ) {
+    if (!(await isBridgeClientConnected(client))) {
+      writeJson(res, 503, { status: "error", error: "Not connected" });
+      return;
     }
+    const deep = req.url.includes("deep=1");
+    if (deep) {
+      const probe = await isBridgeTargetReachable(client);
+      if (!probe.ok) {
+        writeJson(res, 503, {
+          status: "error",
+          error: "CDP target unreachable",
+          reason: probe.reason,
+        });
+        return;
+      }
+    }
+    writeJson(res, 200, { status: "ok" });
     return;
   }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -6,7 +6,7 @@
  *   POST /call  { name, args }  → { result }
  *   GET  /tools                 → [{ name, description }]
  *   GET  /health                → { status: "ok" } or 503 { status: "error", error }
- *   GET  /health?deep=1         → also verifies the attached CDP target
+ *   GET  /health?deep=1         → also verifies the attached CDP target; 503 may include reason
  *
  * Writes a PID file to ~/.chrome-devtools-axi/bridge.pid on startup.
  */

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -5,7 +5,8 @@
  * persistent MCP session. Exposes a simple HTTP API:
  *   POST /call  { name, args }  → { result }
  *   GET  /tools                 → [{ name, description }]
- *   GET  /health                → { status: "ok" }
+ *   GET  /health                → { status: "ok" } or 503 { status: "error", error }
+ *   GET  /health?deep=1         → also verifies the attached CDP target
  *
  * Writes a PID file to ~/.chrome-devtools-axi/bridge.pid on startup.
  */

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,7 @@
  * HTTP client for the chrome-devtools-axi bridge + bridge lifecycle management.
  */
 
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
@@ -15,6 +15,8 @@ const PID_FILE = join(STATE_DIR, "bridge.pid");
 const DEFAULT_PORT = 9224;
 const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
 const MIN_BRIDGE_TIMEOUT_MS = 1_000;
+const HEALTH_TIMEOUT_MS = 2_000;
+const DEEP_HEALTH_TIMEOUT_MS = 5_000;
 
 /**
  * Resolve the bridge readiness deadline in milliseconds.
@@ -155,7 +157,8 @@ export async function checkBridgeHealth(
 ): Promise<boolean> {
   try {
     const path = opts.deep ? "/health?deep=1" : "/health";
-    const resp = await httpGet(port, path);
+    const timeoutMs = opts.deep ? DEEP_HEALTH_TIMEOUT_MS : HEALTH_TIMEOUT_MS;
+    const resp = await httpGet(port, path, timeoutMs);
     const data = JSON.parse(resp);
     return data.status === "ok";
   } catch {
@@ -179,6 +182,18 @@ export async function waitForProcessExit(
   return !isProcessAlive(pid);
 }
 
+function isBridgeProcess(pid: number): boolean {
+  try {
+    const command = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf-8",
+      timeout: 1000,
+    });
+    return command.includes("chrome-devtools-axi-bridge");
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Terminate a bridge process and reap its detached process group. Sends
  * SIGTERM, polls up to ~2s for exit, then escalates to SIGKILL on the entire
@@ -186,8 +201,12 @@ export async function waitForProcessExit(
  * orphans. Returns once the bridge PID is gone (or the SIGKILL grace window
  * expires).
  */
-export async function terminateBridgeProcess(pid: number): Promise<void> {
+export async function terminateBridgeProcess(
+  pid: number,
+  opts: { killProcessGroup?: boolean } = {},
+): Promise<void> {
   if (!isProcessAlive(pid)) return;
+  const killProcessGroup = opts.killProcessGroup === true;
 
   // Give the bridge a chance to run its own shutdown handler (which kills its
   // process group on `exit`).
@@ -198,20 +217,28 @@ export async function terminateBridgeProcess(pid: number): Promise<void> {
   }
 
   if (await waitForProcessExit(pid, 2000)) {
-    // Belt-and-suspenders: even on a clean exit, sweep the process group in
-    // case any chrome-devtools-mcp child outlived its parent.
-    try {
-      process.kill(-pid, "SIGKILL");
-    } catch {
-      // Group already gone or pid was never a group leader — fine.
+    if (killProcessGroup) {
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        // Group already gone or pid was never a group leader — fine.
+      }
     }
     return;
   }
 
   // Escalate: kill the whole process group so children get reaped together.
-  try {
-    process.kill(-pid, "SIGKILL");
-  } catch {
+  if (killProcessGroup) {
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already dead.
+      }
+    }
+  } else {
     try {
       process.kill(pid, "SIGKILL");
     } catch {
@@ -242,7 +269,9 @@ export async function ensureBridge(): Promise<number> {
     if (await checkBridgeHealth(pidInfo.port, { deep: true })) {
       return pidInfo.port;
     }
-    await terminateBridgeProcess(pidInfo.pid);
+    await terminateBridgeProcess(pidInfo.pid, {
+      killProcessGroup: isBridgeProcess(pidInfo.pid),
+    });
   }
 
   // Start a new bridge
@@ -409,6 +438,8 @@ export async function stopBridge(): Promise<boolean> {
   const pidInfo = readPidFile();
   if (!pidInfo) return false;
   if (!isProcessAlive(pidInfo.pid)) return false;
-  await terminateBridgeProcess(pidInfo.pid);
+  await terminateBridgeProcess(pidInfo.pid, {
+    killProcessGroup: isBridgeProcess(pidInfo.pid),
+  });
   return true;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -142,9 +142,20 @@ function httpPost(
   });
 }
 
-async function checkBridgeHealth(port: number): Promise<boolean> {
+/**
+ * Probe the bridge's `/health` endpoint. With `deep: true`, asks the bridge
+ * to drive one CDP-backed MCP call (`list_pages`) so callers can distinguish
+ * "MCP server is up but the attached browser is gone" from genuine readiness.
+ *
+ * Exported for tests; production code uses it via `ensureBridge`.
+ */
+export async function checkBridgeHealth(
+  port: number,
+  opts: { deep?: boolean } = {},
+): Promise<boolean> {
   try {
-    const resp = await httpGet(port, "/health");
+    const path = opts.deep ? "/health?deep=1" : "/health";
+    const resp = await httpGet(port, path);
     const data = JSON.parse(resp);
     return data.status === "ok";
   } catch {
@@ -156,8 +167,67 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+export async function waitForProcessExit(
+  pid: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await sleep(50);
+  }
+  return !isProcessAlive(pid);
+}
+
+/**
+ * Terminate a bridge process and reap its detached process group. Sends
+ * SIGTERM, polls up to ~2s for exit, then escalates to SIGKILL on the entire
+ * process group so chrome-devtools-mcp / Chrome children can't survive as
+ * orphans. Returns once the bridge PID is gone (or the SIGKILL grace window
+ * expires).
+ */
+export async function terminateBridgeProcess(pid: number): Promise<void> {
+  if (!isProcessAlive(pid)) return;
+
+  // Give the bridge a chance to run its own shutdown handler (which kills its
+  // process group on `exit`).
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return;
+  }
+
+  if (await waitForProcessExit(pid, 2000)) {
+    // Belt-and-suspenders: even on a clean exit, sweep the process group in
+    // case any chrome-devtools-mcp child outlived its parent.
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // Group already gone or pid was never a group leader — fine.
+    }
+    return;
+  }
+
+  // Escalate: kill the whole process group so children get reaped together.
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already dead.
+    }
+  }
+  await waitForProcessExit(pid, 1000);
+}
+
 /**
  * Ensure the bridge is running, starting it if needed. Returns the port.
+ *
+ * Verifies a *deep* health check (one round-trip CDP-backed MCP call) before
+ * declaring the bridge ready, so a bridge whose attached browser/Electron
+ * target was killed while still answering local /health requests gets torn
+ * down + restarted instead of being reused as a stale endpoint.
  */
 export async function ensureBridge(): Promise<number> {
   const port = parseInt(
@@ -165,17 +235,14 @@ export async function ensureBridge(): Promise<number> {
     10,
   );
 
-  // Check existing bridge via PID file
+  // Check existing bridge via PID file. Use a deep probe so a bridge whose
+  // attached CDP target has gone away gets recycled instead of returned.
   const pidInfo = readPidFile();
   if (pidInfo && isProcessAlive(pidInfo.pid)) {
-    if (await checkBridgeHealth(pidInfo.port)) {
+    if (await checkBridgeHealth(pidInfo.port, { deep: true })) {
       return pidInfo.port;
     }
-    try {
-      process.kill(pidInfo.pid, "SIGTERM");
-    } catch {
-      // Best effort — if shutdown fails, the startup poll below will time out.
-    }
+    await terminateBridgeProcess(pidInfo.pid);
   }
 
   // Start a new bridge
@@ -198,17 +265,38 @@ export async function ensureBridge(): Promise<number> {
   );
   child.unref();
 
-  // Poll for health — Chrome launch + npx bootstrap can be slow
+  // Poll for health — Chrome launch + npx bootstrap can be slow.
+  // Track whether the *shallow* health check ever passed so we can attribute
+  // the failure correctly: shallow-but-no-deep means the MCP server came up
+  // but the attached CDP target is dead, vs. nothing-came-up which is the
+  // generic startup-timeout case.
   const timeoutMs = resolveBridgeTimeoutMs();
   const deadline = Date.now() + timeoutMs;
+  let sawShallowReady = false;
   while (Date.now() < deadline) {
-    if (await checkBridgeHealth(port)) {
+    if (await checkBridgeHealth(port, { deep: true })) {
       return port;
+    }
+    if (!sawShallowReady && (await checkBridgeHealth(port))) {
+      sawShallowReady = true;
     }
     await sleep(500);
   }
 
   const seconds = Math.round(timeoutMs / 1000);
+
+  if (sawShallowReady) {
+    throw new CdpError(
+      "Bridge is running but the attached CDP target appears to have gone away",
+      "BRIDGE_NOT_READY",
+      [
+        "The Chrome/Electron instance the bridge was attached to may have exited.",
+        "Verify the target is still listening on its remote-debugging port, then re-run the command.",
+        "If the target was restarted, the bridge has already been recycled — this run will succeed once the target is reachable.",
+      ],
+    );
+  }
+
   const usingNpx = !process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
   const suggestions = [
     "Check that chrome-devtools-mcp is installed: npx chrome-devtools-mcp@latest --help",
@@ -312,16 +400,15 @@ export async function getSessionSnapshotIfRunning(): Promise<string | null> {
 }
 
 /**
- * Stop the bridge process.
+ * Stop the bridge process. Waits for the bridge PID to actually exit (bounded
+ * poll, ~2s) before escalating to SIGKILL on the entire detached process
+ * group, so chrome-devtools-mcp + Chrome children get reaped together rather
+ * than orphaned. Resolves once the bridge process is gone.
  */
-export function stopBridge(): boolean {
+export async function stopBridge(): Promise<boolean> {
   const pidInfo = readPidFile();
-  if (!pidInfo) {
-    return false;
-  }
-  if (isProcessAlive(pidInfo.pid)) {
-    process.kill(pidInfo.pid, "SIGTERM");
-    return true;
-  }
-  return false;
+  if (!pidInfo) return false;
+  if (!isProcessAlive(pidInfo.pid)) return false;
+  await terminateBridgeProcess(pidInfo.pid);
+  return true;
 }

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import {
   buildTransportArgs,
   detectGlobalMcpPath,
   extractToolText,
   getErrorMessage,
+  handleBridgeRequest,
   isBridgeClientConnected,
+  isBridgeTargetReachable,
   parseBridgeCallPayload,
   resolveBridgeScript,
   resolveTransportSpec,
+  type BridgeClient,
 } from "../src/bridge.js";
 
 describe("extractToolText", () => {
@@ -411,5 +416,169 @@ describe("bridge health", () => {
     });
 
     expect(healthy).toBe(true);
+  });
+});
+
+describe("isBridgeTargetReachable", () => {
+  it("returns ok when list_pages succeeds", async () => {
+    const client: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async ({ name }) => {
+        expect(name).toBe("list_pages");
+        return { content: [] };
+      },
+      close: async () => {},
+    };
+
+    const result = await isBridgeTargetReachable(client);
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok=false with reason when the CDP target is gone", async () => {
+    const client: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => {
+        throw new Error("Target closed");
+      },
+      close: async () => {},
+    };
+
+    const result = await isBridgeTargetReachable(client);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("Target closed");
+    }
+  });
+});
+
+function makeRequest(method: string, url: string): IncomingMessage {
+  const req = new IncomingMessage(new Socket());
+  req.method = method;
+  req.url = url;
+  return req;
+}
+
+interface CapturedResponse {
+  statusCode: number;
+  body: string;
+  headers: Record<string, string>;
+}
+
+function makeResponse(): { res: ServerResponse; captured: CapturedResponse } {
+  const captured: CapturedResponse = {
+    statusCode: 0,
+    body: "",
+    headers: {},
+  };
+  const req = new IncomingMessage(new Socket());
+  const res = new ServerResponse(req);
+  const origSetHeader = res.setHeader.bind(res);
+  res.setHeader = ((name: string, value: string | number | string[]) => {
+    captured.headers[String(name).toLowerCase()] = String(value);
+    return origSetHeader(name, value as string);
+  }) as typeof res.setHeader;
+  res.end = ((chunk?: unknown) => {
+    if (typeof chunk === "string") captured.body += chunk;
+    captured.statusCode = res.statusCode;
+    return res;
+  }) as typeof res.end;
+  return { res, captured };
+}
+
+describe("handleBridgeRequest /health", () => {
+  it("returns 200 ok for shallow /health when MCP is connected", async () => {
+    const client: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => ({ content: [] }),
+      close: async () => {},
+    };
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(client, makeRequest("GET", "/health"), res);
+
+    expect(captured.statusCode).toBe(200);
+    expect(JSON.parse(captured.body)).toEqual({ status: "ok" });
+  });
+
+  it("returns 503 when MCP server is disconnected", async () => {
+    const client: BridgeClient = {
+      listTools: async () => {
+        throw new Error("Not connected");
+      },
+      callTool: async () => ({}),
+      close: async () => {},
+    };
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(client, makeRequest("GET", "/health"), res);
+
+    expect(captured.statusCode).toBe(503);
+    expect(JSON.parse(captured.body)).toMatchObject({ status: "error" });
+  });
+
+  it("returns 503 from /health?deep=1 when CDP target is unreachable", async () => {
+    const client: BridgeClient = {
+      // Shallow probe (listTools) passes — local MCP server is fine.
+      listTools: async () => ({ tools: [] }),
+      // Deep probe (list_pages) fails — attached browser is gone.
+      callTool: async () => {
+        throw new Error("Target closed");
+      },
+      close: async () => {},
+    };
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest("GET", "/health?deep=1"),
+      res,
+    );
+
+    expect(captured.statusCode).toBe(503);
+    const body = JSON.parse(captured.body);
+    expect(body.status).toBe("error");
+    expect(body.error).toContain("CDP target unreachable");
+    expect(body.reason).toContain("Target closed");
+  });
+
+  it("returns 200 from /health?deep=1 when both MCP and CDP target are healthy", async () => {
+    let listPagesCalls = 0;
+    const client: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async ({ name }) => {
+        if (name === "list_pages") listPagesCalls++;
+        return { content: [] };
+      },
+      close: async () => {},
+    };
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest("GET", "/health?deep=1"),
+      res,
+    );
+
+    expect(captured.statusCode).toBe(200);
+    expect(JSON.parse(captured.body)).toEqual({ status: "ok" });
+    expect(listPagesCalls).toBe(1);
+  });
+
+  it("does not invoke the deep CDP probe on the shallow /health path", async () => {
+    let callToolCalls = 0;
+    const client: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => {
+        callToolCalls++;
+        return { content: [] };
+      },
+      close: async () => {},
+    };
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(client, makeRequest("GET", "/health"), res);
+
+    expect(captured.statusCode).toBe(200);
+    expect(callToolCalls).toBe(0);
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
 import { AxiError } from "axi-sdk-js";
 import {
   CdpError,
+  checkBridgeHealth,
   mapErrorMessage,
   resolveBridgeTimeoutMs,
+  terminateBridgeProcess,
+  waitForProcessExit,
 } from "../src/client.js";
 
 describe("CdpError", () => {
@@ -78,5 +84,181 @@ describe("resolveBridgeTimeoutMs", () => {
     expect(resolveBridgeTimeoutMs()).toBe(30_000);
     process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "-100";
     expect(resolveBridgeTimeoutMs()).toBe(30_000);
+  });
+});
+
+interface FakeBridgeOptions {
+  shallow: "ok" | "error";
+  deep: "ok" | "error";
+}
+
+function startFakeBridgeServer(opts: FakeBridgeOptions): Promise<{
+  port: number;
+  server: Server;
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolveStart, rejectStart) => {
+    const server = createServer((req, res) => {
+      if (req.method === "GET" && req.url?.startsWith("/health")) {
+        const wantsDeep = req.url.includes("deep=1");
+        const outcome = wantsDeep ? opts.deep : opts.shallow;
+        res.setHeader("Content-Type", "application/json");
+        if (outcome === "ok") {
+          res.statusCode = 200;
+          res.end(JSON.stringify({ status: "ok" }));
+        } else {
+          res.statusCode = 503;
+          res.end(JSON.stringify({ status: "error" }));
+        }
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    server.on("error", rejectStart);
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolveStart({
+        port,
+        server,
+        close: () =>
+          new Promise<void>((closeResolve) => {
+            server.close(() => closeResolve());
+          }),
+      });
+    });
+  });
+}
+
+describe("checkBridgeHealth (deep probe)", () => {
+  it("returns true on a shallow probe when /health responds 200 ok", async () => {
+    const fake = await startFakeBridgeServer({ shallow: "ok", deep: "error" });
+    try {
+      expect(await checkBridgeHealth(fake.port)).toBe(true);
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("returns false on the deep probe when the bridge reports CDP target unreachable", async () => {
+    // This is the exact stale-bridge scenario from issue #43: the local MCP
+    // server still answers /health, but the attached browser is gone, so the
+    // deep probe correctly reports unhealthy.
+    const fake = await startFakeBridgeServer({ shallow: "ok", deep: "error" });
+    try {
+      expect(await checkBridgeHealth(fake.port)).toBe(true);
+      expect(await checkBridgeHealth(fake.port, { deep: true })).toBe(false);
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("returns true on the deep probe when the bridge reports both layers healthy", async () => {
+    const fake = await startFakeBridgeServer({ shallow: "ok", deep: "ok" });
+    try {
+      expect(await checkBridgeHealth(fake.port, { deep: true })).toBe(true);
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("returns false when nothing is listening on the port", async () => {
+    // Port 1 is privileged and unbound — connection should be refused immediately.
+    expect(await checkBridgeHealth(1)).toBe(false);
+    expect(await checkBridgeHealth(1, { deep: true })).toBe(false);
+  });
+});
+
+describe("waitForProcessExit", () => {
+  it("returns true once the process is gone", async () => {
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 200)"], {
+      stdio: "ignore",
+    });
+    expect(child.pid).toBeDefined();
+    const pid = child.pid as number;
+    child.unref();
+
+    // Process is alive at first
+    expect(await waitForProcessExit(pid, 50)).toBe(false);
+
+    // After it exits naturally, the wait should succeed
+    expect(await waitForProcessExit(pid, 2000)).toBe(true);
+  });
+
+  it("returns false when the process outlives the timeout", async () => {
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 5000)"], {
+      stdio: "ignore",
+    });
+    const pid = child.pid as number;
+    try {
+      expect(await waitForProcessExit(pid, 100)).toBe(false);
+    } finally {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+  });
+});
+
+describe("terminateBridgeProcess", () => {
+  it("waits for the bridge process to actually exit before returning", async () => {
+    // Mimics a well-behaved bridge: exits cleanly on SIGTERM.
+    const child = spawn(
+      process.execPath,
+      ["-e", "process.on('SIGTERM', () => process.exit(0)); setTimeout(() => {}, 30000);"],
+      { stdio: "ignore", detached: true },
+    );
+    const pid = child.pid as number;
+    child.unref();
+
+    // Give the listener a moment to register before we send the signal.
+    await new Promise((r) => setTimeout(r, 50));
+    await terminateBridgeProcess(pid);
+
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  });
+
+  it("escalates to SIGKILL when the bridge ignores SIGTERM", async () => {
+    // Mimics a stuck bridge: ignores SIGTERM. Without escalation, stop +
+    // start can't recover (issue #43). The 2s SIGTERM grace window means
+    // the test takes ~2s to drive the escalation path.
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        "process.on('SIGTERM', () => {}); setTimeout(() => {}, 30000);",
+      ],
+      { stdio: "ignore", detached: true },
+    );
+    const pid = child.pid as number;
+    child.unref();
+
+    await new Promise((r) => setTimeout(r, 50));
+    await terminateBridgeProcess(pid);
+
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  }, 10_000);
+
+  it("is a no-op when the pid is already gone", async () => {
+    // Pick a likely-unused pid by spawning + waiting for it to exit.
+    const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+    const pid = child.pid as number;
+    await new Promise<void>((r) => child.on("exit", () => r()));
+
+    await expect(terminateBridgeProcess(pid)).resolves.toBeUndefined();
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { spawn } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { AxiError } from "axi-sdk-js";
 import {
   CdpError,
@@ -90,6 +93,7 @@ describe("resolveBridgeTimeoutMs", () => {
 interface FakeBridgeOptions {
   shallow: "ok" | "error";
   deep: "ok" | "error";
+  deepDelayMs?: number;
 }
 
 function startFakeBridgeServer(opts: FakeBridgeOptions): Promise<{
@@ -103,12 +107,19 @@ function startFakeBridgeServer(opts: FakeBridgeOptions): Promise<{
         const wantsDeep = req.url.includes("deep=1");
         const outcome = wantsDeep ? opts.deep : opts.shallow;
         res.setHeader("Content-Type", "application/json");
-        if (outcome === "ok") {
-          res.statusCode = 200;
-          res.end(JSON.stringify({ status: "ok" }));
+        const sendResponse = () => {
+          if (outcome === "ok") {
+            res.statusCode = 200;
+            res.end(JSON.stringify({ status: "ok" }));
+          } else {
+            res.statusCode = 503;
+            res.end(JSON.stringify({ status: "error" }));
+          }
+        };
+        if (wantsDeep && opts.deepDelayMs) {
+          setTimeout(sendResponse, opts.deepDelayMs);
         } else {
-          res.statusCode = 503;
-          res.end(JSON.stringify({ status: "error" }));
+          sendResponse();
         }
         return;
       }
@@ -162,6 +173,19 @@ describe("checkBridgeHealth (deep probe)", () => {
     }
   });
 
+  it("allows a slower deep probe to complete successfully", async () => {
+    const fake = await startFakeBridgeServer({
+      shallow: "ok",
+      deep: "ok",
+      deepDelayMs: 2200,
+    });
+    try {
+      expect(await checkBridgeHealth(fake.port, { deep: true })).toBe(true);
+    } finally {
+      await fake.close();
+    }
+  }, 10_000);
+
   it("returns false when nothing is listening on the port", async () => {
     // Port 1 is privileged and unbound — connection should be refused immediately.
     expect(await checkBridgeHealth(1)).toBe(false);
@@ -203,6 +227,34 @@ describe("waitForProcessExit", () => {
 });
 
 describe("terminateBridgeProcess", () => {
+  function waitForFile(path: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const deadline = Date.now() + 2000;
+      const poll = () => {
+        try {
+          resolve(readFileSync(path, "utf-8").trim());
+          return;
+        } catch (err) {
+          if (Date.now() >= deadline) {
+            reject(err);
+            return;
+          }
+          setTimeout(poll, 25);
+        }
+      };
+      poll();
+    });
+  }
+
+  function isAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   it("waits for the bridge process to actually exit before returning", async () => {
     // Mimics a well-behaved bridge: exits cleanly on SIGTERM.
     const child = spawn(
@@ -260,5 +312,41 @@ describe("terminateBridgeProcess", () => {
     await new Promise<void>((r) => child.on("exit", () => r()));
 
     await expect(terminateBridgeProcess(pid)).resolves.toBeUndefined();
+  });
+
+  it("does not kill the process group unless group termination is trusted", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "chrome-devtools-axi-test-"));
+    const childPidFile = join(dir, "child.pid");
+    const parent = spawn(
+      process.execPath,
+      [
+        "-e",
+        [
+          "const { spawn } = require('node:child_process');",
+          "const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'], { stdio: 'ignore' });",
+          `require('node:fs').writeFileSync(${JSON.stringify(childPidFile)}, String(child.pid));`,
+          "process.on('SIGTERM', () => {});",
+          "setTimeout(() => {}, 30000);",
+        ].join(""),
+      ],
+      { stdio: "ignore", detached: true },
+    );
+    const parentPid = parent.pid as number;
+    parent.unref();
+
+    const childPid = Number.parseInt(await waitForFile(childPidFile), 10);
+    try {
+      await terminateBridgeProcess(parentPid);
+
+      expect(isAlive(parentPid)).toBe(false);
+      expect(isAlive(childPid)).toBe(true);
+    } finally {
+      try {
+        process.kill(childPid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds deep CDP-backed bridge health checks so commands can detect and replace bridges whose browser target has gone stale.
- Hardens bridge shutdown by waiting for process exit and escalating termination when needed, while avoiding unsafe stale-PID group kills.
- Updates bridge lifecycle documentation and adds client/bridge coverage for stale-target recovery and termination behavior.

## Risk Assessment

⚠️ Medium: The remaining change is focused and includes targeted coverage, but it touches bridge lifecycle, health probing, and process termination behavior where environment-specific edge cases are possible.

## Testing

- Summary: Exercised the new bridge deep-health behavior, stale bridge process termination paths, CLI stop wiring, and the full Vitest suite; all tests passed.
- `npm test -- test/bridge.test.ts test/client.test.ts`
- `npm test -- test/cli.test.ts test/main.test.ts test/run.test.ts`
- `npm test`
- Outcome: ✅ passed across 1 run (1m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/client.ts:245` - A single failed deep health probe now causes an existing bridge to be terminated. Because `checkBridgeHealth` uses the same 2s HTTP timeout for `/health?deep=1` and collapses target errors, timeouts, malformed responses, and transient CDP slowness into `false`, a slow-but-live browser can be mistaken for a stale bridge and lose its session. Consider retrying the deep probe or using a longer/deep-specific timeout before terminating the process.
- ⚠️ `src/client.ts:213` - The SIGKILL escalation targets process group `-pid` based only on the PID file. If the PID file is stale and that PID has been reused by an unrelated process, `ensureBridge`/`stopBridge` can now kill an unrelated process group, which is a larger blast radius than the previous single SIGTERM. Consider validating that the PID still belongs to this bridge before group-killing, or limiting group escalation to processes started in the current run.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npm test -- test/bridge.test.ts test/client.test.ts`
- `npm test -- test/cli.test.ts test/main.test.ts test/run.test.ts`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `src/bridge.ts:8` - The bridge HTTP API doc comment still documents only `GET /health -&gt; { status: &#34;ok&#34; }`, but the change adds `GET /health?deep=1` and new 503 error payloads with `status: &#34;error&#34;`, `error`, and optional `reason`. Update this API documentation so the health endpoint behavior matches the implementation.
- ℹ️ `README.md:65` - The README&#39;s bridge lifecycle documentation describes persistence and PID auto-lifecycle, but the change adds user-visible stale-target recovery: commands now run a deep CDP-backed health check, recycle stale bridges when the attached Chrome/Electron target is gone, and `stop` waits/escalates to reap child processes. Update the bridge lifecycle description to cover this behavior.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/bridge.ts:8` - The bridge HTTP API doc comment still documents health failures as only `503 { status: &#34;error&#34;, error }`, but `GET /health?deep=1` now returns an additional `reason` field when the CDP target is unreachable. Update the API comment to document the deep-health 503 payload, including the optional `reason`.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
