### PR TITLE
feat(bridge): add CHROME_DEVTOOLS_AXI_CHANNEL to select a Chrome release channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ The bridge holds one persistent MCP stdio session and exposes a localhost HTTP A
 Teardown is careful about orphans: the bridge kills its own process group on exit, and `terminateBridgeProcess` escalates SIGTERM -> SIGKILL on the group so chrome-devtools-mcp and Chrome children get reaped (group kill only when `ps` confirms the PID is actually a bridge).
 
 `resolveTransportSpec` (`src/bridge.ts`) picks how chrome-devtools-mcp is spawned: explicit `CHROME_DEVTOOLS_AXI_MCP_PATH`, else an auto-detected global npm install (fast), else `npx -y chrome-devtools-mcp@latest` (slow first run).
-Connection modes are env-driven (`buildTransportArgs`): `AUTO_CONNECT` (Chrome 144+ remote debugging), `BROWSER_URL` (http(s) -> `--browserUrl`, ws(s) -> `--wsEndpoint` + `WS_HEADERS`), `USER_DATA_DIR` (persistent profile) vs the default `--isolated`, and `HEADED`.
+Connection modes are env-driven (`buildTransportArgs`): `AUTO_CONNECT` (Chrome 144+ remote debugging), `BROWSER_URL` (http(s) -> `--browserUrl`, ws(s) -> `--wsEndpoint` + `WS_HEADERS`), `USER_DATA_DIR` (persistent profile) vs the default `--isolated`, `CHANNEL` (`--channel` to pick which installed Chrome release channel is attached to or launched, omitted in `BROWSER_URL`/`wsEndpoint` mode), and `HEADED`.
 
 ### Snapshot generations and STALE_REF
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,16 @@ export CHROME_DEVTOOLS_AXI_BROWSER_URL=wss://cluster.example/launch
 export CHROME_DEVTOOLS_AXI_WS_HEADERS='{"Authorization":"Bearer token"}'
 ```
 
+Pick which installed Chrome release channel to target with `CHROME_DEVTOOLS_AXI_CHANNEL` - `stable` (the default), `beta`, `canary`, or `dev`:
+
+```sh
+export CHROME_DEVTOOLS_AXI_AUTO_CONNECT=1
+export CHROME_DEVTOOLS_AXI_CHANNEL=beta
+```
+
+This selects which Chrome `--autoConnect` attaches to, and which one is launched in the default and `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` modes.
+It is ignored when `CHROME_DEVTOOLS_AXI_BROWSER_URL` is set, since that connects to an explicit endpoint regardless of channel.
+
 State is stored in `~/.chrome-devtools-axi/`:
 
 | File                  | Purpose                               |

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -268,6 +268,7 @@ export function buildTransportArgs(): string[] {
   const autoConnect = process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT === "1";
   const browserUrl = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
   const userDataDir = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+  const channel = process.env.CHROME_DEVTOOLS_AXI_CHANNEL?.trim();
 
   if (autoConnect) {
     // Chrome 144+ built-in remote debugging via chrome://inspect/#remote-debugging.
@@ -313,6 +314,14 @@ export function buildTransportArgs(): string[] {
     if (process.env.CHROME_DEVTOOLS_AXI_HEADED !== "1") {
       args.push("--headless");
     }
+  }
+
+  // --channel selects which installed Chrome distribution chrome-devtools-mcp
+  // targets: the running instance --autoConnect attaches to, or the one launched
+  // by default. It is irrelevant when attaching to an explicit endpoint, so it is
+  // omitted in BROWSER_URL/wsEndpoint mode. Validation is left to chrome-devtools-mcp.
+  if (channel && !browserUrl) {
+    args.push(`--channel=${channel}`);
   }
 
   const extraChromeArgs = process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,10 @@ environment:
   CHROME_DEVTOOLS_AXI_AUTO_CONNECT  Set to 1 to connect to the user's running Chrome (144+)
                                     via chrome://inspect/#remote-debugging instead of launching
                                     a new browser. Requires remote debugging enabled in Chrome.
+  CHROME_DEVTOOLS_AXI_CHANNEL       Chrome release channel to target: stable (default), beta,
+                                    canary, or dev. Selects which installed Chrome --autoConnect
+                                    attaches to, and which one is launched in the default and
+                                    USER_DATA_DIR modes. Ignored with CHROME_DEVTOOLS_AXI_BROWSER_URL.
   CHROME_DEVTOOLS_AXI_HEADED        Set to 1 to run Chrome in headed (visible) mode
   CHROME_DEVTOOLS_AXI_CHROME_ARGS   Whitespace-separated Chrome flags forwarded to the browser
                                     (no shell-style quoting; flags with spaces are not supported)

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -81,12 +81,15 @@ describe("buildTransportArgs", () => {
       process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS =
       process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
+    savedEnv.CHROME_DEVTOOLS_AXI_CHANNEL =
+      process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
     delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
     delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     delete process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
     delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     delete process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
+    delete process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
   });
 
   afterEach(() => {
@@ -102,6 +105,8 @@ describe("buildTransportArgs", () => {
       savedEnv.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS =
       savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS;
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL =
+      savedEnv.CHROME_DEVTOOLS_AXI_CHANNEL;
   });
 
   it("defaults to headless and isolated", () => {
@@ -209,6 +214,55 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).not.toContain("--autoConnect");
     expect(args).toContain("--isolated");
+  });
+
+  it("omits --channel by default", () => {
+    const args = buildTransportArgs();
+    expect(args.some((a) => a.startsWith("--channel"))).toBe(false);
+  });
+
+  it("appends --channel to --autoConnect", () => {
+    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = "1";
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL = "beta";
+    const args = buildTransportArgs();
+    expect(args).toContain("--autoConnect");
+    expect(args).toContain("--channel=beta");
+  });
+
+  it("appends --channel in the default launch mode", () => {
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL = "beta";
+    const args = buildTransportArgs();
+    expect(args).toContain("--channel=beta");
+    expect(args).toContain("--isolated");
+    expect(args).toContain("--headless");
+  });
+
+  it("appends --channel alongside --userDataDir", () => {
+    process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = "/path/to/.chrome-profile";
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL = "canary";
+    const args = buildTransportArgs();
+    expect(args).toContain("--userDataDir=/path/to/.chrome-profile");
+    expect(args).toContain("--channel=canary");
+  });
+
+  it("ignores --channel when connecting via --browserUrl", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL = "beta";
+    const args = buildTransportArgs();
+    expect(args).toContain("--browserUrl=http://127.0.0.1:9222");
+    expect(args.some((a) => a.startsWith("--channel"))).toBe(false);
+  });
+
+  it("trims surrounding whitespace from the channel", () => {
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL = "  beta  ";
+    const args = buildTransportArgs();
+    expect(args).toContain("--channel=beta");
+  });
+
+  it("ignores a blank channel", () => {
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL = "   ";
+    const args = buildTransportArgs();
+    expect(args.some((a) => a.startsWith("--channel"))).toBe(false);
   });
 
   it("routes ws:// BROWSER_URL to --wsEndpoint", () => {


### PR DESCRIPTION
## Intent

Add CHROME_DEVTOOLS_AXI_CHANNEL: forward --channel to chrome-devtools-mcp in the auto-connect and default launch paths (omitted for BROWSER_URL/wsEndpoint, where no browser is launched; value validation is delegated to chrome-devtools-mcp, matching the existing CHROME_ARGS passthrough). This lets users target a non-stable Chrome - e.g. --autoConnect to a logged-in Beta profile - which is impossible today because the channel is always stable. Documented in --help and the README, covered by buildTransportArgs unit tests.

## What Changed

- `buildTransportArgs` (`src/bridge.ts`) now reads `CHROME_DEVTOOLS_AXI_CHANNEL` and forwards a trimmed value as `--channel=<value>` to chrome-devtools-mcp, so the auto-connect, default, and `USER_DATA_DIR` launch paths can target stable/beta/canary/dev instead of always stable; the flag is omitted in `BROWSER_URL`/`wsEndpoint` mode (no browser is launched) and value validation is delegated to chrome-devtools-mcp, matching the existing `CHROME_ARGS` passthrough.
- Documented the new env var in the CLI `--help` text (`src/cli.ts`), the README, and the architecture connection-modes section of AGENTS.md.
- Added 7 `buildTransportArgs` cases to `test/bridge.test.ts` covering channel forwarding across modes plus the blank-value omission, bringing that file's suite to 54 cases.

## Risk Assessment

✅ Low: A small, additive, well-tested env-var passthrough whose guard logic exactly mirrors chrome-devtools-mcp's own channel handling (used for autoConnect/launch, ignored for explicit endpoints), with accurate docs and full branch coverage.

## Testing

<code>Installed deps with corepack pnpm, ran the targeted bridge tests and the full 346-test suite (all green, including the skill-drift and airlock guards that protect the README/help docs). Captured the end-user CLI surface from `--help`, produced a transcript of the literal command line spawned for chrome-devtools-mcp across all launch modes (channel forwarded for autoConnect/default/userDataDir, correctly omitted for browserUrl and blank values), and then ran the flagship real-world check: the same CLI launch with only the env var changed booted two different installed Chromes — stable as HeadlessChrome/149 and beta as HeadlessChrome/150 — proving the channel selection works end-to-end through CLI -&gt; bridge -&gt; chrome-devtools-mcp -&gt; Chrome. This is a CLI/behavioral change with no rendered UI, so visual artifacts are not applicable; evidence is the CLI transcripts. Cleaned up the temp helper, stopped the bridge, and verified the worktree is clean with no leaked processes.</code>

<details>
<summary>Evidence: Real launch comparison: stable=Chrome149 vs beta=Chrome150</summary>

<code>CHANNEL=stable -&gt; HeadlessChrome/149.0.0.0&#10;CHANNEL=beta -&gt; HeadlessChrome/150.0.0.0&#10;(same `chrome-devtools-axi open about:blank` + `eval navigator.userAgent`, only the env var changed)</code>

```text
Real end-to-end launch via chrome-devtools-axi CLI
(full pipeline: CLI -> detached bridge -> chrome-devtools-mcp -> Chrome)

