### PR TITLE
fix(skills): add guardrails to generated agent skill

### DIFF
--- a/.no-mistakes/evidence/fm/cdax-skill-adopt-m7/generated-skill-guardrails.md
+++ b/.no-mistakes/evidence/fm/cdax-skill-adopt-m7/generated-skill-guardrails.md
@@ -1,0 +1,32 @@
+# Generated chrome-devtools-axi Skill Guardrails
+
+Evidence captured from `skills/chrome-devtools-axi/SKILL.md` after running `pnpm run build:skill`.
+This is the installable skill surface agents read, generated from `src/skill.ts`.
+
+## When to use
+
+```md
+Use chrome-devtools-axi whenever a task needs a real browser: opening or testing a web page, clicking through a flow, filling forms, extracting page content, debugging console errors or network requests, taking screenshots, or auditing performance.
+
+Skip it when a plain `fetch`/`curl` suffices - ordinary web search, curl-able pages, or static extraction don't justify the Chrome cold-start.
+```
+
+## Workflow
+
+```md
+1. Run `npx -y chrome-devtools-axi open <url>` to navigate. Output includes the page's accessibility snapshot; interactive elements carry `uid=` refs.
+2. Interact by ref: `click @<uid>`, `fill @<uid> <text>`, `fillform @<uid>=<val>...`, `hover @<uid>`, `drag @<from> @<to>`, `upload @<uid> <path>`.
+3. Pass refs back exactly as printed, including the `g<N>:` generation prefix. If the page re-rendered since the snapshot, the action fails loudly with `STALE_REF` - run `snapshot` again and retry with fresh refs.
+4. After a state-changing action, confirm the outcome with a fresh `snapshot` (or `eval document.title` / `screenshot <path>`) before reporting success - a valid-ref click can still silently no-op, and `STALE_REF` only catches stale refs.
+5. Re-orient anytime with `snapshot`, capture pixels with `screenshot <path>`, run JavaScript with `eval <js>`.
+6. Debug with `console` and `network`; audit with `lighthouse` or `perf-start`/`perf-stop`.
+7. Every response ends with contextual next-step hints - follow them. The first command auto-starts a persistent bridge, so the browser session survives across invocations; run `stop` when you are done.
+```
+
+## Tips
+
+```md
+- Pipe output through grep/head to extract specific data from large pages.
+- Add `--full` to snapshot-producing commands to disable truncation.
+- Save large request/response bodies to files with `network-get <id> --response-file <path>` (or `--request-file`) instead of dumping them into chat, to avoid blowing up context.
+```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The skill teaches your agent to run chrome-devtools-axi through `npx -y chrome-d
 
 The skill is not a user-facing slash command (`user-invocable: false`).
 Just ask for anything that needs a real browser - opening a page, clicking through a flow, extracting page content, debugging console or network, auditing performance - and the agent loads the skill on its own when it recognizes the task.
+For ordinary web search, curl-able pages, or static extraction, the skill tells agents to skip Chrome and use simpler fetch/curl-style tooling.
 The skill frontmatter also includes Hermes Agent metadata (`author` plus `metadata.hermes` tags/category) so Hermes can list it as a first-class browser automation skill; other harnesses ignore those extra fields.
 
 `-g` installs the skill for all projects (`~/.claude/skills/`, for example); drop it to install for the current project only (`.claude/skills/`).
@@ -73,6 +74,7 @@ snapshot:
 ```
 
 Refs in snapshot output carry a `g<N>:` generation prefix that bumps every time a new accessibility tree is captured. Pass refs back exactly as printed - if the page re-rendered between snapshot and action, the action fails loudly with `STALE_REF` instead of silently no-op'ing, so the agent re-snapshots and retries.
+The skill also instructs agents to verify state-changing actions with a fresh snapshot, `eval`, or screenshot before reporting success, because a current ref can still produce no visible page change.
 
 ## Other Ways to Install
 
@@ -195,6 +197,8 @@ chrome-devtools-axi eval "() => { const rows = [...document.querySelectorAll('tr
 | `console-get <id>` | Get a specific console message |
 | `network`          | List network requests          |
 | `network-get [id]` | Get a specific network request |
