### PR TITLE
fix: handle function eval input wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Execute `npx -y chrome-devtools-axi` to get browser automation tools.
 | `eval <js>`       | Evaluate a JavaScript expression or function |
 | `run`             | Execute a multi-step script from stdin       |
 
-`eval` wraps plain input as `() => (<expr>)` before sending it to DevTools. For multi-statement logic, pass an arrow function, `function`, or IIFE yourself.
+`eval` wraps plain input as `() => (<expr>)` before sending it to DevTools. For multi-statement logic, pass an arrow function or `function`. No-arg IIFE form `(...)()` is accepted too and unwrapped automatically.
 
 ```sh
 chrome-devtools-axi eval "document.title"
-chrome-devtools-axi eval "(() => { const rows = [...document.querySelectorAll('tr')]; return rows.map((row) => row.textContent) })()"
+chrome-devtools-axi eval "() => { const rows = [...document.querySelectorAll('tr')]; return rows.map((row) => row.textContent) }"
 ```
 
 ### Interaction

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,14 @@ import {
   stopBridge,
 } from "./client.js";
 import { bumpGeneration, getCurrentGeneration } from "./generation.js";
-import { parseEvalOutput, readStdin, runScript } from "./run.js";
+import {
+  parseEvalOutput,
+  readStdin,
+  runScript,
+  wrapJsExpression,
+} from "./run.js";
+
+export { wrapJsExpression };
 import {
   checkUidGeneration,
   countRefs,
@@ -230,8 +237,9 @@ examples:
 
   eval: `usage: chrome-devtools-axi eval <js>
 Evaluate a JavaScript expression in the page context and return the result.
-The input is wrapped as () => (<js>), so it must be a single expression.
-For multi-statement logic, pass an arrow function or IIFE.
+A bare expression is wrapped as () => (<js>); pass a function (arrow or
+function-keyword) for multi-statement logic. No-arg IIFE form (...)() is
+also accepted and unwrapped automatically.
 
 args:
   <js>  JavaScript expression (required)
@@ -239,7 +247,7 @@ args:
 examples:
   chrome-devtools-axi eval "document.title"
   chrome-devtools-axi eval "document.querySelectorAll('a').length"
-  chrome-devtools-axi eval "(() => { const rows = [...document.querySelectorAll('tr')]; return rows.map(r => r.textContent) })()"`,
+  chrome-devtools-axi eval "() => { const rows = [...document.querySelectorAll('tr')]; return rows.map(r => r.textContent) }"`,
 
   run: `usage: chrome-devtools-axi run <<'EOF'
   ...script...
@@ -1253,19 +1261,6 @@ async function handleWait(args: string[]): Promise<string> {
   const suggestions = getSuggestions({ command: "wait" });
   if (suggestions.length > 0) blocks.push(renderHelp(suggestions));
   return renderOutput(blocks);
-}
-
-/** Wrap plain JS expressions for MCP evaluate_script, but pass functions through unchanged. */
-export function wrapJsExpression(js: string): string {
-  const trimmed = js.trim();
-  if (
-    /^(async\s*)?(\(.*?\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>|function[\s*(])/.test(
-      trimmed,
-    )
-  ) {
-    return trimmed;
-  }
-  return `() => (${trimmed})`;
 }
 
 /** Extract the actual value from MCP evaluate_script response. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -273,6 +273,7 @@ script API (available as global \`page\`):
   await page.back()                 Navigate back
 
 click and fill accept either @uid refs (from snapshot) or CSS selectors.
+page.eval accepts functions, arrow functions, and bare expression strings; no-arg IIFE strings are unwrapped automatically.
 
 examples:
   chrome-devtools-axi run <<'EOF'

--- a/src/run.ts
+++ b/src/run.ts
@@ -16,6 +16,68 @@ type CallTool = (
   args?: Record<string, unknown>,
 ) => Promise<string>;
 
+// --- JS expression wrapping ---
+
+/**
+ * If `s` is a no-arg IIFE of the form `(<fn-expr>)()`, return `<fn-expr>`.
+ * Returns `s` unchanged otherwise. Walks parens with depth-tracking and
+ * skips string literals so nested parens inside strings don't fool us.
+ *
+ * Conservative: only unwraps when the trailing call is `()` (empty args),
+ * which covers the common documented IIFE form.
+ */
+function unwrapNoArgIIFE(s: string): string {
+  if (s.length < 4 || s[0] !== "(" || !s.endsWith(")")) return s;
+  let depth = 0;
+  let inString: string | null = null;
+  let escape = false;
+  let closeIdx = -1;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (c === "\\") {
+        escape = true;
+        continue;
+      }
+      if (c === inString) inString = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      inString = c;
+      continue;
+    }
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) {
+        closeIdx = i;
+        break;
+      }
+    }
+  }
+  if (closeIdx < 0) return s;
+  const rest = s.slice(closeIdx + 1).trim();
+  if (rest !== "()") return s;
+  return s.slice(1, closeIdx).trim();
+}
+
+/** Wrap plain JS expressions for MCP evaluate_script, but pass functions through unchanged. */
+export function wrapJsExpression(js: string): string {
+  const trimmed = unwrapNoArgIIFE(js.trim());
+  if (
+    /^(async\s*)?(\(.*?\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>|function[\s*(])/.test(
+      trimmed,
+    )
+  ) {
+    return trimmed;
+  }
+  return `() => (${trimmed})`;
+}
+
 // --- Value parsing ---
 
 /** Extract the actual JS value from MCP evaluate_script response wrapper. */
@@ -129,7 +191,7 @@ export function createPageHelper(callTool: CallTool): PageHelper {
       const fn =
         typeof jsOrFn === "function"
           ? String(jsOrFn)
-          : `() => (${jsOrFn.trim()})`;
+          : wrapJsExpression(jsOrFn);
       return evalJs(fn);
     },
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -27,13 +27,16 @@ type CallTool = (
  * which covers the common documented IIFE form.
  */
 function unwrapNoArgIIFE(s: string): string {
-  if (s.length < 4 || s[0] !== "(" || !s.endsWith(")")) return s;
+  const candidate = s.endsWith(";") ? s.slice(0, -1).trimEnd() : s;
+  if (candidate.length < 4 || candidate[0] !== "(" || !candidate.endsWith(")")) {
+    return s;
+  }
   let depth = 0;
   let inString: string | null = null;
   let escape = false;
   let closeIdx = -1;
-  for (let i = 0; i < s.length; i++) {
-    const c = s[i];
+  for (let i = 0; i < candidate.length; i++) {
+    const c = candidate[i];
     if (escape) {
       escape = false;
       continue;
@@ -60,9 +63,9 @@ function unwrapNoArgIIFE(s: string): string {
     }
   }
   if (closeIdx < 0) return s;
-  const rest = s.slice(closeIdx + 1).trim();
+  const rest = candidate.slice(closeIdx + 1).trim();
   if (rest !== "()") return s;
-  const inner = s.slice(1, closeIdx).trim();
+  const inner = candidate.slice(1, closeIdx).trim();
   if (
     /^(async\s*)?(\(.*?\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>|function[\s*(])/.test(
       inner,

--- a/src/run.ts
+++ b/src/run.ts
@@ -62,7 +62,15 @@ function unwrapNoArgIIFE(s: string): string {
   if (closeIdx < 0) return s;
   const rest = s.slice(closeIdx + 1).trim();
   if (rest !== "()") return s;
-  return s.slice(1, closeIdx).trim();
+  const inner = s.slice(1, closeIdx).trim();
+  if (
+    /^(async\s*)?(\(.*?\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>|function[\s*(])/.test(
+      inner,
+    )
+  ) {
+    return inner;
+  }
+  return s;
 }
 
 /** Wrap plain JS expressions for MCP evaluate_script, but pass functions through unchanged. */

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -70,9 +70,9 @@ export function getSuggestions(ctx: SuggestionContext): string[] {
     lines.push("Run `chrome-devtools-axi scroll down` to scroll down");
   }
 
-  // Teach eval syntax — use IIFE for multi-statement logic
+  // Teach eval syntax - pass a function for multi-statement logic
   lines.push(
-    'Use `chrome-devtools-axi eval <expr>` for JS expressions. For multi-statement code, wrap in an IIFE: `eval "(() => { ...; return result })()"`',
+    'Use `chrome-devtools-axi eval <expr>` for JS expressions. For multi-statement code, pass a function: `eval "() => { ...; return result }"`',
   );
 
   return lines;

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -492,6 +492,61 @@ describe("page.eval variants", () => {
     const fn = callTool.mock.calls[0][1].function;
     expect(fn).toContain("() => []");
   });
+
+  it("unwraps an arrow IIFE so MCP receives a function (not a value)", async () => {
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\n42\n```",
+    );
+
+    const page = createPageHelper(callTool);
+    const result = await page.eval("(() => 42)()");
+
+    // The function passed to MCP should be a callable arrow, not the IIFE
+    // double-wrapped as `() => ((() => 42)())`.
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: "() => 42",
+    });
+    expect(result).toBe(42);
+  });
+
+  it("unwraps a multi-statement arrow IIFE", async () => {
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\n6\n```",
+    );
+
+    const page = createPageHelper(callTool);
+    await page.eval("(() => { const x = 5; return x + 1 })()");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: "() => { const x = 5; return x + 1 }",
+    });
+  });
+
+  it("unwraps an async arrow IIFE", async () => {
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\n7\n```",
+    );
+
+    const page = createPageHelper(callTool);
+    await page.eval("(async () => 7)()");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: "async () => 7",
+    });
+  });
+
+  it("passes a bare arrow string through unchanged", async () => {
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\n42\n```",
+    );
+
+    const page = createPageHelper(callTool);
+    await page.eval("() => 42");
+
+    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
+      function: "() => 42",
+    });
+  });
 });
 
 // --- 10. isUidRef detection ---

--- a/test/wrap-js.test.ts
+++ b/test/wrap-js.test.ts
@@ -34,6 +34,10 @@ describe("wrapJsExpression", () => {
     expect(wrapJsExpression("(() => 42)()")).toBe("() => 42");
   });
 
+  it("unwraps a simple arrow IIFE with a trailing semicolon", () => {
+    expect(wrapJsExpression("(() => 42)();")).toBe("() => 42");
+  });
+
   it("unwraps a multi-statement arrow IIFE", () => {
     expect(wrapJsExpression("(() => { const x = 5; return x + 1 })()")).toBe(
       "() => { const x = 5; return x + 1 }",

--- a/test/wrap-js.test.ts
+++ b/test/wrap-js.test.ts
@@ -56,4 +56,14 @@ describe("wrapJsExpression", () => {
       "() => ((x => x + 1)(5))",
     );
   });
+
+  it("wraps a parenthesized property call", () => {
+    expect(wrapJsExpression("(window.getValue)()")).toBe(
+      "() => ((window.getValue)())",
+    );
+  });
+
+  it("wraps a parenthesized method call", () => {
+    expect(wrapJsExpression("(obj.method)()")).toBe("() => ((obj.method)())");
+  });
 });

--- a/test/wrap-js.test.ts
+++ b/test/wrap-js.test.ts
@@ -29,4 +29,31 @@ describe("wrapJsExpression", () => {
       "() => (document.querySelectorAll('a').length)",
     );
   });
+
+  it("unwraps a simple arrow IIFE to the inner function", () => {
+    expect(wrapJsExpression("(() => 42)()")).toBe("() => 42");
+  });
+
+  it("unwraps a multi-statement arrow IIFE", () => {
+    expect(wrapJsExpression("(() => { const x = 5; return x + 1 })()")).toBe(
+      "() => { const x = 5; return x + 1 }",
+    );
+  });
+
+  it("unwraps an async arrow IIFE", () => {
+    expect(wrapJsExpression("(async () => 7)()")).toBe("async () => 7");
+  });
+
+  it("unwraps a function-keyword IIFE", () => {
+    expect(wrapJsExpression("(function() { return 1 })()")).toBe(
+      "function() { return 1 }",
+    );
+  });
+
+  it("wraps an IIFE with non-empty args (conservative: only () unwraps)", () => {
+    // Not a no-arg IIFE — wrap so MCP can call it as a function and get the value.
+    expect(wrapJsExpression("(x => x + 1)(5)")).toBe(
+      "() => ((x => x + 1)(5))",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Update eval/page helper wrapping to pass function and arrow inputs through while preserving supported no-arg IIFE compatibility.
- Fix IIFE unwrapping edge cases for parenthesized calls and trailing semicolons so non-function calls are not rewritten incorrectly.
- Align README, CLI help, and suggestions with the preferred direct function/arrow eval guidance.

## Risk Assessment

✅ Low: The change is narrowly scoped to JavaScript expression wrapping for eval/run helpers, includes targeted coverage for prior edge cases, and does not introduce broad control-flow or integration changes.

## Testing

- Summary: Exercised the new JavaScript wrapping/IIFE behavior directly and then the full Vitest suite; all tests passed.
- `npm test -- test/run.test.ts test/wrap-js.test.ts`
- `npm test`
- Outcome: ✅ passed across 1 run (30.5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/run.ts:64` - `unwrapNoArgIIFE` unwraps every parenthesized no-arg call before confirming the inner expression is actually a function literal. Valid eval inputs such as `(window.getValue)()` or `(obj.method)()` are now converted into `() =&gt; (window.getValue)`/`() =&gt; (obj.method)`, so the function is returned instead of invoked. Only unwrap when the inner expression matches the supported function forms; otherwise preserve the original expression wrapping.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/run.ts:63` - No-arg IIFEs with a trailing semicolon, such as `(() =&gt; 1)();`, are not unwrapped because `rest` must be exactly `()`. After that, the existing function-detection regex still treats the original string as a function and sends the IIFE text to `evaluate_script`, so a common copy-pasted IIFE form remains broken despite the new documented support. Accept `();` here, or strip trailing semicolons before checking the no-arg call.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npm test -- test/run.test.ts test/wrap-js.test.ts`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `src/suggestions.ts:75` - The user-facing eval tip still teaches multi-statement code by recommending an IIFE as the primary pattern. The change updates eval handling to pass arrow/function inputs through and unwrap no-arg IIFEs, and README/command help now document direct arrow/function input as the preferred multi-statement form with IIFE as accepted compatibility. Update this suggestion and its comment to match the new guidance.
- ℹ️ `src/cli.ts:241` - The run command&#39;s public script API help lists `await page.eval(jsOrFn)` but does not document that string inputs now use the same wrapping rules as the CLI eval command, including function passthrough and no-arg IIFE unwrapping. Since this change explicitly modifies `page.eval` behavior in `createPageHelper`, the run help should mention the accepted string/function forms or point to the eval syntax rules.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