Same command, only CHROME_DEVTOOLS_AXI_CHANNEL changed. Both Chrome stable
and Chrome Beta are installed on this machine; the channel var selects which
installed release actually boots.

--- CHROME_DEVTOOLS_AXI_CHANNEL=stable ---
$ chrome-devtools-axi open about:blank
$ chrome-devtools-axi eval "navigator.userAgent"
result: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/149.0.0.0 Safari/537.36"

--- CHROME_DEVTOOLS_AXI_CHANNEL=beta ---
$ chrome-devtools-axi open about:blank
$ chrome-devtools-axi eval "navigator.userAgent"
result: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36"

Result: stable launched Chrome 149, beta launched Chrome 150 (one major
version ahead) - confirming CHROME_DEVTOOLS_AXI_CHANNEL forwards --channel to
chrome-devtools-mcp and targets a non-stable installed Chrome end-to-end,
which was impossible before this change (channel was always stable).
```
</details>
<details>
<summary>Evidence: Spawned command line per launch mode (buildTransportArgs/resolveTransportSpec)</summary>

<code>autoConnect+beta -&gt; npx -y chrome-devtools-mcp@latest --autoConnect --channel=beta&#10;default+canary -&gt; ... --isolated --headless --channel=canary&#10;userDataDir+dev -&gt; ... --userDataDir=/Users/me/.chrome-profile --headless --channel=dev&#10;browserUrl+beta -&gt; ... --browserUrl=http://127.0.0.1:9222 (channel omitted)&#10;blank channel -&gt; ... --isolated --headless (channel omitted)</code>

```text
Command line chrome-devtools-axi spawns for chrome-devtools-mcp
(buildTransportArgs -> resolveTransportSpec, the real spawn path)

