### PR TITLE
fix(cli): make type all clear prior filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ session is active or the no-session status/help block when one is not.
 | `--response-file <path>`    | Save response body (network-get)            |
 | `--request-file <path>`     | Save request body (network-get)             |
 
+`console --type` accepts `log`, `debug`, `info`, `error`, `warn`, `dir`, `dirxml`, `table`, `trace`, `clear`, `startGroup`, `startGroupCollapsed`, `endGroup`, `assert`, `profile`, `profileEnd`, `count`, `timeEnd`, `verbose`, `issue`, and `all`.
+`network --type` accepts `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `prefetch`, `eventsource`, `websocket`, `manifest`, `signedexchange`, `ping`, `cspviolationreport`, `preflight`, `fedcm`, `other`, and `all`.
+For both commands, `all` or an omitted `--type` returns every item.
+
 ## Configuration
 
 The bridge server port defaults to `9224`. Override it with an environment variable:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -676,7 +676,8 @@ export function parseConsoleArgs(args: string[]): {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--type" && i + 1 < args.length) {
       const value = args[++i];
-      if (value.toLowerCase() !== "all") result.types = [value];
+      if (value.toLowerCase() === "all") delete result.types;
+      else result.types = [value];
     } else if (args[i] === "--limit" && i + 1 < args.length) {
       const pageSize = parseOptionalInteger(args[++i]);
       if (pageSize !== undefined) result.pageSize = pageSize;
@@ -701,7 +702,8 @@ export function parseNetworkArgs(args: string[]): {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--type" && i + 1 < args.length) {
       const value = args[++i];
-      if (value.toLowerCase() !== "all") result.resourceTypes = [value];
+      if (value.toLowerCase() === "all") delete result.resourceTypes;
+      else result.resourceTypes = [value];
     } else if (args[i] === "--limit" && i + 1 < args.length) {
       const pageSize = parseOptionalInteger(args[++i]);
       if (pageSize !== undefined) result.pageSize = pageSize;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -418,13 +418,18 @@ examples:
 List console messages for the current page.
 
 flags:
-  --type <type>  Filter by message type (error, warn, log, etc.)
+  --type <type>  Filter by message type. Valid values:
+                   log, debug, info, error, warn, dir, dirxml, table, trace,
+                   clear, startGroup, startGroupCollapsed, endGroup, assert,
+                   profile, profileEnd, count, timeEnd, verbose, issue, all
+                 ("all" or omitted returns every message.)
   --limit <n>    Maximum messages to return
   --page <n>     Page number (0-based)
 
 examples:
   chrome-devtools-axi console
-  chrome-devtools-axi console --type error --limit 50`,
+  chrome-devtools-axi console --type error --limit 50
+  chrome-devtools-axi console --type all`,
 
   "console-get": `usage: chrome-devtools-axi console-get <id>
 Get a specific console message by ID.
@@ -439,13 +444,19 @@ examples:
 List network requests for the current page.
 
 flags:
-  --type <type>  Filter by resource type (fetch, xhr, document, etc.)
+  --type <type>  Filter by resource type. Valid values:
+                   document, stylesheet, image, media, font, script, texttrack,
+                   xhr, fetch, prefetch, eventsource, websocket, manifest,
+                   signedexchange, ping, cspviolationreport, preflight, fedcm,
+                   other, all
+                 ("all" or omitted returns every request.)
   --limit <n>    Maximum requests to return
   --page <n>     Page number (0-based)
 
 examples:
   chrome-devtools-axi network