+
+For large request or response bodies, prefer `network-get <id> --response-file <path>` or `--request-file <path>` so the body goes to disk instead of flooding agent context.
 
 ### Performance
 

--- a/skills/chrome-devtools-axi/SKILL.md
+++ b/skills/chrome-devtools-axi/SKILL.md
@@ -27,7 +27,7 @@ Skip it when a plain `fetch`/`curl` suffices - ordinary web search, curl-able pa
 1. Run `npx -y chrome-devtools-axi open <url>` to navigate. Output includes the page's accessibility snapshot; interactive elements carry `uid=` refs.
 2. Interact by ref: `click @<uid>`, `fill @<uid> <text>`, `fillform @<uid>=<val>...`, `hover @<uid>`, `drag @<from> @<to>`, `upload @<uid> <path>`.
 3. Pass refs back exactly as printed, including the `g<N>:` generation prefix. If the page re-rendered since the snapshot, the action fails loudly with `STALE_REF` - run `snapshot` again and retry with fresh refs.
-4. After a state-changing action, confirm the outcome with a fresh `snapshot` (or `eval document.title` / `screenshot`) before reporting success - a valid-ref click can still silently no-op, and `STALE_REF` only catches stale refs.
+4. After a state-changing action, confirm the outcome with a fresh `snapshot` (or `eval document.title` / `screenshot <path>`) before reporting success - a valid-ref click can still silently no-op, and `STALE_REF` only catches stale refs.
 5. Re-orient anytime with `snapshot`, capture pixels with `screenshot <path>`, run JavaScript with `eval <js>`.
 6. Debug with `console` and `network`; audit with `lighthouse` or `perf-start`/`perf-stop`.
 7. Every response ends with contextual next-step hints - follow them. The first command auto-starts a persistent bridge, so the browser session survives across invocations; run `stop` when you are done.

