### PR TITLE
fix: reject stale generation-tagged refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ snapshot:
 RootWebArea "Example Domain"
   heading "Example Domain"
   paragraph "This domain is for use in illustrative examples..."
-  uid=1 link "More information..."
+  uid=g1:1 link "More information..."
 help[1]:
-  Run `chrome-devtools-axi click @1` to click the "More information..." link
+  Run `chrome-devtools-axi click @g1:1` to click the "More information..." link
 
-$ chrome-devtools-axi click @1
+$ chrome-devtools-axi click @g1:1
 page: {title: "IANA — IANA-Managed Reserved Domains", refs: 12}
 snapshot:
 ...
 ```
+
+Refs in snapshot output carry a `g<N>:` generation prefix that bumps every time a new accessibility tree is captured. Pass refs back exactly as printed - if the page re-rendered between snapshot and action, the action fails loudly with `STALE_REF` instead of silently no-op'ing, so the agent re-snapshots and retries.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,10 @@ export CHROME_DEVTOOLS_AXI_WS_HEADERS='{"Authorization":"Bearer token"}'
 
 State is stored in `~/.chrome-devtools-axi/`:
 
-| File         | Purpose                            |
-| ------------ | ---------------------------------- |
-| `bridge.pid` | PID and port of the running bridge |
+| File                  | Purpose                              |
+| --------------------- | ------------------------------------ |
+| `bridge.pid`          | PID and port of the running bridge   |
+| `snapshot-generation` | Counter used to detect stale uid refs |
 
 ### Session Hooks
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,11 +11,12 @@ import {
   stopBridge,
 } from "./client.js";
 import { bumpGeneration, getCurrentGeneration } from "./generation.js";
-import { readStdin, runScript } from "./run.js";
+import { parseEvalOutput, readStdin, runScript } from "./run.js";
 import {
   checkUidGeneration,
   countRefs,
   extractTitle,
+  parseStampedUid,
   stampSnapshotGeneration,
   truncateSnapshot,
   truncateText,
@@ -27,8 +28,14 @@ const HOME_DESCRIPTION =
 
 const VERSION = readPackageVersion();
 const RAW_STDOUT_MARKER = "__CHROME_DEVTOOLS_AXI_RAW__";
+const PAGE_GENERATION_KEY = "__chromeDevtoolsAxiSnapshotGeneration";
 
 type CliStdout = Pick<NodeJS.WriteStream, "write">;
+
+type ToolCaller = (
+  name: string,
+  args?: Record<string, unknown>,
+) => Promise<string>;
 
 export type MainOptions = {
   argv?: string[];
@@ -962,21 +969,86 @@ export function parseUid(arg: string): string {
   const current = getCurrentGeneration();
   const check = checkUidGeneration(arg, current);
   if (check.stale) {
-    const refRaw = arg.startsWith("@") ? arg.slice(1) : arg;
-    throw new CdpError(
-      `Stale ref @${refRaw}: from snapshot generation ${check.refGeneration}, current is ${current}. Re-snapshot to get fresh refs.`,
-      "STALE_REF",
-      [
-        "Run `chrome-devtools-axi snapshot` to capture current refs, then retry the action",
-      ],
-    );
+    throwStaleRef(arg, check.refGeneration, current);
   }
   return check.uid;
 }
 
 /** Tag a freshly captured snapshot with a bumped generation marker. */
-function stampFresh(snapshot: string): string {
-  return stampSnapshotGeneration(snapshot, bumpGeneration());
+async function stampFresh(snapshot: string): Promise<string> {
+  const generation = bumpGeneration();
+  await markPageSnapshotGeneration(generation);
+  return stampSnapshotGeneration(snapshot, generation);
+}
+
+function throwStaleRef(
+  arg: string,
+  refGeneration: number | null,
+  currentGeneration: number,
+): never {
+  const refRaw = arg.startsWith("@") ? arg.slice(1) : arg;
+  throw new CdpError(
+    `Stale ref @${refRaw}: from snapshot generation ${refGeneration}, current is ${currentGeneration}. Re-snapshot to get fresh refs.`,
+    "STALE_REF",
+    [
+      "Run `chrome-devtools-axi snapshot` to capture current refs, then retry the action",
+    ],
+  );
+}
+
+async function markPageSnapshotGeneration(generation: number): Promise<void> {
+  const key = JSON.stringify(PAGE_GENERATION_KEY);
+  try {
+    await callTool("evaluate_script", {
+      function: `() => {
+  const key = ${key};
+  const previous = globalThis[key];
+  if (previous && previous.observer) previous.observer.disconnect();
+  const state = { generation: ${generation}, mutations: 0, observer: null };
+  const observer = new MutationObserver(() => { state.mutations += 1; });
+  observer.observe(document.documentElement || document, { childList: true, subtree: true, attributes: true, characterData: true });
+  state.observer = observer;
+  globalThis[key] = state;
+  return state.generation;
+}`,
+    });
+  } catch {
+  }
+}
+
+async function getPageRefGeneration(caller: ToolCaller): Promise<number> {
+  const key = JSON.stringify(PAGE_GENERATION_KEY);
+  const fallback = getCurrentGeneration();
+  try {
+    const output = await caller("evaluate_script", {
+      function: `() => {
+  const state = globalThis[${key}];
+  if (!state || typeof state.generation !== 'number') return ${fallback};
+  const mutations = typeof state.mutations === 'number' ? state.mutations : 0;
+  return state.generation + mutations;
+}`,
+    });
+    const parsed = parseEvalOutput(output);
+    return typeof parsed === "number" && Number.isFinite(parsed)
+      ? parsed
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function parseUidFresh(
+  arg: string,
+  caller: ToolCaller = callTool,
+): Promise<string> {
+  const { generation } = parseStampedUid(arg);
+  const current =
+    generation === null ? getCurrentGeneration() : await getPageRefGeneration(caller);
+  const check = checkUidGeneration(arg, current);
+  if (check.stale) {
+    throwStaleRef(arg, check.refGeneration, current);
+  }
+  return check.uid;
 }
 
 function isRecoverableOpenError(error: unknown): error is CdpError {
@@ -998,10 +1070,10 @@ async function callWithSnapshot(
   const result = await callTool(name, { ...args, includeSnapshot: true });
   const snapshot = parseSnapshotFromResponse(result);
   if (snapshot && snapshot.length > 0) {
-    return stampFresh(stripSnapshotHeader(snapshot));
+    return await stampFresh(stripSnapshotHeader(snapshot));
   }
   // Fallback: take snapshot separately
-  return stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  return await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
 }
 
 const SCROLL_FUNCTIONS: Record<string, string> = {
@@ -1027,12 +1099,12 @@ async function handleOpen(args: string[], full: boolean): Promise<string> {
     }
     await callTool("new_page", { url });
   }
-  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "open", url, full);
 }
 
 async function handleSnapshot(full: boolean): Promise<string> {
-  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "snapshot", undefined, full);
 }
 
@@ -1045,7 +1117,7 @@ async function handleScreenshot(args: string[]): Promise<string> {
   }
 
   const toolArgs: Record<string, unknown> = { filePath: parsed.filePath };
-  if (parsed.uid) toolArgs.uid = parseUid(parsed.uid);
+  if (parsed.uid) toolArgs.uid = await parseUidFresh(parsed.uid);
   if (parsed.fullPage) toolArgs.fullPage = true;
   if (parsed.format) toolArgs.format = parsed.format;
 
@@ -1061,7 +1133,7 @@ async function handleClick(args: string[], full: boolean): Promise<string> {
     ]);
   }
 
-  const snapshot = await callWithSnapshot("click", { uid: parseUid(uid) });
+  const snapshot = await callWithSnapshot("click", { uid: await parseUidFresh(uid) });
   return formatPageOutput(snapshot, "click", undefined, full);
 }
 
@@ -1080,7 +1152,7 @@ async function handleFill(args: string[], full: boolean): Promise<string> {
   }
 
   const snapshot = await callWithSnapshot("fill", {
-    uid: parseUid(uid),
+    uid: await parseUidFresh(uid),
     value,
   });
   return formatPageOutput(snapshot, "fill", undefined, full);
@@ -1107,7 +1179,7 @@ async function handleType(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("type_text", { text });
-  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "type", undefined, full);
 }
 
@@ -1121,13 +1193,13 @@ async function handleScroll(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("evaluate_script", { function: fn });
-  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "scroll", undefined, full);
 }
 
 async function handleBack(full: boolean): Promise<string> {
   await callTool("navigate_page", { type: "back" });
-  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "back", undefined, full);
 }
 
@@ -1259,7 +1331,7 @@ async function handleNewPage(args: string[], full: boolean): Promise<string> {
   const toolArgs: Record<string, unknown> = { url };
   if (background) toolArgs.background = true;
   await callTool("new_page", toolArgs);
-  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "newpage", url, full);
 }
 
@@ -1280,7 +1352,7 @@ async function handleSelectPage(
     ]);
   }
   await callTool("select_page", { pageId });
-  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "selectpage", undefined, full);
 }
 
@@ -1343,7 +1415,7 @@ async function handleHover(args: string[], full: boolean): Promise<string> {
       "Run `chrome-devtools-axi hover @<uid>` — get uid from snapshot",
     ]);
   }
-  const snapshot = await callWithSnapshot("hover", { uid: parseUid(uid) });
+  const snapshot = await callWithSnapshot("hover", { uid: await parseUidFresh(uid) });
   return formatPageOutput(snapshot, "hover", undefined, full);
 }
 
@@ -1356,8 +1428,8 @@ async function handleDrag(args: string[], full: boolean): Promise<string> {
     ]);
   }
   const snapshot = await callWithSnapshot("drag", {
-    from_uid: parseUid(from),
-    to_uid: parseUid(to),
+    from_uid: await parseUidFresh(from),
+    to_uid: await parseUidFresh(to),
   });
   return formatPageOutput(snapshot, "drag", undefined, full);
 }
@@ -1369,7 +1441,9 @@ async function handleFillForm(args: string[], full: boolean): Promise<string> {
       'Run `chrome-devtools-axi fillform @1="hello" @2="world"` to fill multiple fields',
     ]);
   }
-  const validated = entries.map((e) => ({ uid: parseUid(e.uid), value: e.value }));
+  const validated = await Promise.all(
+    entries.map(async (e) => ({ uid: await parseUidFresh(e.uid), value: e.value })),
+  );
   const snapshot = await callWithSnapshot("fill_form", { elements: validated });
   return formatPageOutput(snapshot, "fillform", undefined, full);
 }
@@ -1402,7 +1476,7 @@ async function handleUpload(args: string[], full: boolean): Promise<string> {
     ]);
   }
   const snapshot = await callWithSnapshot("upload_file", {
-    uid: parseUid(uid),
+    uid: await parseUidFresh(uid),
     filePath,
   });
   return formatPageOutput(snapshot, "upload", undefined, full);
@@ -1535,7 +1609,7 @@ async function handleHome(_full: boolean): Promise<string> {
       renderHelp(["Run `chrome-devtools-axi open <url>` to start browsing"]),
     ]);
   }
-  const snapshot = stampFresh(stripSnapshotHeader(result));
+  const snapshot = await stampFresh(stripSnapshotHeader(result));
   const title = extractTitle(snapshot);
   const refs = countRefs(snapshot);
   const page: Record<string, unknown> = {};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,13 +116,15 @@ args:
   <path>  File path to save the screenshot (required)
 
 flags:
-  --uid @<uid>    Capture a specific element instead of the full viewport
+  --uid @<uid>    Capture a specific element instead of the full viewport.
+                  Refs are generation-tagged (e.g. @g3:12) - pass them back
+                  exactly as printed. A stale ref returns STALE_REF.
   --full-page     Capture the entire scrollable page
   --format <fmt>  Image format: png (default), jpeg, or webp
 
 examples:
   chrome-devtools-axi screenshot ./page.png
-  chrome-devtools-axi screenshot ./element.png --uid @3
+  chrome-devtools-axi screenshot ./element.png --uid @g1:3
   chrome-devtools-axi screenshot ./full.png --full-page --format jpeg`,
 
   snapshot: `usage: chrome-devtools-axi snapshot [--full]
@@ -154,15 +156,17 @@ examples:
 Fill a form field with text.
 
 args:
-  @<uid>  Element ref from snapshot (required)
+  @<uid>  Element ref from snapshot (required). Refs are generation-tagged
+          (e.g. @g3:12) - pass them back exactly as printed. A stale ref
+          returns a STALE_REF error so you know to re-snapshot.
   <text>  Text to fill (required)
 
 flags:
   --full  Show complete snapshot without truncation
 
 examples:
-  chrome-devtools-axi fill @3 "hello world"
-  chrome-devtools-axi fill @3 "search query" --full`,
+  chrome-devtools-axi fill @g1:3 "hello world"
+  chrome-devtools-axi fill @g2:3 "search query" --full`,
 
   type: `usage: chrome-devtools-axi type <text> [--full]
 Type text at the currently focused element.
