### PR TITLE
feat(cli): add explicit hook setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ chrome-devtools-axi eval "() => { const rows = [...document.querySelectorAll('tr
 
 ### Bridge
 
-| Command | Description             |
-| ------- | ----------------------- |
-| `start` | Start the bridge server |
-| `stop`  | Stop the bridge server  |
+| Command       | Description                         |
+| ------------- | ----------------------------------- |
+| `start`       | Start the bridge server             |
+| `stop`        | Stop the bridge server              |
+| `setup hooks` | Install or repair agent hooks       |
 
 Running with no command shows the CLI home view. It prepends `bin` and
 `description` metadata, then includes the current snapshot when a browser

--- a/README.md
+++ b/README.md
@@ -219,11 +219,10 @@ State is stored in `~/.chrome-devtools-axi/`:
 
 ### Session Hooks
 
-On supported agents, the packaged CLI also installs a `SessionStart` hook in `~/.claude/settings.json` and `~/.codex/hooks.json`, and enables `hooks` in `~/.codex/config.toml`.
+Run `chrome-devtools-axi setup hooks` once to install or repair optional agent `SessionStart` hooks for ambient browser context.
+The setup command writes Claude Code hooks, Codex hooks and config, and the OpenCode ambient context plugin.
 
-Set `CHROME_DEVTOOLS_AXI_DISABLE_HOOKS=1` to skip that auto-install behavior.
-
-Development entrypoints such as `pnpm run dev` and `bin/chrome-devtools-axi.ts` do not modify those hook files.
+Development entrypoints such as `pnpm run dev` and `bin/chrome-devtools-axi.ts` are still guarded from accidental hook installation.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ chrome-devtools-axi eval "() => { const rows = [...document.querySelectorAll('tr
 
 ### Bridge
 
-| Command       | Description                         |
-| ------------- | ----------------------------------- |
-| `start`       | Start the bridge server             |
-| `stop`        | Stop the bridge server              |
-| `setup hooks` | Install or repair agent hooks       |
+| Command       | Description                   |
+| ------------- | ----------------------------- |
+| `start`       | Start the bridge server       |
+| `stop`        | Stop the bridge server        |
+| `setup hooks` | Install or repair agent hooks |
 
 Running with no command shows the CLI home view. It prepends `bin` and
 `description` metadata, then includes the current snapshot when a browser

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@toon-format/toon": "^2.1.0",
-    "axi-sdk-js": "^0.1.6"
+    "axi-sdk-js": "^0.1.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       axi-sdk-js:
-        specifier: ^0.1.6
-        version: 0.1.6
+        specifier: ^0.1.7
+        version: 0.1.7
     devDependencies:
       "@types/node":
         specifier: ^22.0.0
@@ -620,10 +620,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  axi-sdk-js@0.1.6:
+  axi-sdk-js@0.1.7:
     resolution:
       {
-        integrity: sha512-Nc/mNasFUVqBieSOLGt2A5u4pJEOZPpueq+ignqoY+vcg8j4VuAvhWTn3cJ7hhTkGVqLg4yjTdjMi4tXyOCsCA==,
+        integrity: sha512-kzIeuQHZx3FFpzJknq+sdbi3XBGdyPGMdOHM2Zepa4MF5MpckhPeWPd5x+RX6gBKEWZdaW73YrOPY+HAGyLekw==,
       }
     engines: { node: ">=20" }
 