--- a/skills/chrome-devtools-axi/SKILL.md
+++ b/skills/chrome-devtools-axi/SKILL.md
@@ -20,14 +20,17 @@ If chrome-devtools-axi output shows a follow-up command starting with `chrome-de
 
 Use chrome-devtools-axi whenever a task needs a real browser: opening or testing a web page, clicking through a flow, filling forms, extracting page content, debugging console errors or network requests, taking screenshots, or auditing performance.
 
+Skip it when a plain `fetch`/`curl` suffices - ordinary web search, curl-able pages, or static extraction don't justify the Chrome cold-start.
+
 ## Workflow
 
 1. Run `npx -y chrome-devtools-axi open <url>` to navigate. Output includes the page's accessibility snapshot; interactive elements carry `uid=` refs.
 2. Interact by ref: `click @<uid>`, `fill @<uid> <text>`, `fillform @<uid>=<val>...`, `hover @<uid>`, `drag @<from> @<to>`, `upload @<uid> <path>`.
 3. Pass refs back exactly as printed, including the `g<N>:` generation prefix. If the page re-rendered since the snapshot, the action fails loudly with `STALE_REF` - run `snapshot` again and retry with fresh refs.
-4. Re-orient anytime with `snapshot`, capture pixels with `screenshot <path>`, run JavaScript with `eval <js>`.
-5. Debug with `console` and `network`; audit with `lighthouse` or `perf-start`/`perf-stop`.
-6. Every response ends with contextual next-step hints - follow them. The first command auto-starts a persistent bridge, so the browser session survives across invocations; run `stop` when you are done.
+4. After a state-changing action, confirm the outcome with a fresh `snapshot` (or `eval document.title` / `screenshot`) before reporting success - a valid-ref click can still silently no-op, and `STALE_REF` only catches stale refs.
+5. Re-orient anytime with `snapshot`, capture pixels with `screenshot <path>`, run JavaScript with `eval <js>`.
+6. Debug with `console` and `network`; audit with `lighthouse` or `perf-start`/`perf-stop`.
+7. Every response ends with contextual next-step hints - follow them. The first command auto-starts a persistent bridge, so the browser session survives across invocations; run `stop` when you are done.
 
 ## Commands
 
@@ -49,3 +52,4 @@ Run `npx -y chrome-devtools-axi --help` for flags and environment variables, or 
 
 - Pipe output through grep/head to extract specific data from large pages.
 - Add `--full` to snapshot-producing commands to disable truncation.
+- Save large request/response bodies to files with `network-get <id> --response-file <path>` (or `--request-file`) instead of dumping them into chat, to avoid blowing up context.

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -67,14 +67,17 @@ If chrome-devtools-axi output shows a follow-up command starting with \`chrome-d
 
 Use chrome-devtools-axi whenever a task needs a real browser: opening or testing a web page, clicking through a flow, filling forms, extracting page content, debugging console errors or network requests, taking screenshots, or auditing performance.
 
+Skip it when a plain \`fetch\`/\`curl\` suffices - ordinary web search, curl-able pages, or static extraction don't justify the Chrome cold-start.
+
 ## Workflow
 
 1. Run \`npx -y chrome-devtools-axi open <url>\` to navigate. Output includes the page's accessibility snapshot; interactive elements carry \`uid=\` refs.
 2. Interact by ref: \`click @<uid>\`, \`fill @<uid> <text>\`, \`fillform @<uid>=<val>...\`, \`hover @<uid>\`, \`drag @<from> @<to>\`, \`upload @<uid> <path>\`.
 3. Pass refs back exactly as printed, including the \`g<N>:\` generation prefix. If the page re-rendered since the snapshot, the action fails loudly with \`STALE_REF\` - run \`snapshot\` again and retry with fresh refs.
-4. Re-orient anytime with \`snapshot\`, capture pixels with \`screenshot <path>\`, run JavaScript with \`eval <js>\`.
-5. Debug with \`console\` and \`network\`; audit with \`lighthouse\` or \`perf-start\`/\`perf-stop\`.
-6. Every response ends with contextual next-step hints - follow them. The first command auto-starts a persistent bridge, so the browser session survives across invocations; run \`stop\` when you are done.
+4. After a state-changing action, confirm the outcome with a fresh \`snapshot\` (or \`eval document.title\` / \`screenshot\`) before reporting success - a valid-ref click can still silently no-op, and \`STALE_REF\` only catches stale refs.
+5. Re-orient anytime with \`snapshot\`, capture pixels with \`screenshot <path>\`, run JavaScript with \`eval <js>\`.
+6. Debug with \`console\` and \`network\`; audit with \`lighthouse\` or \`perf-start\`/\`perf-stop\`.
+7. Every response ends with contextual next-step hints - follow them. The first command auto-starts a persistent bridge, so the browser session survives across invocations; run \`stop\` when you are done.
 
 ## Commands
 
@@ -88,5 +91,6 @@ Run \`npx -y chrome-devtools-axi --help\` for flags and environment variables, o
 
 - Pipe output through grep/head to extract specific data from large pages.
 - Add \`--full\` to snapshot-producing commands to disable truncation.
+- Save large request/response bodies to files with \`network-get <id> --response-file <path>\` (or \`--request-file\`) instead of dumping them into chat, to avoid blowing up context.
 `;
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -74,7 +74,7 @@ Skip it when a plain \`fetch\`/\`curl\` suffices - ordinary web search, curl-abl
 1. Run \`npx -y chrome-devtools-axi open <url>\` to navigate. Output includes the page's accessibility snapshot; interactive elements carry \`uid=\` refs.
 2. Interact by ref: \`click @<uid>\`, \`fill @<uid> <text>\`, \`fillform @<uid>=<val>...\`, \`hover @<uid>\`, \`drag @<from> @<to>\`, \`upload @<uid> <path>\`.
 3. Pass refs back exactly as printed, including the \`g<N>:\` generation prefix. If the page re-rendered since the snapshot, the action fails loudly with \`STALE_REF\` - run \`snapshot\` again and retry with fresh refs.
-4. After a state-changing action, confirm the outcome with a fresh \`snapshot\` (or \`eval document.title\` / \`screenshot\`) before reporting success - a valid-ref click can still silently no-op, and \`STALE_REF\` only catches stale refs.
+4. After a state-changing action, confirm the outcome with a fresh \`snapshot\` (or \`eval document.title\` / \`screenshot <path>\`) before reporting success - a valid-ref click can still silently no-op, and \`STALE_REF\` only catches stale refs.
 5. Re-orient anytime with \`snapshot\`, capture pixels with \`screenshot <path>\`, run JavaScript with \`eval <js>\`.
 6. Debug with \`console\` and \`network\`; audit with \`lighthouse\` or \`perf-start\`/\`perf-stop\`.
 7. Every response ends with contextual next-step hints - follow them. The first command auto-starts a persistent bridge, so the browser session survives across invocations; run \`stop\` when you are done.


### PR DESCRIPTION
## Intent

Fold three behavioral guardrails into the chrome-devtools-axi agent skill to improve agent success without bloating the deliberately-terse skill. The skill is GENERATED: SKILL.md is produced by src/skill.ts (createSkillMarkdown) and test/skill.test.ts fails if the committed SKILL.md drifts from the generator, so all edits go into src/skill.ts and SKILL.md is regenerated via 'pnpm run build:skill' (never hand-edited).

The three additions, sourced from the firstmate cdax-skill-compare-k4 report (items 1-3 only; items 4-5 were intentionally out of scope per the captain):
1. Verify before claiming success - a new Workflow step telling the agent to confirm the outcome of a state-changing action with a fresh snapshot / eval document.title / screenshot before reporting success, because a valid-ref click can still silently no-op and STALE_REF only catches stale refs. Subsequent workflow steps were renumbered (5,6,7).
2. A 'when NOT to use' negative boundary under 'When to use': skip the browser when a plain fetch/curl suffices (ordinary web search, curl-able pages, static extraction) to avoid the Chrome cold-start. Deliberately did NOT copy the external skill's stealth/anti-detection/Camofox clause - that is a third party's ecosystem and does not apply to us.
3. A Tips bullet teaching the habit of saving large request/response bodies to files with 'network-get <id> --response-file <path>' (or --request-file) instead of dumping them into chat, to avoid context blow-up.

Each addition is intentionally kept to roughly one line to preserve the skill's minimalism (the README benchmark shows minimalism wins on tokens/turns) and matches the existing generator template voice. No CLI behavior, commands, or unrelated docs were changed. Verified locally: pnpm run build:skill regenerated SKILL.md, pnpm test green (339 tests incl. skill parity), pnpm run build clean, prettier --check clean.

## What Changed

- Added generated skill guardrails for when to avoid browser automation, how to verify state-changing actions before reporting success, and how to stream large network bodies to files.
- Updated the skill generator and regenerated `skills/chrome-devtools-axi/SKILL.md` so the committed skill stays in parity with `src/skill.ts`.
- Documented the generated guardrails evidence for the no-mistakes workflow.

## Risk Assessment

✅ Low: The change is limited to generated skill guidance and its generator, with the referenced CLI commands and options matching existing help and parsers.

## Testing

Exercised the generated skill path by regenerating SKILL.md, running the focused skill parity tests and the full Vitest suite, then captured reviewer-visible Markdown evidence showing the negative browser boundary, post-action verification workflow step, and network body file-saving tip in the installable skill.

- Evidence: [Generated skill guardrails evidence](https://github.com/kunchenguid/chrome-devtools-axi/blob/62ad0b79d1f90df15aa6302f43a215e456797091/.no-mistakes/evidence/fm/cdax-skill-adopt-m7/generated-skill-guardrails.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/skill.ts:77` - The new verifier example uses `screenshot` as if it were a complete command, but the CLI requires `screenshot &lt;path&gt;`. Agents following this literally will get a validation error instead of confirming the state-changing action. Change this to `screenshot &lt;path&gt;` or leave the examples to `snapshot` and a task-specific `eval`.

🔧 Fix: Fix skill screenshot verification guidance
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm test test/skill.test.ts`
- `pnpm run build:skill`
- `pnpm test`
- `rg -n "Skip it when|After a state-changing action|network-get <id> --response-file|Camofox|stealth|anti-detection" skills/chrome-devtools-axi/SKILL.md src/skill.ts .no-mistakes/evidence/fm/cdax-skill-adopt-m7/generated-skill-guardrails.md`
- <code>Manual review of `.no-mistakes/evidence/fm/cdax-skill-adopt-m7/generated-skill-guardrails.md` against the generated skill surface</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