-  chrome-devtools-axi network --type fetch --limit 50`,
+  chrome-devtools-axi network --type fetch --limit 50
+  chrome-devtools-axi network --type all`,
 
   "network-get": `usage: chrome-devtools-axi network-get [id] [--response-file <path>] [--request-file <path>]
 Get a specific network request. If id is omitted, gets the selected request.
@@ -664,7 +675,8 @@ export function parseConsoleArgs(args: string[]): {
   const result: { types?: string[]; pageSize?: number; pageIdx?: number } = {};
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--type" && i + 1 < args.length) {
-      result.types = [args[++i]];
+      const value = args[++i];
+      if (value.toLowerCase() !== "all") result.types = [value];
     } else if (args[i] === "--limit" && i + 1 < args.length) {
       const pageSize = parseOptionalInteger(args[++i]);
       if (pageSize !== undefined) result.pageSize = pageSize;
@@ -688,7 +700,8 @@ export function parseNetworkArgs(args: string[]): {
   } = {};
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--type" && i + 1 < args.length) {
-      result.resourceTypes = [args[++i]];
+      const value = args[++i];
+      if (value.toLowerCase() !== "all") result.resourceTypes = [value];
     } else if (args[i] === "--limit" && i + 1 < args.length) {
       const pageSize = parseOptionalInteger(args[++i]);
       if (pageSize !== undefined) result.pageSize = pageSize;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { formatStopOutput, formatScreenshotOutput, getCommandHelp, parseScreenshotArgs } from "../src/cli.js";
+import {
+  formatStopOutput,
+  formatScreenshotOutput,
+  getCommandHelp,
+  parseConsoleArgs,
+  parseNetworkArgs,
+  parseScreenshotArgs,
+} from "../src/cli.js";
 
 describe("formatStopOutput", () => {
   it("returns stopped status when bridge was running", () => {
@@ -72,6 +79,22 @@ describe("parseScreenshotArgs", () => {
   it("returns null filePath when missing", () => {
     const result = parseScreenshotArgs(["--full-page"]);
     expect(result.filePath).toBeNull();
+  });
+});
+
+describe("parseConsoleArgs", () => {
+  it("clears earlier type filters when all is specified last", () => {
+    const result = parseConsoleArgs(["--type", "error", "--type", "all"]);
+
+    expect(result).toEqual({});
+  });
+});
+
+describe("parseNetworkArgs", () => {
+  it("clears earlier resource type filters when all is specified last", () => {
+    const result = parseNetworkArgs(["--type", "fetch", "--type", "all"]);
+
+    expect(result).toEqual({});
   });
 });
 

--- a/test/devtools.test.ts
+++ b/test/devtools.test.ts
@@ -65,6 +65,21 @@ describe("parseConsoleArgs", () => {
     const result = parseConsoleArgs(["--limit", "many", "--page", "later"]);
     expect(result).toEqual({});
   });
+
+  it("treats --type all as no filter", () => {
+    const result = parseConsoleArgs(["--type", "all"]);
+    expect(result).toEqual({});
+  });
+
+  it("treats --type ALL as no filter (case-insensitive)", () => {
+    const result = parseConsoleArgs(["--type", "ALL"]);
+    expect(result).toEqual({});
+  });
+
+  it("strips --type all but keeps other flags", () => {
+    const result = parseConsoleArgs(["--type", "all", "--limit", "10"]);
+    expect(result).toEqual({ pageSize: 10 });
+  });
 });
 
 describe("parseNetworkArgs", () => {
@@ -87,6 +102,84 @@ describe("parseNetworkArgs", () => {
     const result = parseNetworkArgs(["--limit", "many", "--page", "later"]);
     expect(result).toEqual({});
   });
+
+  it("treats --type all as no filter", () => {
+    const result = parseNetworkArgs(["--type", "all"]);
+    expect(result).toEqual({});
+  });
+
+  it("treats --type ALL as no filter (case-insensitive)", () => {
+    const result = parseNetworkArgs(["--type", "ALL"]);
+    expect(result).toEqual({});
+  });
+
+  it("strips --type all but keeps other flags", () => {
+    const result = parseNetworkArgs(["--type", "all", "--limit", "10"]);
+    expect(result).toEqual({ pageSize: 10 });
+  });
+});
+
+describe("console help enumerates valid --type values", () => {
+  const help = getCommandHelp("console") ?? "";
+  const expectedTypes = [
+    "log",
+    "debug",
+    "info",
+    "error",
+    "warn",
+    "dir",
+    "dirxml",
+    "table",
+    "trace",
+    "clear",
+    "startGroup",
+    "startGroupCollapsed",
+    "endGroup",
+    "assert",
+    "profile",
+    "profileEnd",
+    "count",
+    "timeEnd",
+    "verbose",
+    "issue",
+    "all",
+  ];
+  for (const type of expectedTypes) {
+    it(`mentions ${type}`, () => {
+      expect(help).toContain(type);
+    });
+  }
+});
+
+describe("network help enumerates valid --type values", () => {
+  const help = getCommandHelp("network") ?? "";
+  const expectedTypes = [
+    "document",
+    "stylesheet",
+    "image",
+    "media",
+    "font",
+    "script",
+    "texttrack",
+    "xhr",
+    "fetch",
+    "prefetch",
+    "eventsource",
+    "websocket",
+    "manifest",
+    "signedexchange",
+    "ping",
+    "cspviolationreport",
+    "preflight",
+    "fedcm",
+    "other",
+    "all",
+  ];
+  for (const type of expectedTypes) {
+    it(`mentions ${type}`, () => {
+      expect(help).toContain(type);
+    });
+  }
 });
 
 describe("parseNetworkGetArgs", () => {


### PR DESCRIPTION
## Summary
- Treat repeated `--type all` flags as last-one-wins for console and network commands by clearing earlier type filters.
- Add coverage for console message and network request filtering, including `all` behavior and valid type handling.
- Document accepted CLI type filter values in the README so users know how to request unfiltered results.

## Risk Assessment

✅ Low: The changes are narrowly scoped to CLI help text, parser handling for the sentinel --type all value, and focused regression tests, with no material issues found.

## Testing

- Summary: <code>Exercised the changed console/network `--type all` parser behavior and help text via targeted Vitest files, then ran the full Vitest suite; all tests passed.</code>
- `npm test -- test/cli.test.ts test/devtools.test.ts`
- `npm test`
- Outcome: ✅ passed across 1 run (30.3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/cli.ts:679` - `--type all` only suppresses assigning a new filter, so repeated flags do not behave like last-one-wins: `chrome-devtools-axi console --type error --type all` still sends `{ types: [&#34;error&#34;] }` instead of returning every message as the help text promises. Clear `result.types` when the value is `all`.
- ⚠️ `src/cli.ts:704` - `--type all` has the same repeated-flag issue for network requests: `chrome-devtools-axi network --type fetch --type all` leaves the earlier `resourceTypes` filter in place instead of returning every request. Clear `result.resourceTypes` when the value is `all`.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npm test -- test/cli.test.ts test/devtools.test.ts`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `README.md:169` - The CLI change adds documented behavior for `console --type all` and `network --type all` to mean no filter, including case-insensitive handling and clearing earlier `--type` filters. The README flag reference still describes `--type &lt;type&gt;` only as &#34;Filter by type (console, network)&#34; and does not mention the new `all` value or the valid console/network type sets, so users reading the project docs will miss the new public CLI behavior.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