@@ -1822,7 +1822,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  axi-sdk-js@0.1.6:
+  axi-sdk-js@0.1.7:
     dependencies:
       "@toon-format/toon": 2.1.0
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1050,8 +1050,7 @@ async function markPageSnapshotGeneration(generation: number): Promise<void> {
   return state.generation;
 }`,
     });
-  } catch {
-  }
+  } catch {}
 }
 
 async function getPageRefGeneration(caller: ToolCaller): Promise<number> {
@@ -1081,7 +1080,9 @@ export async function parseUidFresh(
 ): Promise<string> {
   const { generation } = parseStampedUid(arg);
   const current =
-    generation === null ? getCurrentGeneration() : await getPageRefGeneration(caller);
+    generation === null
+      ? getCurrentGeneration()
+      : await getPageRefGeneration(caller);
   const check = checkUidGeneration(arg, current);
   if (check.stale) {
     throwStaleRef(arg, check.refGeneration, current);
@@ -1137,12 +1138,16 @@ async function handleOpen(args: string[], full: boolean): Promise<string> {
     }
     await callTool("new_page", { url });
   }
-  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
   return formatPageOutput(snapshot, "open", url, full);
 }
 
 async function handleSnapshot(full: boolean): Promise<string> {
-  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
   return formatPageOutput(snapshot, "snapshot", undefined, full);
 }
 
@@ -1171,7 +1176,9 @@ async function handleClick(args: string[], full: boolean): Promise<string> {
     ]);
   }
 
-  const snapshot = await callWithSnapshot("click", { uid: await parseUidFresh(uid) });
+  const snapshot = await callWithSnapshot("click", {
+    uid: await parseUidFresh(uid),
+  });
   return formatPageOutput(snapshot, "click", undefined, full);
 }
 
@@ -1217,7 +1224,9 @@ async function handleType(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("type_text", { text });
-  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
   return formatPageOutput(snapshot, "type", undefined, full);
 }
 
@@ -1231,13 +1240,17 @@ async function handleScroll(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("evaluate_script", { function: fn });
-  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
   return formatPageOutput(snapshot, "scroll", undefined, full);
 }
 
 async function handleBack(full: boolean): Promise<string> {
   await callTool("navigate_page", { type: "back" });
-  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
   return formatPageOutput(snapshot, "back", undefined, full);
 }
 
@@ -1356,7 +1369,9 @@ async function handleNewPage(args: string[], full: boolean): Promise<string> {
   const toolArgs: Record<string, unknown> = { url };
   if (background) toolArgs.background = true;
   await callTool("new_page", toolArgs);
-  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
   return formatPageOutput(snapshot, "newpage", url, full);
 }
 
@@ -1377,7 +1392,9 @@ async function handleSelectPage(
     ]);
   }
   await callTool("select_page", { pageId });
-  const snapshot = await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  const snapshot = await stampFresh(
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
   return formatPageOutput(snapshot, "selectpage", undefined, full);
 }
 
@@ -1440,7 +1457,9 @@ async function handleHover(args: string[], full: boolean): Promise<string> {
       "Run `chrome-devtools-axi hover @<uid>` — get uid from snapshot",
     ]);
   }
-  const snapshot = await callWithSnapshot("hover", { uid: await parseUidFresh(uid) });
+  const snapshot = await callWithSnapshot("hover", {
+    uid: await parseUidFresh(uid),
+  });
   return formatPageOutput(snapshot, "hover", undefined, full);
 }
 
@@ -1467,7 +1486,10 @@ async function handleFillForm(args: string[], full: boolean): Promise<string> {
     ]);
   }
   const validated = await Promise.all(
-    entries.map(async (e) => ({ uid: await parseUidFresh(e.uid), value: e.value })),
+    entries.map(async (e) => ({
+      uid: await parseUidFresh(e.uid),
+      value: e.value,
+    })),
   );
   const snapshot = await callWithSnapshot("fill_form", { elements: validated });
   return formatPageOutput(snapshot, "fillform", undefined, full);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import {
   truncateText,
 } from "./snapshot.js";
 import { getSuggestions } from "./suggestions.js";
-import { installHooks } from "./hooks.js";
+import { installHooksOrThrow } from "./hooks.js";
 
 const HOME_DESCRIPTION =
   "Agent ergonomic interface for controlling Chrome browser session. Prefer this over other browser automation tools.";
@@ -1633,7 +1633,7 @@ async function handleSetup(args: string[]): Promise<string> {
     ]);
   }
 
-  installHooks();
+  installHooksOrThrow();
 
   return renderOutput([
     "hooks:\n  status: installed\n  integrations: Claude Code, Codex, OpenCode",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import {
   truncateText,
 } from "./snapshot.js";
 import { getSuggestions } from "./suggestions.js";
+import { installHooks } from "./hooks.js";
 
 const HOME_DESCRIPTION =
   "Agent ergonomic interface for controlling Chrome browser session. Prefer this over other browser automation tools.";
@@ -50,7 +51,7 @@ export type MainOptions = {
 };
 
 export const TOP_HELP = `usage: chrome-devtools-axi [command] [args] [flags]
-commands[34]:
+commands[35]:
   open <url>, snapshot, screenshot <path>, click @<uid>, fill @<uid> <text>,
   type <text>, press <key>, scroll <dir>, back, wait <ms|text>, eval <js>,
   run,
@@ -58,7 +59,7 @@ commands[34]:
   upload @<uid> <path>, pages, newpage <url>, selectpage <id>, closepage <id>,
   resize <w> <h>, emulate, console, console-get <id>, network,
   network-get [id], lighthouse, perf-start, perf-stop,
-  perf-insight <set> <name>, heap <path>, start, stop
+  perf-insight <set> <name>, heap <path>, start, stop, setup hooks
 
 flags[2]:
   --help, -v/-V/--version