### default launch, no channel (baseline)
  env: {}
  spawn: npx -y chrome-devtools-mcp@latest --isolated --headless
  channel forwarded: (none)

### auto-connect to running Chrome Beta
  env: {"CHROME_DEVTOOLS_AXI_AUTO_CONNECT":"1","CHROME_DEVTOOLS_AXI_CHANNEL":"beta"}
  spawn: npx -y chrome-devtools-mcp@latest --autoConnect --channel=beta
  channel forwarded: --channel=beta

### default headless launch, canary channel
  env: {"CHROME_DEVTOOLS_AXI_CHANNEL":"canary"}
  spawn: npx -y chrome-devtools-mcp@latest --isolated --headless --channel=canary
  channel forwarded: --channel=canary

### persistent user-data-dir launch, dev channel
  env: {"CHROME_DEVTOOLS_AXI_USER_DATA_DIR":"/Users/me/.chrome-profile","CHROME_DEVTOOLS_AXI_CHANNEL":"dev"}
  spawn: npx -y chrome-devtools-mcp@latest --userDataDir=/Users/me/.chrome-profile --headless --channel=dev
  channel forwarded: --channel=dev

### explicit browserUrl endpoint, channel ignored
  env: {"CHROME_DEVTOOLS_AXI_BROWSER_URL":"http://127.0.0.1:9222","CHROME_DEVTOOLS_AXI_CHANNEL":"beta"}
  spawn: npx -y chrome-devtools-mcp@latest --browserUrl=http://127.0.0.1:9222
  channel forwarded: (none)

### whitespace-only channel ignored
  env: {"CHROME_DEVTOOLS_AXI_CHANNEL":"   "}
  spawn: npx -y chrome-devtools-mcp@latest --isolated --headless
  channel forwarded: (none)
```
</details>
<details>
<summary>Evidence: --help documents CHROME_DEVTOOLS_AXI_CHANNEL</summary>

```text
CHROME_DEVTOOLS_AXI_CHANNEL Chrome release channel to target: stable (default), beta,
canary, or dev. Selects which installed Chrome --autoConnect
attaches to, and which one is launched in the default and
USER_DATA_DIR modes. Ignored with CHROME_DEVTOOLS_AXI_BROWSER_URL.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm test test/bridge.test.ts` — 54 buildTransportArgs cases incl. the 7 new channel cases, all pass</code>
- <code>`pnpm test` — full suite 346/346 pass, incl. test/skill.test.ts (drift guard) and test/airlock-lint.test.ts</code>
- <code>`tsx bin/chrome-devtools-axi.ts --help` — confirmed CHROME_DEVTOOLS_AXI_CHANNEL documented with stable/beta/canary/dev and BROWSER_URL caveat</code>
- `Transcript via resolveTransportSpec across 6 env combos — channel forwarded for autoConnect/default/userDataDir, omitted for browserUrl and blank values`
- <code>Real launch: `CHROME_DEVTOOLS_AXI_CHANNEL=stable chrome-devtools-axi open about:blank` + `eval navigator.userAgent` -&gt; HeadlessChrome/149</code>
- <code>Real launch: `CHROME_DEVTOOLS_AXI_CHANNEL=beta chrome-devtools-axi open about:blank` + `eval navigator.userAgent` -&gt; HeadlessChrome/150 (different installed Chrome actually booted)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