@@ -350,39 +354,42 @@ examples:
 Hover over an element to trigger hover states.
 
 args:
-  @<uid>  Element ref from snapshot (required)
+  @<uid>  Element ref from snapshot (required). Refs are generation-tagged
+          (e.g. @g3:12) - pass them back exactly as printed. A stale ref
+          returns a STALE_REF error so you know to re-snapshot.
 
 flags:
   --full  Show complete snapshot without truncation
 
 examples:
-  chrome-devtools-axi hover @5`,
+  chrome-devtools-axi hover @g1:5`,
 
   drag: `usage: chrome-devtools-axi drag @<from> @<to> [--full]
 Drag an element onto another element.
 
 args:
-  @<from>  Element to drag (required)
-  @<to>    Element to drop onto (required)
+  @<from>  Element to drag (required). Use refs from the latest snapshot.
+  @<to>    Element to drop onto (required). Stale refs return STALE_REF.
 
 flags:
   --full  Show complete snapshot without truncation
 
 examples:
-  chrome-devtools-axi drag @3 @7`,
+  chrome-devtools-axi drag @g1:3 @g1:7`,
 
   fillform: `usage: chrome-devtools-axi fillform @<uid>=<value>... [--full]
 Fill multiple form fields at once.
 
 args:
-  @<uid>=<value>  One or more field entries (required)
+  @<uid>=<value>  One or more field entries from the latest snapshot (required).
+                  Stale refs return STALE_REF.
 
 flags:
   --full  Show complete snapshot without truncation
 
 examples:
-  chrome-devtools-axi fillform @1="hello" @2="world"
-  chrome-devtools-axi fillform @3="user@email.com" @4="password123"`,
+  chrome-devtools-axi fillform @g1:1="hello" @g1:2="world"
+  chrome-devtools-axi fillform @g2:3="user@email.com" @g2:4="password123"`,
 
   dialog: `usage: chrome-devtools-axi dialog <accept|dismiss> [text]
 Handle a browser dialog (alert, confirm, prompt).
@@ -400,14 +407,15 @@ examples:
 Upload a file through a file input element.
 
 args:
-  @<uid>  File input element ref from snapshot (required)
+  @<uid>  File input element ref from snapshot (required). Refs are
+          generation-tagged; stale refs return STALE_REF.
   <path>  Local file path to upload (required)
 
 flags:
   --full  Show complete snapshot without truncation
 
 examples:
-  chrome-devtools-axi upload @5 ./photo.jpg`,
+  chrome-devtools-axi upload @g1:5 ./photo.jpg`,
 
   // Emulation
   emulate: `usage: chrome-devtools-axi emulate [flags]
@@ -1438,7 +1446,7 @@ async function handleFillForm(args: string[], full: boolean): Promise<string> {
   const { entries } = parseFillFormArgs(args);
   if (entries.length === 0) {
     throw new CdpError("No valid field entries", "VALIDATION_ERROR", [
-      'Run `chrome-devtools-axi fillform @1="hello" @2="world"` to fill multiple fields',
+      'Run `chrome-devtools-axi fillform @g1:1="hello" @g1:2="world"` to fill multiple fields',
     ]);
   }
   const validated = await Promise.all(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,10 +10,13 @@ import {
   getSessionSnapshotIfRunning,
   stopBridge,
 } from "./client.js";
+import { bumpGeneration, getCurrentGeneration } from "./generation.js";
 import { readStdin, runScript } from "./run.js";
 import {
+  checkUidGeneration,
   countRefs,
   extractTitle,
+  stampSnapshotGeneration,
   truncateSnapshot,
   truncateText,
 } from "./snapshot.js";
@@ -129,14 +132,16 @@ examples:
 Click an interactive element by its ref from the snapshot.
 
 args:
-  @<uid>  Element ref from snapshot (required)
+  @<uid>  Element ref from snapshot (required). Refs are generation-tagged
+          (e.g. @g3:12) - pass them back exactly as printed. A stale ref
+          (older generation) returns a STALE_REF error so you know to re-snapshot.
 
 flags:
   --full  Show complete snapshot without truncation
 
 examples:
-  chrome-devtools-axi click @1
-  chrome-devtools-axi click @12 --full`,
+  chrome-devtools-axi click @g1:1
+  chrome-devtools-axi click @g2:12 --full`,
 
   fill: `usage: chrome-devtools-axi fill @<uid> <text> [--full]
 Fill a form field with text.
@@ -947,9 +952,31 @@ function stripSnapshotHeader(text: string): string {
   return text.replace(/^[\s\S]*?##\s+Latest page snapshot\s*\n/, "");
 }
 
-/** Strip leading @ from uid ref. */
-function parseUid(arg: string): string {
-  return arg.startsWith("@") ? arg.slice(1) : arg;
+/**
+ * Strip the `@` prefix and any generation tag from a uid ref, validating
+ * that the tag (if present) matches the current snapshot generation. A
+ * stale tag throws a loud STALE_REF error rather than letting a silent
+ * no-op fall through to upstream MCP.
+ */
+export function parseUid(arg: string): string {
+  const current = getCurrentGeneration();
+  const check = checkUidGeneration(arg, current);
+  if (check.stale) {
+    const refRaw = arg.startsWith("@") ? arg.slice(1) : arg;
+    throw new CdpError(
+      `Stale ref @${refRaw}: from snapshot generation ${check.refGeneration}, current is ${current}. Re-snapshot to get fresh refs.`,
+      "STALE_REF",
+      [
+        "Run `chrome-devtools-axi snapshot` to capture current refs, then retry the action",
+      ],
+    );
+  }
+  return check.uid;
+}
+
+/** Tag a freshly captured snapshot with a bumped generation marker. */
+function stampFresh(snapshot: string): string {
+  return stampSnapshotGeneration(snapshot, bumpGeneration());
 }
 
 function isRecoverableOpenError(error: unknown): error is CdpError {
@@ -970,9 +997,11 @@ async function callWithSnapshot(
 ): Promise<string> {
   const result = await callTool(name, { ...args, includeSnapshot: true });
   const snapshot = parseSnapshotFromResponse(result);
-  if (snapshot && snapshot.length > 0) return stripSnapshotHeader(snapshot);
+  if (snapshot && snapshot.length > 0) {
+    return stampFresh(stripSnapshotHeader(snapshot));
+  }
   // Fallback: take snapshot separately
-  return stripSnapshotHeader(await callTool("take_snapshot"));
+  return stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
 }
 
 const SCROLL_FUNCTIONS: Record<string, string> = {
@@ -998,12 +1027,12 @@ async function handleOpen(args: string[], full: boolean): Promise<string> {
     }
     await callTool("new_page", { url });
   }
-  const snapshot = stripSnapshotHeader(await callTool("take_snapshot"));
+  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "open", url, full);
 }
 
 async function handleSnapshot(full: boolean): Promise<string> {
-  const snapshot = stripSnapshotHeader(await callTool("take_snapshot"));
+  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "snapshot", undefined, full);
 }
 
@@ -1016,7 +1045,7 @@ async function handleScreenshot(args: string[]): Promise<string> {
   }
 
   const toolArgs: Record<string, unknown> = { filePath: parsed.filePath };
-  if (parsed.uid) toolArgs.uid = parsed.uid;
+  if (parsed.uid) toolArgs.uid = parseUid(parsed.uid);
   if (parsed.fullPage) toolArgs.fullPage = true;
   if (parsed.format) toolArgs.format = parsed.format;
 
@@ -1078,7 +1107,7 @@ async function handleType(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("type_text", { text });
-  const snapshot = stripSnapshotHeader(await callTool("take_snapshot"));
+  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "type", undefined, full);
 }
 
@@ -1092,13 +1121,13 @@ async function handleScroll(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("evaluate_script", { function: fn });
-  const snapshot = stripSnapshotHeader(await callTool("take_snapshot"));
+  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "scroll", undefined, full);
 }
 
 async function handleBack(full: boolean): Promise<string> {
   await callTool("navigate_page", { type: "back" });
-  const snapshot = stripSnapshotHeader(await callTool("take_snapshot"));
+  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "back", undefined, full);
 }
 
@@ -1230,7 +1259,7 @@ async function handleNewPage(args: string[], full: boolean): Promise<string> {
   const toolArgs: Record<string, unknown> = { url };
   if (background) toolArgs.background = true;
   await callTool("new_page", toolArgs);
-  const snapshot = stripSnapshotHeader(await callTool("take_snapshot"));
+  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "newpage", url, full);
 }
 
@@ -1251,7 +1280,7 @@ async function handleSelectPage(
     ]);
   }
   await callTool("select_page", { pageId });
-  const snapshot = stripSnapshotHeader(await callTool("take_snapshot"));
+  const snapshot = stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
   return formatPageOutput(snapshot, "selectpage", undefined, full);
 }
 
@@ -1340,7 +1369,8 @@ async function handleFillForm(args: string[], full: boolean): Promise<string> {
       'Run `chrome-devtools-axi fillform @1="hello" @2="world"` to fill multiple fields',
     ]);
   }
-  const snapshot = await callWithSnapshot("fill_form", { elements: entries });
+  const validated = entries.map((e) => ({ uid: parseUid(e.uid), value: e.value }));
+  const snapshot = await callWithSnapshot("fill_form", { elements: validated });
   return formatPageOutput(snapshot, "fillform", undefined, full);
 }
 
@@ -1505,7 +1535,7 @@ async function handleHome(_full: boolean): Promise<string> {
       renderHelp(["Run `chrome-devtools-axi open <url>` to start browsing"]),
     ]);
   }
-  const snapshot = stripSnapshotHeader(result);
+  const snapshot = stampFresh(stripSnapshotHeader(result));
   const title = extractTitle(snapshot);
   const refs = countRefs(snapshot);
   const page: Record<string, unknown> = {};

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,6 +36,7 @@ export function resolveBridgeTimeoutMs(): number {
 export type ErrorCode =
   | "BRIDGE_NOT_READY"
   | "REF_NOT_FOUND"
+  | "STALE_REF"
   | "TIMEOUT"
   | "BROWSER_ERROR"
   | "VALIDATION_ERROR"

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -1,0 +1,51 @@
+/**
+ * Snapshot generation persistence. The counter survives across CLI
+ * invocations (which are short-lived processes sharing one bridge) by
+ * writing to a file in STATE_DIR. Each new snapshot bumps the counter,
+ * so refs minted in older snapshots can be detected as stale.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
+const GEN_FILE = join(STATE_DIR, "snapshot-generation");
+
+export function getCurrentGeneration(): number {
+  try {
+    if (!existsSync(GEN_FILE)) return 0;
+    const parsed = Number.parseInt(readFileSync(GEN_FILE, "utf-8").trim(), 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  } catch {
+    return 0;
+  }
+}
+
+export function bumpGeneration(): number {
+  const next = getCurrentGeneration() + 1;
+  try {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(GEN_FILE, String(next));
+  } catch {
+    // Best-effort: a write failure still returns the bumped value so the
+    // current invocation behaves consistently. The next process will
+    // re-read the on-disk value (potentially the prior one) and the
+    // worst case is one missed stale-ref detection, not a hang.
+  }
+  return next;
+}
+
+export function resetGeneration(): void {
+  try {
+    if (existsSync(GEN_FILE)) unlinkSync(GEN_FILE);
+  } catch {
+    // ignore
+  }
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import { mkdtempSync, writeFileSync, unlinkSync, rmdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CdpError } from "./client.js";
+import { parseStampedUid } from "./snapshot.js";
 
 type CallTool = (
   name: string,
@@ -49,7 +50,7 @@ function stripSnapshotHeader(text: string): string {
 
 /** Strip leading @ from uid ref string. */
 function parseUid(ref: string): string {
-  return ref.startsWith("@") ? ref.slice(1) : ref;
+  return parseStampedUid(ref).uid;
 }
 
 /** Check if an open error is recoverable by falling back to new_page. */
@@ -63,7 +64,7 @@ function isRecoverableOpenError(error: unknown): boolean {
 
 // --- Selector detection ---
 
-const UID_RE = /^@?\d[\d_]*$/;
+const UID_RE = /^@?(?:\d[\d_]*|g\d+:.+)$/;
 
 /** Returns true when the string looks like a @uid ref (e.g. "@12", "26_181"). */
 export function isUidRef(s: string): boolean {

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -21,6 +21,69 @@ export function extractRefs(snapshot: string): RefInfo[] {
   return refs;
 }
 
+export interface ParsedUid {
+  /** The raw upstream uid (without @ prefix and without generation tag). */
+  uid: string;
+  /** The snapshot generation the ref was minted in, or null if untagged (legacy). */
+  generation: number | null;
+}
+
+/**
+ * Parse a uid argument that may carry an `@` prefix and/or a generation tag.
+ * Examples: `@g7:237_15` -> { uid: "237_15", generation: 7 }
+ *           `@237_15`    -> { uid: "237_15", generation: null }
+ *           `g3:abc`     -> { uid: "abc", generation: 3 }
+ */
+export function parseStampedUid(arg: string): ParsedUid {
+  const stripped = arg.startsWith("@") ? arg.slice(1) : arg;
+  const m = stripped.match(/^g(\d+):(.+)$/);
+  if (m) return { uid: m[2], generation: Number.parseInt(m[1], 10) };
+  return { uid: stripped, generation: null };
+}
+
+/**
+ * Rewrite every `uid=<id>` token in snapshot text to carry a generation tag,
+ * e.g. `uid=237_15` -> `uid=g7:237_15`. Already-stamped tokens are left alone
+ * so this is idempotent. Agents detect re-render churn by feeding tagged refs
+ * back to action commands - mismatched generations fail loudly instead of
+ * silently no-op'ing against a stale tree.
+ */
+export function stampSnapshotGeneration(
+  snapshot: string,
+  generation: number,
+): string {
+  return snapshot.replace(/\buid=(\S+)/g, (match, uid: string) => {
+    if (/^g\d+:/.test(uid)) return match;
+    return `uid=g${generation}:${uid}`;
+  });
+}
+
+export interface UidCheckResult {
+  /** The raw upstream uid (no @ prefix, no generation tag). */
+  uid: string;
+  /** True when the ref carries a generation tag that does not match current. */
+  stale: boolean;
+  /** The generation embedded in the ref, or null if the ref was untagged. */
+  refGeneration: number | null;
+}
+
+/**
+ * Pure validation: given a ref argument and the current snapshot generation,
+ * return the upstream uid plus whether the ref is stale. Untagged refs are
+ * accepted (legacy compatibility) and reported as not-stale.
+ */
+export function checkUidGeneration(
+  arg: string,
+  currentGeneration: number,
+): UidCheckResult {
+  const { uid, generation } = parseStampedUid(arg);
+  return {
+    uid,
+    stale: generation !== null && generation !== currentGeneration,
+    refGeneration: generation,
+  };
+}
+
 /** Extract page title from snapshot (RootWebArea or first heading). */
 export function extractTitle(snapshot: string): string {
   const rootMatch = snapshot.match(/RootWebArea\s+"([^"]+)"/);

--- a/test/interaction.test.ts
+++ b/test/interaction.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { getCommandHelp, parseFillFormArgs } from "../src/cli.js";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { getCommandHelp, parseFillFormArgs, parseUid } from "../src/cli.js";
+import * as generation from "../src/generation.js";
 
 describe("getCommandHelp", () => {
   it("returns non-null for hover", () => {
@@ -65,5 +66,47 @@ describe("parseFillFormArgs", () => {
   it("handles empty args array", () => {
     const result = parseFillFormArgs([]);
     expect(result.entries).toEqual([]);
+  });
+});
+
+describe("parseUid (generation validation)", () => {
+  beforeEach(() => {
+    vi.spyOn(generation, "getCurrentGeneration").mockReturnValue(7);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the bare uid for a fresh generation-tagged ref", () => {
+    expect(parseUid("@g7:237_15")).toBe("237_15");
+  });
+
+  it("returns the bare uid for an untagged legacy ref", () => {
+    expect(parseUid("@237_15")).toBe("237_15");
+  });
+
+  it("throws STALE_REF on an older-generation ref", () => {
+    let caught: unknown;
+    try {
+      parseUid("@g3:237_15");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const e = caught as Error & { code?: string };
+    expect(e.code).toBe("STALE_REF");
+    expect(e.message).toContain("generation 3");
+    expect(e.message).toContain("current is 7");
+    expect(e.message).toContain("@g3:237_15");
+  });
+
+  it("throws STALE_REF on a newer-generation ref (defensive)", () => {
+    expect(() => parseUid("@g9:237_15")).toThrow(/Stale ref/);
+  });
+
+  it("works without an @ prefix on the input", () => {
+    expect(parseUid("g7:abc")).toBe("abc");
+    expect(() => parseUid("g4:abc")).toThrow(/Stale ref/);
   });
 });

--- a/test/interaction.test.ts
+++ b/test/interaction.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import { getCommandHelp, parseFillFormArgs, parseUid } from "../src/cli.js";
+import {
+  getCommandHelp,
+  parseFillFormArgs,
+  parseUid,
+  parseUidFresh,
+} from "../src/cli.js";
 import * as generation from "../src/generation.js";
 
 describe("getCommandHelp", () => {
@@ -108,5 +113,25 @@ describe("parseUid (generation validation)", () => {
   it("works without an @ prefix on the input", () => {
     expect(parseUid("g7:abc")).toBe("abc");
     expect(() => parseUid("g4:abc")).toThrow(/Stale ref/);
+  });
+});
+
+describe("parseUidFresh", () => {
+  beforeEach(() => {
+    vi.spyOn(generation, "getCurrentGeneration").mockReturnValue(7);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws STALE_REF when page mutations advance the current ref generation", async () => {
+    const callTool = vi.fn().mockResolvedValue(
+      'Script ran on page and returned:\n```json\n8\n```',
+    );
+
+    await expect(parseUidFresh("@g7:237_15", callTool)).rejects.toMatchObject({
+      code: "STALE_REF",
+    });
   });
 });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -104,6 +104,10 @@ describe("main", () => {
       ["navigate_page", { type: "url", url: "https://airlockhq.com" }],
       ["new_page", { url: "https://airlockhq.com" }],
       ["take_snapshot"],
+      [
+        "evaluate_script",
+        { function: expect.stringContaining("__chromeDevtoolsAxiSnapshotGeneration") },
+      ],
     ]);
     expect(String(write.mock.calls[0]?.[0])).toContain("title: Airlock");
     expect(String(write.mock.calls[0]?.[0])).toContain(

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -244,6 +244,15 @@ describe("createPageHelper", () => {
     expect(callTool).toHaveBeenCalledWith("click", { uid: "5" });
   });
 
+  it("page.click accepts stamped uid refs", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.click("@g7:12_3");
+
+    expect(callTool).toHaveBeenCalledWith("click", { uid: "12_3" });
+  });
+
   it("page.click with CSS selector uses evaluate_script", async () => {
     callTool.mockResolvedValueOnce("");
 
@@ -273,6 +282,15 @@ describe("createPageHelper", () => {
 
     const page = createPageHelper(callTool);
     await page.fill("@3", "hello");
+
+    expect(callTool).toHaveBeenCalledWith("fill", { uid: "3", value: "hello" });
+  });
+
+  it("page.fill accepts stamped uid refs", async () => {
+    callTool.mockResolvedValueOnce("");
+
+    const page = createPageHelper(callTool);
+    await page.fill("@g7:3", "hello");
 
     expect(callTool).toHaveBeenCalledWith("fill", { uid: "3", value: "hello" });
   });
@@ -488,6 +506,11 @@ describe("isUidRef", () => {
   it("recognizes bare numeric refs", () => {
     expect(isUidRef("5")).toBe(true);
     expect(isUidRef("26_181")).toBe(true);
+  });
+
+  it("recognizes generation-stamped refs", () => {
+    expect(isUidRef("@g7:12")).toBe(true);
+    expect(isUidRef("g7:12_3")).toBe(true);
   });
 
   it("rejects CSS selectors", () => {

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
+  checkUidGeneration,
   countRefs,
   extractRefs,
   extractTitle,
   isInputType,
+  parseStampedUid,
+  stampSnapshotGeneration,
   truncateSnapshot,
   truncateText,
 } from "../src/snapshot.js";
@@ -149,5 +152,77 @@ describe("truncateText", () => {
     expect(result.text).toBe(text);
     expect(result.truncated).toBe(false);
     expect(result.totalLength).toBe(120);
+  });
+});
+
+describe("parseStampedUid", () => {
+  it("strips leading @ and returns null generation for untagged refs", () => {
+    expect(parseStampedUid("@237_15")).toEqual({
+      uid: "237_15",
+      generation: null,
+    });
+  });
+
+  it("returns generation when ref carries g<N>: prefix", () => {
+    expect(parseStampedUid("@g7:237_15")).toEqual({
+      uid: "237_15",
+      generation: 7,
+    });
+  });
+
+  it("works without leading @", () => {
+    expect(parseStampedUid("g3:abc")).toEqual({ uid: "abc", generation: 3 });
+  });
+
+  it("treats malformed gN-only ref (no colon) as untagged", () => {
+    expect(parseStampedUid("@g7")).toEqual({ uid: "g7", generation: null });
+  });
+});
+
+describe("stampSnapshotGeneration", () => {
+  it("rewrites uid= tokens with the given generation", () => {
+    const snapshot = `RootWebArea "Page"
+  uid=1 button "OK"
+  uid=237_15 link "Home"`;
+    const stamped = stampSnapshotGeneration(snapshot, 7);
+    expect(stamped).toContain("uid=g7:1");
+    expect(stamped).toContain("uid=g7:237_15");
+    expect(stamped).not.toMatch(/\buid=1\b/);
+  });
+
+  it("is idempotent on already-stamped refs", () => {
+    const snapshot = `  uid=g3:5 button "OK"`;
+    const stamped = stampSnapshotGeneration(snapshot, 9);
+    // Existing g3: tag is preserved; not re-stamped.
+    expect(stamped).toContain("uid=g3:5");
+    expect(stamped).not.toContain("uid=g9:");
+  });
+
+  it("preserves the rest of the line when stamping", () => {
+    const snapshot = `  uid=42 textbox "Name"`;
+    const stamped = stampSnapshotGeneration(snapshot, 1);
+    expect(stamped).toBe(`  uid=g1:42 textbox "Name"`);
+  });
+});
+
+describe("checkUidGeneration", () => {
+  it("flags refs from older generations as stale", () => {
+    const result = checkUidGeneration("@g3:5", 7);
+    expect(result).toEqual({ uid: "5", stale: true, refGeneration: 3 });
+  });
+
+  it("flags refs from newer generations as stale (defensive)", () => {
+    const result = checkUidGeneration("@g9:5", 7);
+    expect(result.stale).toBe(true);
+  });
+
+  it("accepts refs that match current generation", () => {
+    const result = checkUidGeneration("@g7:abc", 7);
+    expect(result).toEqual({ uid: "abc", stale: false, refGeneration: 7 });
+  });
+
+  it("accepts untagged legacy refs as not stale", () => {
+    const result = checkUidGeneration("@5", 7);
+    expect(result).toEqual({ uid: "5", stale: false, refGeneration: null });
   });
 });


### PR DESCRIPTION
## Summary
- Stamp snapshot element refs with a persisted generation so CLI interactions can detect and reject stale refs instead of silently no-oping after page changes.
- Update click, fill, hover, drag, upload, screenshot, and run-helper ref handling to accept generation-tagged refs consistently.
- Document the new ref format and persisted snapshot-generation state, with tests covering stale and tagged ref behavior.

## Risk Assessment

⚠️ Medium: The change is reasonably bounded and previous stale-ref issues appear addressed, but it touches most browser interaction commands and adds page-level mutation tracking plus persisted generation state, so integration behavior still warrants pipeline coverage.

## Testing

- Summary: Exercised the generation-stamped snapshot ref parsing, stale-ref validation, affected CLI interactions, and the full Vitest suite; all completed successfully.
- `npm test -- test/snapshot.test.ts test/interaction.test.ts test/run.test.ts test/main.test.ts`
- `npm test`
- Outcome: ✅ passed across 1 run (31.1s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `src/cli.ts:962` - The stale-ref check only compares against the last generation written by this CLI, so refs from the latest snapshot are still accepted after the page changes without another stamped snapshot, such as a timer-driven re-render, `wait`, or mutating `eval`. That leaves the original silent no-op failure mode in place for a common stale-ref path despite the new `STALE_REF` contract.
- ⚠️ `src/snapshot.ts:57` - Stamping printed refs as `g&lt;N&gt;:&lt;uid&gt;` changes the public ref format, but the `run` helper still only treats numeric refs as uids, so `page.click(&#34;@g1:1&#34;)` or `page.fill(&#34;@g1:1&#34;, ...)` will be handled as CSS selectors instead of DevTools refs.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npm test -- test/snapshot.test.ts test/interaction.test.ts test/run.test.ts test/main.test.ts`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 7 issues found → auto-fixed</summary>

**Round 1** - found 7 warnings
- ⚠️ `src/cli.ts:112` - The `screenshot --uid` command help still documents/examples untagged refs (`@3`) and does not explain that element refs in current snapshots are generation-tagged and may raise `STALE_REF`. Update this help section to match the new ref format and stale-ref behavior, like the updated `click` help.
- ⚠️ `src/cli.ts:153` - The `fill` command help still documents/examples untagged refs (`@3`) and does not mention passing generation-tagged refs back exactly as printed or the `STALE_REF` failure mode introduced for stale refs.
- ⚠️ `src/cli.ts:349` - The `hover` command help still documents/examples untagged refs (`@5`) and omits the new generation-tagged ref and `STALE_REF` behavior now applied before invoking the MCP hover action.
- ⚠️ `src/cli.ts:361` - The `drag` command help still documents/examples untagged refs (`@3 @7`) and omits that both refs should be generation-tagged refs from the latest snapshot or the command can fail with `STALE_REF`.
- ⚠️ `src/cli.ts:374` - The `fillform` command help still documents/examples untagged refs (`@1`, `@2`, etc.) and does not describe generation-tagged field refs or stale-ref errors for multi-field form fills.
- ⚠️ `src/cli.ts:399` - The `upload` command help still documents/examples an untagged file-input ref (`@5`) and omits that refs from snapshot output are now generation-tagged and stale refs raise `STALE_REF`.
- ⚠️ `README.md:209` - The state-file documentation lists only `bridge.pid`, but the change adds persistent snapshot generation state at `~/.chrome-devtools-axi/snapshot-generation`. Add this file to the state table so users understand the new persisted state used for stale-ref detection.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