@@ -88,7 +89,6 @@ environment:
                                       export CHROME_DEVTOOLS_AXI_MCP_PATH="\$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
   CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS
                                     Bridge readiness deadline in ms (default: 30000, min: 1000)
-  CHROME_DEVTOOLS_AXI_DISABLE_HOOKS Set to 1 to skip auto-installing session hooks
 
 gpu:
   Headless Chrome cannot access hardware GPU on most Linux systems.
@@ -555,6 +555,12 @@ args:
 
 examples:
   chrome-devtools-axi heap ./snapshot.heapsnapshot`,
+
+  setup: `usage: chrome-devtools-axi setup hooks
+Install or repair agent SessionStart hooks for chrome-devtools-axi ambient context.
+
+examples:
+  chrome-devtools-axi setup hooks`,
 };
 
 export function getCommandHelp(command: string): string | null {
@@ -1620,6 +1626,23 @@ async function handleRun(): Promise<string> {
   return RAW_STDOUT_MARKER + trimSingleTrailingNewline(result.stdout);
 }
 
+async function handleSetup(args: string[]): Promise<string> {
+  if (args.length !== 1 || args[0] !== "hooks") {
+    throw new CdpError("Unknown setup action", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi setup hooks`",
+    ]);
+  }
+
+  installHooks();
+
+  return renderOutput([
+    "hooks:\n  status: installed\n  integrations: Claude Code, Codex, OpenCode",
+    renderHelp([
+      "Restart your agent session to receive chrome-devtools-axi ambient context",
+    ]),
+  ]);
+}
+
 async function handleHome(_full: boolean): Promise<string> {
   const result = await getSessionSnapshotIfRunning();
   if (!result) {
@@ -1694,6 +1717,7 @@ const COMMANDS: Record<string, CommandFn> = {
   heap: withoutFullFlag(handleHeap),
   start: async () => handleStart(),
   stop: async () => handleStop(),
+  setup: withoutFullFlag(handleSetup),
 };
 
 export async function main(
@@ -1711,9 +1735,6 @@ export async function main(
     description: HOME_DESCRIPTION,
     version: VERSION,
     topLevelHelp: TOP_HELP,
-    ...(process.env.CHROME_DEVTOOLS_AXI_DISABLE_HOOKS === "1"
-      ? { hooks: false }
-      : {}),
     home: async (args) => handleHome(homeFull || splitFullFlag(args).full),
     commands: COMMANDS,
     getCommandHelp,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -93,9 +93,16 @@ export function installHooks(): void {
 }
 
 export function installHooksOrThrow(): void {
+  const errors: string[] = [];
   installSessionStartHooks({
     marker: HOOK_MARKER,
     timeoutSeconds: 10,
     shouldInstall: shouldInstallHooksForExecPath,
+    onError: (message) => {
+      errors.push(message);
+    },
   });
+  if (errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -86,12 +86,16 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
  */
 export function installHooks(): void {
   try {
-    installSessionStartHooks({
-      marker: HOOK_MARKER,
-      timeoutSeconds: 10,
-      shouldInstall: shouldInstallHooksForExecPath,
-    });
+    installHooksOrThrow();
   } catch {
     // Best-effort — never fail the CLI over hook installation
   }
+}
+
+export function installHooksOrThrow(): void {
+  installSessionStartHooks({
+    marker: HOOK_MARKER,
+    timeoutSeconds: 10,
+    shouldInstall: shouldInstallHooksForExecPath,
+  });
 }

--- a/test/cli-runtime.test.ts
+++ b/test/cli-runtime.test.ts
@@ -17,9 +17,8 @@ vi.mock("axi-sdk-js", async () => {
 });
 
 vi.mock("../src/hooks.js", async () => {
-  const actual = await vi.importActual<typeof import("../src/hooks.js")>(
-    "../src/hooks.js",
-  );
+  const actual =
+    await vi.importActual<typeof import("../src/hooks.js")>("../src/hooks.js");
   return {
     ...actual,
     installHooks,
@@ -109,9 +108,7 @@ describe("main CLI runtime", () => {
       }
     }
 
-    expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty(
-      "hooks",
-    );
+    expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty("hooks");
   });
 
   it("installs session hooks from the explicit setup command", async () => {

--- a/test/cli-runtime.test.ts
+++ b/test/cli-runtime.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { installHooks, runAxiCli } = vi.hoisted(() => ({
+const { installHooks, installHooksOrThrow, runAxiCli } = vi.hoisted(() => ({
   installHooks: vi.fn(),
+  installHooksOrThrow: vi.fn(),
   runAxiCli: vi.fn(),
 }));
 
@@ -22,6 +23,7 @@ vi.mock("../src/hooks.js", async () => {
   return {
     ...actual,
     installHooks,
+    installHooksOrThrow,
   };
 });
 
@@ -118,9 +120,23 @@ describe("main CLI runtime", () => {
     const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
     const output = await options.commands.setup(["hooks"]);
 
-    expect(installHooks).toHaveBeenCalledTimes(1);
+    expect(installHooksOrThrow).toHaveBeenCalledTimes(1);
     expect(output).toContain("hooks:");
     expect(output).toContain("status: installed");
     expect(output).toContain("Restart your agent session");
+  });
+
+  it("surfaces explicit hook setup failures", async () => {
+    installHooksOrThrow.mockImplementationOnce(() => {
+      throw new Error("permission denied");
+    });
+
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+
+    await expect(options.commands.setup(["hooks"])).rejects.toThrow(
+      "permission denied",
+    );
   });
 });

--- a/test/cli-runtime.test.ts
+++ b/test/cli-runtime.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { runAxiCli } = vi.hoisted(() => ({
+const { installHooks, runAxiCli } = vi.hoisted(() => ({
+  installHooks: vi.fn(),
   runAxiCli: vi.fn(),
 }));
 
@@ -11,6 +12,16 @@ vi.mock("axi-sdk-js", async () => {
   return {
     ...actual,
     runAxiCli,
+  };
+});
+
+vi.mock("../src/hooks.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/hooks.js")>(
+    "../src/hooks.js",
+  );
+  return {
+    ...actual,
+    installHooks,
   };
 });
 
@@ -28,6 +39,11 @@ describe("main CLI runtime", () => {
   it("documents top-level version flags in help output", () => {
     expect(TOP_HELP).toContain("--help");
     expect(TOP_HELP).toContain("-v/-V/--version");
+  });
+
+  it("documents explicit hook setup in help output", () => {
+    expect(TOP_HELP).toContain("setup hooks");
+    expect(TOP_HELP).not.toContain("CHROME_DEVTOOLS_AXI_DISABLE_HOOKS");
   });
 
   it("passes bare top-level help argv through to axi-sdk-js", async () => {
@@ -75,5 +91,36 @@ describe("main CLI runtime", () => {
       }),
     );
     expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty("argv");
+  });
+
+  it("does not pass the removed hooks option to axi-sdk-js", async () => {
+    const originalDisableHooks = process.env.CHROME_DEVTOOLS_AXI_DISABLE_HOOKS;
+    process.env.CHROME_DEVTOOLS_AXI_DISABLE_HOOKS = "1";
+
+    try {
+      await main();
+    } finally {
+      if (originalDisableHooks === undefined) {
+        delete process.env.CHROME_DEVTOOLS_AXI_DISABLE_HOOKS;
+      } else {
+        process.env.CHROME_DEVTOOLS_AXI_DISABLE_HOOKS = originalDisableHooks;
+      }
+    }
+
+    expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty(
+      "hooks",
+    );
+  });
+
+  it("installs session hooks from the explicit setup command", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const output = await options.commands.setup(["hooks"]);
+
+    expect(installHooks).toHaveBeenCalledTimes(1);
+    expect(output).toContain("hooks:");
+    expect(output).toContain("status: installed");
+    expect(output).toContain("Restart your agent session");
   });
 });

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -5,9 +5,8 @@ const { installSessionStartHooks } = vi.hoisted(() => ({
 }));
 
 vi.mock("axi-sdk-js", async () => {
-  const actual = await vi.importActual<typeof import("axi-sdk-js")>(
-    "axi-sdk-js",
-  );
+  const actual =
+    await vi.importActual<typeof import("axi-sdk-js")>("axi-sdk-js");
   return {
     ...actual,
     installSessionStartHooks,

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,10 +1,38 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+const { installSessionStartHooks } = vi.hoisted(() => ({
+  installSessionStartHooks: vi.fn(),
+}));
+
+vi.mock("axi-sdk-js", async () => {
+  const actual = await vi.importActual<typeof import("axi-sdk-js")>(
+    "axi-sdk-js",
+  );
+  return {
+    ...actual,
+    installSessionStartHooks,
+  };
+});
+
 import {
   computeCodexConfigUpdate,
   computeHookUpdate,
   getHookTargets,
+  installHooksOrThrow,
   shouldInstallHooksForExecPath,
 } from "../src/hooks.js";
+
+describe("installHooksOrThrow", () => {
+  it("throws when the hook installer reports an internal install error", () => {
+    installSessionStartHooks.mockImplementationOnce((options) => {
+      options.onError?.("/home/user/.claude/settings.json: permission denied");
+    });
+
+    expect(() => installHooksOrThrow()).toThrow(
+      "/home/user/.claude/settings.json: permission denied",
+    );
+  });
+});
 
 describe("computeHookUpdate", () => {
   it("installs hook when settings have no hooks", () => {


### PR DESCRIPTION
## What Changed

- Added `chrome-devtools-axi setup hooks` to explicitly install or repair Claude, Codex, and OpenCode session hooks and report the install status.
- Updated hook installation so the explicit setup path surfaces installer and callback failures instead of reporting success after failed writes.
- Documented the new command in the README and added CLI/runtime and hook tests for the setup flow.

## Risk Assessment

✅ Low: The change is narrowly scoped to replacing automatic hook installation with an explicit setup command and the reviewed implementation handles the prior failure paths without exposing material new risks.

## Testing

<code>Reviewed the target diff to confirm the change intent, ran the focused CLI runtime and hook tests, built the distributable CLI, then exercised `setup hooks` end-to-end with an isolated repository-local HOME and verified it produced Claude, Codex, and OpenCode hook configuration successfully.</code>

<details>
<summary>Evidence: CLI help exposes explicit hook setup</summary>

```text
usage: chrome-devtools-axi [command] [args] [flags]
commands[35]:
open <url>, snapshot, screenshot <path>, click @<uid>, fill @<uid> <text>,
type <text>, press <key>, scroll <dir>, back, wait <ms|text>, eval <js>,
run,
hover @<uid>, drag @<from> @<to>, fillform @<uid>=<val>..., dialog <action>,
upload @<uid> <path>, pages, newpage <url>, selectpage <id>, closepage <id>,
resize <w> <h>, emulate, console, console-get <id>, network,
network-get [id], lighthouse, perf-start, perf-stop,
perf-insight <set> <name>, heap <path>, start, stop, setup hooks
```
</details>
<details>
<summary>Evidence: Explicit setup command end-user output</summary>

```text
hooks:
status: installed
integrations: Claude Code, Codex, OpenCode
help[1]:
Restart your agent session to receive chrome-devtools-axi ambient context
```
</details>
<details>
<summary>Evidence: Generated isolated-home hook evidence</summary>

```text
Generated files under HOME=$PWD/.tmp-home:
- .claude/settings.json SessionStart command: /Users/kunchen/.no-mistakes/worktrees/b11c12c49a1c/01KS964J4FVZ5T06P7BCZ00BCG/dist/bin/chrome-devtools-axi.js, timeout: 10
- .codex/hooks.json SessionStart command: /Users/kunchen/.no-mistakes/worktrees/b11c12c49a1c/01KS964J4FVZ5T06P7BCZ00BCG/dist/bin/chrome-devtools-axi.js, timeout: 10
- .codex/config.toml: [features] hooks = true
- .config/opencode/plugins/axi-chrome-devtools-axi.js ambientHeader: ## AXI ambient context: chrome-devtools-axi
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/cli.ts:1636` - `setup hooks` always reports `status: installed` even when hook installation throws, because `installHooks()` swallows all errors. For an explicit repair command this can leave users believing Claude/Codex/OpenCode hooks were installed when no files were written; let this path surface failures or return an install result before printing success.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/hooks.ts:96` - `installHooksOrThrow()` still does not surface most install failures: `installSessionStartHooks()` catches JSON parse, mkdir/write, Codex config, and OpenCode plugin errors internally and only reports them through `onError`. Because this wrapper does not provide an `onError` that accumulates and throws, `chrome-devtools-axi setup hooks` can still print `status: installed` when no hook files were repaired.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `git diff --stat 5213f460c1c3c52b7dee3314a525fdf933c767a2..266088835b2dbd2259278168ddbf23ade730d04e`
- `pnpm exec vitest run test/cli-runtime.test.ts test/hooks.test.ts`
- `pnpm run build`
- `HOME="$PWD/.tmp-home" node dist/bin/chrome-devtools-axi.js --help`
- `HOME="$PWD/.tmp-home" node dist/bin/chrome-devtools-axi.js setup hooks`
- <code>Read generated isolated-home hook files: `.claude/settings.json`, `.codex/hooks.json`, `.codex/config.toml`, and `.config/opencode/plugins/axi-chrome-devtools-axi.js`</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `README.md:143` - The change adds a new public CLI command, `chrome-devtools-axi setup hooks`, but the README CLI Reference command tables still omit it. The Session Hooks section mentions the command, but users scanning the command reference will not see that `setup hooks` is an available command or what it does. Update the CLI Reference, likely near the Bridge or Configuration commands, to list `setup hooks` with a short description.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
