### PR TITLE
feat(sessions): add CHROME_DEVTOOLS_AXI_SESSION for concurrent bridge isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,19 +43,24 @@ Every invocation is a short-lived process, so anything that must survive across 
 Three processes: CLI -> bridge -> chrome-devtools-mcp (which drives headless Chrome over CDP).
 
 The CLI (`bin/chrome-devtools-axi.ts` -> `src/cli.ts`) parses args, calls MCP tools through the bridge, and formats output.
-`ensureBridge` (`src/client.ts`) reads `~/.chrome-devtools-axi/bridge.pid` and reuses a live bridge only after a **deep** health check (`/health?deep=1` drives one CDP-backed `list_pages` call), so a bridge whose attached browser died gets terminated and respawned instead of reused as a stale endpoint.
+`ensureBridge` (`src/client.ts`) reads its session's `bridge.pid` (`~/.chrome-devtools-axi/bridge.pid` for the default session) and reuses a live bridge only after a **deep** health check (`/health?deep=1` drives one CDP-backed `list_pages` call), so a bridge whose attached browser died gets terminated and respawned instead of reused as a stale endpoint.
 Otherwise it spawns the bridge (`bin/chrome-devtools-axi-bridge.ts` -> `src/bridge.ts`) **detached** as a process group leader and polls health until the `CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS` deadline (default 30s).
 
-The bridge holds one persistent MCP stdio session and exposes a localhost HTTP API on port 9224 (`CHROME_DEVTOOLS_AXI_PORT`): `POST /call`, `GET /tools`, `GET /health[?deep=1]`.
+The bridge holds one persistent MCP stdio session and exposes a localhost HTTP API on its session port (9224 by default; `CHROME_DEVTOOLS_AXI_PORT` overrides - see Named sessions): `POST /call`, `GET /tools`, `GET /health[?deep=1]`.
 Teardown is careful about orphans: the bridge kills its own process group on exit, and `terminateBridgeProcess` escalates SIGTERM -> SIGKILL on the group so chrome-devtools-mcp and Chrome children get reaped (group kill only when `ps` confirms the PID is actually a bridge).
 
 `resolveTransportSpec` (`src/bridge.ts`) picks how chrome-devtools-mcp is spawned: explicit `CHROME_DEVTOOLS_AXI_MCP_PATH`, else an auto-detected global npm install (fast), else `npx -y chrome-devtools-mcp@latest` (slow first run).
 Connection modes are env-driven (`buildTransportArgs`): `AUTO_CONNECT` (Chrome 144+ remote debugging), `BROWSER_URL` (http(s) -> `--browserUrl`, ws(s) -> `--wsEndpoint` + `WS_HEADERS`), `USER_DATA_DIR` (persistent profile) vs the default `--isolated`, `CHANNEL` (`--channel` to pick which installed Chrome release channel is attached to or launched, omitted in `BROWSER_URL`/`wsEndpoint` mode), and `HEADED`.
 
+Named sessions (`CHROME_DEVTOOLS_AXI_SESSION`, `src/sessions.ts`) give each name its own bridge - its own port (explicit `CHROME_DEVTOOLS_AXI_PORT`, else a deterministic FNV-1a hash of the name) and its own state dir under `~/.chrome-devtools-axi/sessions/<name>/` (PID file + generation counter) - so concurrent sessions don't share a bridge or each other's stale-ref tracking.
+The default (unset) session keeps port 9224 and the legacy `~/.chrome-devtools-axi/` paths, so existing behavior is unchanged.
+`resolveSessionName` validates the name (rejecting path-traversal/unsafe and all-dot names) and is the single chokepoint every entry point resolves through; a session isolates only the bridge, so the connection mode and profile compose unchanged.
+`/health` reports the bridge's `session`, and `checkBridgeHealth`/`ensureBridge` reject a mismatched session so two sessions forced onto one port (a globally-exported `CHROME_DEVTOOLS_AXI_PORT`) fail loudly instead of silently sharing; the bridge exits with `BRIDGE_PORT_IN_USE_EXIT_CODE` (48) on an EADDRINUSE bind so the early-exit error attributes the collision (`buildBridgeEarlyExitError`).
+
 ### Snapshot generations and STALE_REF
 
 Snapshots are accessibility trees whose interactive elements carry `uid=` refs.
-Because CLI processes are short-lived, a generation counter persists at `~/.chrome-devtools-axi/snapshot-generation` (`src/generation.ts`); every fresh snapshot bumps it and `stampSnapshotGeneration` (`src/snapshot.ts`) rewrites `uid=X` to `uid=g<N>:X`.
+Because CLI processes are short-lived, a generation counter persists in the active session's state dir as `snapshot-generation` (`~/.chrome-devtools-axi/snapshot-generation` by default; `src/generation.ts`); every fresh snapshot bumps it and `stampSnapshotGeneration` (`src/snapshot.ts`) rewrites `uid=X` to `uid=g<N>:X`.
 Action commands parse refs through `parseUidFresh` (`src/cli.ts`), which fails loudly with `STALE_REF` instead of letting upstream MCP silently no-op against a stale tree.
 `stampFresh` also installs a MutationObserver in the page (`markPageSnapshotGeneration`), so the effective page generation is `snapshot generation + observed mutations` - a re-render invalidates refs even without a newer snapshot.
 
@@ -78,6 +83,6 @@ Only the script's own `console.log` output reaches stdout: handlers return text 
 ## Things to know when editing
 
 - The bridge resolves its own script path at runtime (`resolveBridgeScript`): it prefers a sibling `.ts` (dev mode, run via tsx) and falls back to the built `.js`, so dev and dist behave the same without flags.
-- `getSessionSnapshotIfRunning` deliberately never starts the bridge - the home view and SessionStart hook must stay cheap and side-effect free when no session exists.
+- `getSessionSnapshotIfRunning` deliberately never starts the bridge - the home view and SessionStart hook must stay cheap and side-effect free when no session exists; it also degrades an invalid `CHROME_DEVTOOLS_AXI_SESSION` to null here, while action commands (`ensureBridge`/`stopBridge`) still fail loudly.
 - Generation-counter writes are best-effort; a failed write degrades to one missed stale-ref detection, never a hang (`src/generation.ts`).
 - Some `test/client.test.ts` cases exercise real SIGTERM/SIGKILL escalation timing and take a couple of seconds each; that is expected, not flakiness.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,23 @@ export CHROME_DEVTOOLS_AXI_CHANNEL=beta
 This selects which Chrome `--autoConnect` attaches to, and which one is launched in the default and `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` modes.
 It is ignored when `CHROME_DEVTOOLS_AXI_BROWSER_URL` is set, since that connects to an explicit endpoint regardless of channel.
 
-State is stored in `~/.chrome-devtools-axi/`:
+Run multiple isolated bridges at once with `CHROME_DEVTOOLS_AXI_SESSION` - one per agent session, worktree, or test worker:
+
+```sh
+CHROME_DEVTOOLS_AXI_SESSION=worker-1 chrome-devtools-axi open https://example.com
+CHROME_DEVTOOLS_AXI_SESSION=worker-2 chrome-devtools-axi open https://example.org
+```
+
+Each session name gets its own bridge process, port (auto-derived from the name, or pinned with `CHROME_DEVTOOLS_AXI_PORT`), and on-disk state.
+In the default `--isolated` and `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` launch modes each bridge also launches its own Chrome, so concurrent sessions share neither browser state nor each other's stale-ref tracking.
+Sessions that attach to the same external browser - multiple `CHROME_DEVTOOLS_AXI_AUTO_CONNECT=1` sessions on one running Chrome, or the same `CHROME_DEVTOOLS_AXI_BROWSER_URL`/`wsEndpoint` - drive that shared browser and are isolated only at the bridge level, where the per-session generation counter does not prevent cross-talk.
+A session only isolates the bridge - the connection mode and profile are unchanged; combine with `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` for a persistent per-session profile.
+The default (unset) session keeps port 9224 and the legacy state paths below.
+
+Do not export `CHROME_DEVTOOLS_AXI_PORT` globally when running concurrent sessions: it overrides the per-session derived port and forces every session onto the same port, so the second session fails to start - its bridge cannot bind the already-taken port, and the first session's bridge is rejected as a mismatch rather than silently shared.
+Rely on the per-session default ports instead, or set `CHROME_DEVTOOLS_AXI_PORT` only inline per command.
+
+State is stored in `~/.chrome-devtools-axi/` (named sessions nest under `sessions/<name>/`):
 
 | File                  | Purpose                               |
 | --------------------- | ------------------------------------- |

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -5,10 +5,12 @@
  * persistent MCP session. Exposes a simple HTTP API:
  *   POST /call  { name, args }  → { result }
  *   GET  /tools                 → [{ name, description }]
- *   GET  /health                → { status: "ok" } or 503 { status: "error", error }
+ *   GET  /health                → { status: "ok", session } or 503 { status: "error", error }
  *   GET  /health?deep=1         → also verifies the attached CDP target; 503 may include reason
  *
- * Writes a PID file to ~/.chrome-devtools-axi/bridge.pid on startup.
+ * Writes a PID file to the active session's state dir on startup
+ * (~/.chrome-devtools-axi/bridge.pid for the default session; named sessions
+ * nest under sessions/<name>/ - see src/sessions.ts).
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -20,16 +22,19 @@ import {
   type Server,
   type ServerResponse,
 } from "node:http";
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { homedir } from "node:os";
-
-const DEFAULT_PORT = Number.parseInt(
-  process.env.CHROME_DEVTOOLS_AXI_PORT ?? "9224",
-  10,
-);
-const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
-const PID_FILE = join(STATE_DIR, "bridge.pid");
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import {
+  resolveSessionName,
+  resolveSessionPidFile,
+  resolveSessionPort,
+} from "./sessions.js";
 
 export interface BridgeContentBlock {
   type: string;
@@ -86,13 +91,35 @@ export async function isBridgeTargetReachable(
 }
 
 function writePidFile(port: number): void {
-  mkdirSync(STATE_DIR, { recursive: true });
-  writeFileSync(PID_FILE, JSON.stringify({ pid: process.pid, port }));
+  const pidFile = resolveSessionPidFile();
+  mkdirSync(dirname(pidFile), { recursive: true });
+  writeFileSync(pidFile, JSON.stringify({ pid: process.pid, port }));
 }
 
-function removePidFile(): void {
+/**
+ * Remove the session PID file, but only when this process owns it. On a
+ * same-session bind race the losing bridge exits via EADDRINUSE after the
+ * winning bridge has already written the shared PID file; an unconditional
+ * unlink would delete the still-running winner's handle and orphan it (later
+ * `stop`/reuse can no longer find it). A missing, unreadable, or malformed
+ * file — or one recording a different pid — is left untouched. `ownerPid` is
+ * injectable for tests.
+ */
+export function removePidFile(
+  pidFile: string = resolveSessionPidFile(),
+  ownerPid: number = process.pid,
+): void {
   try {
-    unlinkSync(PID_FILE);
+    const data = JSON.parse(readFileSync(pidFile, "utf-8")) as {
+      pid?: unknown;
+    };
+    if (data.pid !== ownerPid) return;
+  } catch {
+    // Missing, unreadable, or malformed — nothing we own to remove.
+    return;
+  }
+  try {
+    unlinkSync(pidFile);
   } catch {
     // Already gone — fine
   }
@@ -203,6 +230,7 @@ export async function handleBridgeRequest(
   client: BridgeClient,
   req: IncomingMessage,
   res: ServerResponse,
+  sessionName?: string,
 ): Promise<void> {
   res.setHeader("Content-Type", "application/json");
 
@@ -226,7 +254,7 @@ export async function handleBridgeRequest(
         return;
       }
     }
-    writeJson(res, 200, { status: "ok" });
+    writeJson(res, 200, { status: "ok", session: sessionName });
     return;
   }
 
@@ -248,14 +276,52 @@ export async function handleBridgeRequest(
   writeJson(res, 404, { error: "not found" });
 }
 
-export function createBridgeServer(client: BridgeClient): Server {
+export function createBridgeServer(
+  client: BridgeClient,
+  sessionName?: string,
+): Server {
   return createServer((req, res) => {
-    void handleBridgeRequest(client, req, res);
+    void handleBridgeRequest(client, req, res, sessionName);
   });
 }
 
 function logBridgeMessage(message: string): void {
   process.stderr.write(`[chrome-devtools-axi] ${message}\n`);
+}
+
+/**
+ * Distinct exit code the bridge uses for an EADDRINUSE bind failure. A generic
+ * non-zero exit is ambiguous (npx/MCP launch failures exit non-zero too), so
+ * `ensureBridge` keys on this sentinel to attribute an early death to a genuine
+ * port collision versus a startup failure and tailor its error accordingly.
+ */
+export const BRIDGE_PORT_IN_USE_EXIT_CODE = 48;
+
+/**
+ * Handle a fatal HTTP server error by logging it and exiting non-zero. An
+ * EADDRINUSE means another bridge already owns this port (typically because
+ * `CHROME_DEVTOOLS_AXI_PORT` was exported globally, forcing every session onto
+ * one port); it exits with {@link BRIDGE_PORT_IN_USE_EXIT_CODE} so `ensureBridge`
+ * can distinguish it from any other early death. Failing loudly prevents
+ * `ensureBridge` from silently attaching to the other session's bridge. `exit`
+ * is injectable for tests.
+ */
+export function handleBridgeServerError(
+  error: NodeJS.ErrnoException,
+  port: number,
+  exit: (code: number) => void = process.exit,
+): void {
+  if (error.code === "EADDRINUSE") {
+    logBridgeMessage(
+      `Port ${port} is already in use (EADDRINUSE) - another bridge is listening there. ` +
+        `Exporting CHROME_DEVTOOLS_AXI_PORT globally forces every session onto one port; ` +
+        `unset it so each session gets its own, or set it only per-session.`,
+    );
+    exit(BRIDGE_PORT_IN_USE_EXIT_CODE);
+    return;
+  }
+  logBridgeMessage(`Bridge server error: ${getErrorMessage(error)}`);
+  exit(1);
 }
 
 function writeReadySignal(): void {
@@ -435,13 +501,23 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
-export async function runBridge(port = DEFAULT_PORT): Promise<void> {
+export async function runBridge(port = resolveSessionPort()): Promise<void> {
+  // Connect the MCP transport (which spawns chrome-devtools-mcp and launches
+  // Chrome) before binding the port. A same-session bind race then self-heals:
+  // both racers finish booting before listen(), so the loser's EADDRINUSE exit
+  // finds the winner already deep-healthy and reuses it instead of failing. The
+  // trade-off is one wasted Chrome launch on a genuine cross-session collision,
+  // a rare and self-correcting path.
   const transport = createTransport();
   const client = createBridgeClient();
   await client.connect(transport);
   logBridgeMessage("Connected to chrome-devtools-mcp");
 
-  const server = createBridgeServer(client);
+  const sessionName = resolveSessionName();
+  const server = createBridgeServer(client, sessionName);
+  server.on("error", (error: NodeJS.ErrnoException) => {
+    handleBridgeServerError(error, port);
+  });
   server.listen(port, "127.0.0.1", () => {
     writePidFile(port);
     logBridgeMessage(`Listening on http://127.0.0.1:${port}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,12 @@ environment:
                                     (no shell-style quoting; flags with spaces are not supported)
                                     e.g. "--enable-gpu --ignore-gpu-blocklist"
   CHROME_DEVTOOLS_AXI_PORT          Bridge server port (default: 9224)
+  CHROME_DEVTOOLS_AXI_SESSION       Named session for concurrent isolation. Each session name gets
+                                    its own bridge process, port (auto-derived from the name, or set
+                                    CHROME_DEVTOOLS_AXI_PORT), and on-disk state, so multiple sessions
+                                    run at once without colliding. Connection mode and profile are
+                                    unchanged. Defaults to "default" (port 9224, legacy state paths).
+                                    e.g. CHROME_DEVTOOLS_AXI_SESSION=worker-1
   CHROME_DEVTOOLS_AXI_BROWSER_URL   Connect to an existing Chrome instance instead of launching one.
                                     http(s):// uses --browserUrl (fetches /json/version).
                                     ws(s):// uses --wsEndpoint (direct WebSocket).

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,15 +4,15 @@
 
 import { execFileSync, spawn } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
 import { request } from "node:http";
 import { AxiError } from "axi-sdk-js";
-import { resolveBridgeScript } from "./bridge.js";
+import { BRIDGE_PORT_IN_USE_EXIT_CODE, resolveBridgeScript } from "./bridge.js";
+import {
+  resolveSessionName,
+  resolveSessionPidFile,
+  resolveSessionPort,
+} from "./sessions.js";
 
-const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
-const PID_FILE = join(STATE_DIR, "bridge.pid");
-const DEFAULT_PORT = 9224;
 const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
 const MIN_BRIDGE_TIMEOUT_MS = 1_000;
 const HEALTH_TIMEOUT_MS = 2_000;
@@ -58,10 +58,12 @@ interface PidInfo {
   port: number;
 }
 
-function readPidFile(): PidInfo | null {
+function readPidFile(
+  pidFile: string = resolveSessionPidFile(),
+): PidInfo | null {
   try {
-    if (!existsSync(PID_FILE)) return null;
-    const data = JSON.parse(readFileSync(PID_FILE, "utf-8"));
+    if (!existsSync(pidFile)) return null;
+    const data = JSON.parse(readFileSync(pidFile, "utf-8"));
     if (typeof data.pid === "number" && typeof data.port === "number") {
       return data as PidInfo;
     }
@@ -150,18 +152,32 @@ function httpPost(
  * to drive one CDP-backed MCP call (`list_pages`) so callers can distinguish
  * "MCP server is up but the attached browser is gone" from genuine readiness.
  *
+ * With `expectedSession`, a bridge that reports a *different* session name is
+ * treated as unhealthy, so a session never silently reuses another session's
+ * bridge after a port collision (two sessions pinned to one port via a global
+ * `CHROME_DEVTOOLS_AXI_PORT`). A bridge that omits the field (older version) is
+ * accepted, since there is no mismatch to detect.
+ *
  * Exported for tests; production code uses it via `ensureBridge`.
  */
 export async function checkBridgeHealth(
   port: number,
-  opts: { deep?: boolean } = {},
+  opts: { deep?: boolean; expectedSession?: string } = {},
 ): Promise<boolean> {
   try {
     const path = opts.deep ? "/health?deep=1" : "/health";
     const timeoutMs = opts.deep ? DEEP_HEALTH_TIMEOUT_MS : HEALTH_TIMEOUT_MS;
     const resp = await httpGet(port, path, timeoutMs);
     const data = JSON.parse(resp);
-    return data.status === "ok";
+    if (data.status !== "ok") return false;
+    if (
+      opts.expectedSession !== undefined &&
+      typeof data.session === "string" &&
+      data.session !== opts.expectedSession
+    ) {
+      return false;
+    }
+    return true;
   } catch {
     return false;
   }
@@ -250,35 +266,24 @@ export async function terminateBridgeProcess(
 }
 
 /**
- * Ensure the bridge is running, starting it if needed. Returns the port.
- *
- * Verifies a *deep* health check (one round-trip CDP-backed MCP call) before
- * declaring the bridge ready, so a bridge whose attached browser/Electron
- * target was killed while still answering local /health requests gets torn
- * down + restarted instead of being reused as a stale endpoint.
+ * Minimal view of the spawned bridge process that {@link ensureBridge} needs:
+ * an `exit` notification so a bridge that dies before reporting healthy can be
+ * detected. The default {@link spawnBridgeProcess} returns a `ChildProcess`
+ * (which satisfies this); tests inject a fake.
  */
-export async function ensureBridge(): Promise<number> {
-  const port = parseInt(
-    process.env.CHROME_DEVTOOLS_AXI_PORT ?? String(DEFAULT_PORT),
-    10,
-  );
+export interface SpawnedBridge {
+  on(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): void;
+}
 
-  // Check existing bridge via PID file. Use a deep probe so a bridge whose
-  // attached CDP target has gone away gets recycled instead of returned.
-  const pidInfo = readPidFile();
-  if (pidInfo && isProcessAlive(pidInfo.pid)) {
-    if (await checkBridgeHealth(pidInfo.port, { deep: true })) {
-      return pidInfo.port;
-    }
-    await terminateBridgeProcess(pidInfo.pid, {
-      killProcessGroup: isBridgeProcess(pidInfo.pid),
-    });
-  }
-
-  // Start a new bridge
-
+/**
+ * Spawn the detached bridge process. Prefers the sibling `.ts` (dev mode, run
+ * via tsx) and falls back to the built `.js`, so dev and dist behave the same.
+ */
+function spawnBridgeProcess(port: number, sessionName: string): SpawnedBridge {
   const bridgeScript = resolveBridgeScript(import.meta.dirname);
-  // Try .ts first (dev mode), fall back to .js (built)
   const script = existsSync(bridgeScript.replace(/\.js$/, ".ts"))
     ? bridgeScript.replace(/\.js$/, ".ts")
     : bridgeScript;
@@ -289,11 +294,122 @@ export async function ensureBridge(): Promise<number> {
     runner === "tsx" ? ["tsx", script] : [script],
     {
       stdio: "ignore",
-      env: { ...process.env, CHROME_DEVTOOLS_AXI_PORT: String(port) },
+      env: {
+        ...process.env,
+        CHROME_DEVTOOLS_AXI_PORT: String(port),
+        CHROME_DEVTOOLS_AXI_SESSION: sessionName,
+      },
       detached: true,
     },
   );
   child.unref();
+  return child;
+}
+
+/**
+ * Build the error thrown when a freshly spawned bridge exits before it ever
+ * reports healthy. Surfacing this the moment the child dies - rather than
+ * polling the full readiness deadline - turns an early death into a fast,
+ * actionable failure instead of a slow, generic "failed to start" timeout.
+ *
+ * The guidance is attributed by exit code. Only {@link BRIDGE_PORT_IN_USE_EXIT_CODE}
+ * (the bridge's EADDRINUSE sentinel) gets the port-in-use explanation; any
+ * other early death is a startup failure (npx could not resolve/download
+ * chrome-devtools-mcp, a broken `CHROME_DEVTOOLS_AXI_MCP_PATH`, or a
+ * Chrome launch failure) and gets the generic startup guidance, so a
+ * single-session user with a broken install is not misdirected to port advice.
+ */
+export function buildBridgeEarlyExitError(
+  sessionName: string,
+  port: number,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): CdpError {
+  const how =
+    signal != null
+      ? `was killed by ${signal}`
+      : `exited with code ${code ?? "unknown"}`;
+  const message = `Bridge for session "${sessionName}" ${how} before becoming ready on port ${port}`;
+
+  if (code === BRIDGE_PORT_IN_USE_EXIT_CODE) {
+    return new CdpError(message, "BRIDGE_NOT_READY", [
+      `Port ${port} is already in use. It may be held by another chrome-devtools-axi session's bridge (a hashed-port collision, or a globally-exported CHROME_DEVTOOLS_AXI_PORT forcing every session onto one port), by a stale or crashed bridge that could not be reused, or by an unrelated process.`,
+      "Set a distinct CHROME_DEVTOOLS_AXI_PORT for this session, unset a global CHROME_DEVTOOLS_AXI_PORT so every session derives its own, or free whatever is holding the port.",
+    ]);
+  }
+
+  const suggestions = [
+    "Check that chrome-devtools-mcp can start: npx chrome-devtools-mcp@latest --help",
+  ];
+  if (process.env.CHROME_DEVTOOLS_AXI_MCP_PATH) {
+    suggestions.push(
+      "Verify CHROME_DEVTOOLS_AXI_MCP_PATH points to a valid chrome-devtools-mcp build.",
+    );
+  } else {
+    suggestions.push(
+      "`npx -y chrome-devtools-mcp@latest` may have failed to resolve/download the package (offline, or a slow cold first run); install it globally and set:",
+      '  export CHROME_DEVTOOLS_AXI_MCP_PATH="$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"',
+    );
+  }
+  suggestions.push(
+    "Or Chrome failed to launch; confirm a usable Chrome is installed.",
+  );
+  return new CdpError(message, "BRIDGE_NOT_READY", suggestions);
+}
+
+/**
+ * Ensure the bridge is running, starting it if needed. Returns the port.
+ *
+ * Verifies a *deep* health check (one round-trip CDP-backed MCP call) before
+ * declaring the bridge ready, so a bridge whose attached browser/Electron
+ * target was killed while still answering local /health requests gets torn
+ * down + restarted instead of being reused as a stale endpoint.
+ *
+ * `spawnBridge` is injectable for tests; production uses {@link spawnBridgeProcess}.
+ */
+export async function ensureBridge(
+  spawnBridge: (
+    port: number,
+    sessionName: string,
+  ) => SpawnedBridge = spawnBridgeProcess,
+): Promise<number> {
+  const sessionName = resolveSessionName();
+  const port = resolveSessionPort(sessionName);
+  const pidFile = resolveSessionPidFile(sessionName);
+
+  // Check existing bridge via PID file. Use a deep probe so a bridge whose
+  // attached CDP target has gone away gets recycled instead of returned.
+  const pidInfo = readPidFile(pidFile);
+  if (pidInfo && isProcessAlive(pidInfo.pid)) {
+    if (
+      await checkBridgeHealth(pidInfo.port, {
+        deep: true,
+        expectedSession: sessionName,
+      })
+    ) {
+      return pidInfo.port;
+    }
+    await terminateBridgeProcess(pidInfo.pid, {
+      killProcessGroup: isBridgeProcess(pidInfo.pid),
+    });
+  }
+
+  // Start a new bridge
+  const child = spawnBridge(port, sessionName);
+
+  // If the freshly spawned bridge dies before it reports healthy - an EADDRINUSE
+  // port collision with another session, or a startup failure (npx/MCP launch,
+  // Chrome), whose stderr is lost to `stdio: "ignore"` - fail fast
+  // instead of polling the full readiness deadline and reporting a generic
+  // timeout. The exit code attributes the cause (see buildBridgeEarlyExitError).
+  let childExited = false;
+  let exitCode: number | null = null;
+  let exitSignal: NodeJS.Signals | null = null;
+  child.on("exit", (code, signal) => {
+    childExited = true;
+    exitCode = code;
+    exitSignal = signal;
+  });
 
   // Poll for health — Chrome launch + npx bootstrap can be slow.
   // Track whether the *shallow* health check ever passed so we can attribute
@@ -304,10 +420,29 @@ export async function ensureBridge(): Promise<number> {
   const deadline = Date.now() + timeoutMs;
   let sawShallowReady = false;
   while (Date.now() < deadline) {
-    if (await checkBridgeHealth(port, { deep: true })) {
+    if (
+      await checkBridgeHealth(port, {
+        deep: true,
+        expectedSession: sessionName,
+      })
+    ) {
       return port;
     }
-    if (!sawShallowReady && (await checkBridgeHealth(port))) {
+    if (childExited) {
+      if (
+        await checkBridgeHealth(port, {
+          deep: true,
+          expectedSession: sessionName,
+        })
+      ) {
+        return port;
+      }
+      throw buildBridgeEarlyExitError(sessionName, port, exitCode, exitSignal);
+    }
+    if (
+      !sawShallowReady &&
+      (await checkBridgeHealth(port, { expectedSession: sessionName }))
+    ) {
       sawShallowReady = true;
     }
     await sleep(500);
@@ -404,14 +539,27 @@ export function mapErrorMessage(message: string): CdpError {
 
 /**
  * Get the current page snapshot without starting the bridge.
- * Returns null if the bridge is not running or healthy.
+ *
+ * Returns null if the bridge is not running or healthy. This is the ambient
+ * home view / SessionStart probe, so it must stay cheap and never throw: an
+ * invalid `CHROME_DEVTOOLS_AXI_SESSION` degrades to "no active session" (null)
+ * here, while action commands (`ensureBridge` / `stopBridge`) still fail loudly.
  */
 export async function getSessionSnapshotIfRunning(): Promise<string | null> {
-  const pidInfo = readPidFile();
+  let sessionName: string;
+  let pidInfo: PidInfo | null;
+  try {
+    sessionName = resolveSessionName();
+    pidInfo = readPidFile(resolveSessionPidFile(sessionName));
+  } catch {
+    return null;
+  }
   if (!pidInfo || !isProcessAlive(pidInfo.pid)) {
     return null;
   }
-  if (!(await checkBridgeHealth(pidInfo.port))) {
+  if (
+    !(await checkBridgeHealth(pidInfo.port, { expectedSession: sessionName }))
+  ) {
     return null;
   }
   try {

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -12,16 +12,19 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { resolveSessionStateDir } from "./sessions.js";
 
-const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
-const GEN_FILE = join(STATE_DIR, "snapshot-generation");
+/** Path to the active session's snapshot-generation counter file. */
+function genFile(): string {
+  return join(resolveSessionStateDir(), "snapshot-generation");
+}
 
 export function getCurrentGeneration(): number {
+  const file = genFile();
   try {
-    if (!existsSync(GEN_FILE)) return 0;
-    const parsed = Number.parseInt(readFileSync(GEN_FILE, "utf-8").trim(), 10);
+    if (!existsSync(file)) return 0;
+    const parsed = Number.parseInt(readFileSync(file, "utf-8").trim(), 10);
     return Number.isNaN(parsed) ? 0 : parsed;
   } catch {
     return 0;
@@ -30,9 +33,10 @@ export function getCurrentGeneration(): number {
 
 export function bumpGeneration(): number {
   const next = getCurrentGeneration() + 1;
+  const file = genFile();
   try {
-    mkdirSync(STATE_DIR, { recursive: true });
-    writeFileSync(GEN_FILE, String(next));
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, String(next));
   } catch {
     // Best-effort: a write failure still returns the bumped value so the
     // current invocation behaves consistently. The next process will
@@ -43,8 +47,9 @@ export function bumpGeneration(): number {
 }
 
 export function resetGeneration(): void {
+  const file = genFile();
   try {
-    if (existsSync(GEN_FILE)) unlinkSync(GEN_FILE);
+    if (existsSync(file)) unlinkSync(file);
   } catch {
     // ignore
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,0 +1,122 @@
+/**
+ * Named sessions - per-session bridge isolation.
+ *
+ * Setting `CHROME_DEVTOOLS_AXI_SESSION` to a non-default name binds the
+ * bridge's port and on-disk state (PID file, snapshot-generation counter) to
+ * that name, so multiple bridges can run concurrently - one per agent session,
+ * worktree, or test worker - without sharing a single bridge or stepping on
+ * each other's stale-ref tracking.
+ *
+ *   CHROME_DEVTOOLS_AXI_SESSION=worker-1 chrome-devtools-axi open ...
+ *   CHROME_DEVTOOLS_AXI_SESSION=worker-2 chrome-devtools-axi open ...
+ *
+ * A session only isolates the bridge itself; the connection mode and profile
+ * (AUTO_CONNECT / BROWSER_URL / USER_DATA_DIR / --isolated) are unchanged. For
+ * a persistent per-session profile, combine with CHROME_DEVTOOLS_AXI_USER_DATA_DIR.
+ *
+ * Precedence:
+ *   port      - CHROME_DEVTOOLS_AXI_PORT > deterministic hash of the session name
+ *   state dir - always derived from the session name
+ *
+ * The default session name is "default", which preserves prior behavior: port
+ * 9224 and the legacy `~/.chrome-devtools-axi/` state paths.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export const DEFAULT_SESSION_NAME = "default";
+export const DEFAULT_BASE_PORT = 9224;
+
+const SESSION_PORT_RANGE = 100; // 9225..9324 reserved for named sessions
+const STATE_DIR_NAME = ".chrome-devtools-axi";
+
+/**
+ * Resolve the active session name from `CHROME_DEVTOOLS_AXI_SESSION`. Returns
+ * DEFAULT_SESSION_NAME when unset, empty, or whitespace.
+ *
+ * A configured-but-unsafe name throws (via `validateSessionName`). This is the
+ * single chokepoint through which every command obtains the active session, so
+ * validating here guarantees that no entry point - `ensureBridge`, `stopBridge`,
+ * `getSessionSnapshotIfRunning`, the generation counter, or the bridge itself -
+ * can resolve an invalid name into a filesystem path that collapses onto the
+ * default session's directory.
+ */
+export function resolveSessionName(): string {
+  const raw = process.env.CHROME_DEVTOOLS_AXI_SESSION?.trim();
+  const name = raw && raw.length > 0 ? raw : DEFAULT_SESSION_NAME;
+  validateSessionName(name);
+  return name;
+}
+
+/**
+ * Throw if a non-default session name is unsafe for a filesystem path. Allows
+ * 1-64 chars from `[A-Za-z0-9._-]`; rejects path traversal, separators, shell
+ * metacharacters, overlong names, and names made only of dots (`.` / `..` /
+ * `...`), which `resolveSessionStateDir` would otherwise collapse onto the
+ * default session's directory.
+ */
+export function validateSessionName(name: string): void {
+  if (name === DEFAULT_SESSION_NAME) return;
+  if (!/^[A-Za-z0-9._-]{1,64}$/.test(name)) {
+    throw new Error(
+      `Invalid CHROME_DEVTOOLS_AXI_SESSION "${name}": use 1-64 chars from [A-Za-z0-9._-]`,
+    );
+  }
+  if (/^\.+$/.test(name)) {
+    throw new Error(
+      `Invalid CHROME_DEVTOOLS_AXI_SESSION "${name}": a name made only of dots would collapse onto the default session's state directory`,
+    );
+  }
+}
+
+/**
+ * Deterministic port for a session name: an FNV-1a hash mapped into
+ * [DEFAULT_BASE_PORT+1, DEFAULT_BASE_PORT+SESSION_PORT_RANGE]. The default
+ * session keeps DEFAULT_BASE_PORT. Two distinct names can hash to the same
+ * port - a concurrency limit, not a correctness bug; set
+ * CHROME_DEVTOOLS_AXI_PORT to break a collision.
+ */
+export function defaultPortForSession(name: string): number {
+  if (name === DEFAULT_SESSION_NAME) return DEFAULT_BASE_PORT;
+  let hash = 2166136261;
+  for (let i = 0; i < name.length; i++) {
+    hash ^= name.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return DEFAULT_BASE_PORT + (Math.abs(hash) % SESSION_PORT_RANGE) + 1;
+}
+
+/**
+ * Resolve the bridge port for a session: explicit `CHROME_DEVTOOLS_AXI_PORT`
+ * wins, otherwise the session-derived default.
+ */
+export function resolveSessionPort(
+  name: string = resolveSessionName(),
+): number {
+  const explicit = process.env.CHROME_DEVTOOLS_AXI_PORT;
+  if (explicit) {
+    const parsed = Number.parseInt(explicit, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return defaultPortForSession(name);
+}
+
+/**
+ * State directory for a session. The default session keeps the legacy
+ * `~/.chrome-devtools-axi/` path so existing tools and older versions stay
+ * compatible; named sessions live under a per-name subdirectory.
+ */
+export function resolveSessionStateDir(
+  name: string = resolveSessionName(),
+): string {
+  const base = join(homedir(), STATE_DIR_NAME);
+  return name === DEFAULT_SESSION_NAME ? base : join(base, "sessions", name);
+}
+
+/** PID file path for a session, under its state directory. */
+export function resolveSessionPidFile(
+  name: string = resolveSessionName(),
+): string {
+  return join(resolveSessionStateDir(name), "bridge.pid");
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -28,7 +28,7 @@ import { homedir } from "node:os";
 export const DEFAULT_SESSION_NAME = "default";
 export const DEFAULT_BASE_PORT = 9224;
 
-const SESSION_PORT_RANGE = 100; // 9225..9324 reserved for named sessions
+const SESSION_PORT_RANGE = 1000; // 9225..10224 reserved for named sessions
 const STATE_DIR_NAME = ".chrome-devtools-axi";
 
 /**

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  BRIDGE_PORT_IN_USE_EXIT_CODE,
   buildTransportArgs,
   detectGlobalMcpPath,
   extractToolText,
   getErrorMessage,
   handleBridgeRequest,
+  handleBridgeServerError,
   isBridgeClientConnected,
   isBridgeTargetReachable,
   parseBridgeCallPayload,
+  removePidFile,
   resolveBridgeScript,
   resolveTransportSpec,
   type BridgeClient,
@@ -597,6 +603,28 @@ describe("handleBridgeRequest /health", () => {
     expect(JSON.parse(captured.body)).toEqual({ status: "ok" });
   });
 
+  it("stamps the session name into the /health response when provided", async () => {
+    const client: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => ({ content: [] }),
+      close: async () => {},
+    };
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest("GET", "/health"),
+      res,
+      "worker-1",
+    );
+
+    expect(captured.statusCode).toBe(200);
+    expect(JSON.parse(captured.body)).toEqual({
+      status: "ok",
+      session: "worker-1",
+    });
+  });
+
   it("returns 503 when MCP server is disconnected", async () => {
     const client: BridgeClient = {
       listTools: async () => {
@@ -677,5 +705,95 @@ describe("handleBridgeRequest /health", () => {
 
     expect(captured.statusCode).toBe(200);
     expect(callToolCalls).toBe(0);
+  });
+});
+
+describe("handleBridgeServerError", () => {
+  function captureStderr<T>(fn: () => T): { result: T; stderr: string } {
+    const original = process.stderr.write.bind(process.stderr);
+    let stderr = "";
+    process.stderr.write = ((chunk: unknown) => {
+      stderr += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      return { result: fn(), stderr };
+    } finally {
+      process.stderr.write = original;
+    }
+  }
+
+  it("exits with the distinct EADDRINUSE code so ensureBridge can attribute a collision", () => {
+    const exitCodes: number[] = [];
+    const { stderr } = captureStderr(() =>
+      handleBridgeServerError(
+        Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" }),
+        9225,
+        (code) => exitCodes.push(code),
+      ),
+    );
+
+    expect(exitCodes).toEqual([BRIDGE_PORT_IN_USE_EXIT_CODE]);
+    expect(BRIDGE_PORT_IN_USE_EXIT_CODE).not.toBe(1);
+    expect(stderr).toContain("9225");
+    expect(stderr).toContain("EADDRINUSE");
+    expect(stderr).toContain("CHROME_DEVTOOLS_AXI_PORT");
+  });
+
+  it("exits non-zero for other fatal server errors", () => {
+    const exitCodes: number[] = [];
+    const { stderr } = captureStderr(() =>
+      handleBridgeServerError(
+        Object.assign(new Error("boom"), { code: "EACCES" }),
+        9225,
+        (code) => exitCodes.push(code),
+      ),
+    );
+
+    expect(exitCodes).toEqual([1]);
+    expect(stderr).toContain("boom");
+  });
+});
+
+describe("removePidFile ownership", () => {
+  let dir: string;
+  let pidFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cda-pid-"));
+    pidFile = join(dir, "bridge.pid");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves the winner's PID file intact when a same-session loser exits", () => {
+    const winnerPid = process.pid + 1;
+    const loserPid = process.pid + 2;
+    writeFileSync(pidFile, JSON.stringify({ pid: winnerPid, port: 9224 }));
+
+    // The EADDRINUSE loser's exit handler must not delete the winner's handle.
+    removePidFile(pidFile, loserPid);
+
+    expect(existsSync(pidFile)).toBe(true);
+  });
+
+  it("removes the PID file when this process owns it", () => {
+    const ownerPid = process.pid + 3;
+    writeFileSync(pidFile, JSON.stringify({ pid: ownerPid, port: 9224 }));
+
+    removePidFile(pidFile, ownerPid);
+
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  it("treats a missing or malformed PID file as nothing to remove", () => {
+    expect(() => removePidFile(pidFile, process.pid)).not.toThrow();
+    expect(existsSync(pidFile)).toBe(false);
+
+    writeFileSync(pidFile, "not json");
+    expect(() => removePidFile(pidFile, process.pid)).not.toThrow();
+    expect(existsSync(pidFile)).toBe(true);
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AxiError } from "axi-sdk-js";
+import { BRIDGE_PORT_IN_USE_EXIT_CODE } from "../src/bridge.js";
 import {
+  buildBridgeEarlyExitError,
   CdpError,
   checkBridgeHealth,
+  ensureBridge,
+  getSessionSnapshotIfRunning,
   mapErrorMessage,
   resolveBridgeTimeoutMs,
+  type SpawnedBridge,
+  stopBridge,
   terminateBridgeProcess,
   waitForProcessExit,
 } from "../src/client.js";
@@ -44,6 +51,33 @@ describe("mapErrorMessage", () => {
 
     expect(error.code).toBe("BROWSER_ERROR");
     expect(error.message).toBe("Page crashed");
+  });
+});
+
+describe("unsafe session names are rejected on action entry points", () => {
+  const saved = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_SESSION = saved;
+    }
+  });
+
+  it("stopBridge rejects a dot-only session instead of killing the default bridge", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "..";
+    await expect(stopBridge()).rejects.toThrow(/Invalid/);
+  });
+
+  it("ensureBridge rejects a dot-only session instead of targeting the default bridge", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "..";
+    await expect(ensureBridge()).rejects.toThrow(/Invalid/);
+  });
+
+  it("getSessionSnapshotIfRunning degrades an invalid session to null instead of throwing", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "..";
+    await expect(getSessionSnapshotIfRunning()).resolves.toBeNull();
   });
 });
 
@@ -94,6 +128,7 @@ interface FakeBridgeOptions {
   shallow: "ok" | "error";
   deep: "ok" | "error";
   deepDelayMs?: number;
+  session?: string;
 }
 
 function startFakeBridgeServer(opts: FakeBridgeOptions): Promise<{
@@ -110,7 +145,7 @@ function startFakeBridgeServer(opts: FakeBridgeOptions): Promise<{
         const sendResponse = () => {
           if (outcome === "ok") {
             res.statusCode = 200;
-            res.end(JSON.stringify({ status: "ok" }));
+            res.end(JSON.stringify({ status: "ok", session: opts.session }));
           } else {
             res.statusCode = 503;
             res.end(JSON.stringify({ status: "error" }));
@@ -190,6 +225,230 @@ describe("checkBridgeHealth (deep probe)", () => {
     // Port 1 is privileged and unbound — connection should be refused immediately.
     expect(await checkBridgeHealth(1)).toBe(false);
     expect(await checkBridgeHealth(1, { deep: true })).toBe(false);
+  });
+
+  it("treats a session-name mismatch as unhealthy (another session's bridge)", async () => {
+    const fake = await startFakeBridgeServer({
+      shallow: "ok",
+      deep: "ok",
+      session: "worker-1",
+    });
+    try {
+      expect(
+        await checkBridgeHealth(fake.port, { expectedSession: "worker-2" }),
+      ).toBe(false);
+      expect(
+        await checkBridgeHealth(fake.port, {
+          deep: true,
+          expectedSession: "worker-2",
+        }),
+      ).toBe(false);
+      expect(
+        await checkBridgeHealth(fake.port, { expectedSession: "worker-1" }),
+      ).toBe(true);
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("accepts a bridge that omits the session field (older version)", async () => {
+    const fake = await startFakeBridgeServer({ shallow: "ok", deep: "ok" });
+    try {
+      expect(
+        await checkBridgeHealth(fake.port, { expectedSession: "worker-1" }),
+      ).toBe(true);
+    } finally {
+      await fake.close();
+    }
+  });
+});
+
+describe("buildBridgeEarlyExitError", () => {
+  const savedMcpPath = process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+
+  afterEach(() => {
+    const restore = (key: string, value: string | undefined) => {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    };
+    restore("CHROME_DEVTOOLS_AXI_MCP_PATH", savedMcpPath);
+  });
+
+  it("names the session, port, exit code, and the port-in-use remedy on the EADDRINUSE code", () => {
+    const err = buildBridgeEarlyExitError(
+      "worker-2",
+      9231,
+      BRIDGE_PORT_IN_USE_EXIT_CODE,
+      null,
+    );
+
+    expect(err).toBeInstanceOf(CdpError);
+    expect(err.code).toBe("BRIDGE_NOT_READY");
+    expect(err.message).toContain("worker-2");
+    expect(err.message).toContain("9231");
+    expect(err.message).toContain(
+      `exited with code ${BRIDGE_PORT_IN_USE_EXIT_CODE}`,
+    );
+    const suggestions = err.suggestions.join("\n");
+    expect(suggestions).toContain("9231");
+    expect(suggestions).toContain("CHROME_DEVTOOLS_AXI_PORT");
+    // Balanced wording: not over-attributed to a session collision - also
+    // names stale/crashed bridges and unrelated processes, with the
+    // free-the-port remedy stated directly.
+    expect(suggestions).toContain("unrelated process");
+    expect(suggestions).toMatch(/stale|crashed/);
+    expect(suggestions).toContain("free");
+  });
+
+  it("gives generic startup guidance (not port collision) for a non-EADDRINUSE early exit", () => {
+    delete process.env.CHROME_DEVTOOLS_AXI_MCP_PATH;
+    const err = buildBridgeEarlyExitError("worker-2", 9231, 1, null);
+
+    expect(err.code).toBe("BRIDGE_NOT_READY");
+    expect(err.message).toContain("exited with code 1");
+    const suggestions = err.suggestions.join("\n");
+    expect(suggestions).toContain("chrome-devtools-mcp");
+    expect(suggestions).not.toContain("hashed-port collision");
+    expect(suggestions).not.toContain("another session's bridge");
+  });
+
+  it("points at CHROME_DEVTOOLS_AXI_MCP_PATH when an explicit path is set", () => {
+    process.env.CHROME_DEVTOOLS_AXI_MCP_PATH = "/opt/mcp.js";
+    const err = buildBridgeEarlyExitError("worker-2", 9231, 1, null);
+
+    const suggestions = err.suggestions.join("\n");
+    expect(suggestions).toContain("CHROME_DEVTOOLS_AXI_MCP_PATH");
+    expect(suggestions).not.toContain("npm prefix -g");
+  });
+
+  it("reports the terminating signal when the bridge was killed", () => {
+    const err = buildBridgeEarlyExitError("worker-2", 9231, null, "SIGKILL");
+
+    expect(err.message).toContain("was killed by SIGKILL");
+  });
+});
+
+describe("ensureBridge early-exit fast-fail", () => {
+  const savedSession = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+  const savedHome = process.env.HOME;
+  const savedTimeout = process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
+  const savedPort = process.env.CHROME_DEVTOOLS_AXI_PORT;
+  let tmpHome: string;
+
+  const restore = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+
+  beforeEach(() => {
+    // Isolate state under a throwaway HOME so no real bridge.pid is found and
+    // ensureBridge is forced down the spawn-a-new-bridge path.
+    tmpHome = mkdtempSync(join(tmpdir(), "axi-ensure-bridge-"));
+    process.env.HOME = tmpHome;
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "early-exit-worker";
+    delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+    // A long deadline so the assertion proves the *early-exit* path returns
+    // fast, not that it merely hit the timeout.
+    process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "20000";
+  });
+
+  afterEach(() => {
+    restore("CHROME_DEVTOOLS_AXI_SESSION", savedSession);
+    restore("HOME", savedHome);
+    restore("CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS", savedTimeout);
+    restore("CHROME_DEVTOOLS_AXI_PORT", savedPort);
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("fails fast with a port-collision error when the bridge exits with the EADDRINUSE code", async () => {
+    const start = Date.now();
+    let caught: unknown;
+    try {
+      await ensureBridge(() => {
+        const fake = new EventEmitter();
+        // Emit *after* ensureBridge attaches its exit listener.
+        setImmediate(() =>
+          fake.emit("exit", BRIDGE_PORT_IN_USE_EXIT_CODE, null),
+        );
+        return fake as unknown as SpawnedBridge;
+      });
+    } catch (error) {
+      caught = error;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(caught).toBeInstanceOf(CdpError);
+    expect((caught as CdpError).code).toBe("BRIDGE_NOT_READY");
+    expect((caught as CdpError).message).toContain("before becoming ready");
+    expect((caught as CdpError).suggestions.join("\n")).toContain(
+      "CHROME_DEVTOOLS_AXI_PORT",
+    );
+    // The whole point: detecting the early exit must beat the 20s deadline.
+    expect(elapsed).toBeLessThan(5000);
+  });
+
+  it("fails fast with generic startup guidance for a non-EADDRINUSE early exit", async () => {
+    const start = Date.now();
+    let caught: unknown;
+    try {
+      await ensureBridge(() => {
+        const fake = new EventEmitter();
+        setImmediate(() => fake.emit("exit", 1, null));
+        return fake as unknown as SpawnedBridge;
+      });
+    } catch (error) {
+      caught = error;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(caught).toBeInstanceOf(CdpError);
+    const suggestions = (caught as CdpError).suggestions.join("\n");
+    expect(suggestions).toContain("chrome-devtools-mcp");
+    expect(suggestions).not.toContain("hashed-port collision");
+    expect(elapsed).toBeLessThan(5000);
+  });
+
+  it("reuses a healthy same-session bridge that won the bind race instead of failing on the loser's early exit", async () => {
+    // A concurrent same-session bridge owns the port and reports healthy only on
+    // the *second* deep probe, so the loser's first in-loop check fails and the
+    // pre-throw final deep check is what catches the winner.
+    let deepProbes = 0;
+    const winner = createServer((req, res) => {
+      if (req.method === "GET" && req.url?.startsWith("/health")) {
+        const wantsDeep = req.url.includes("deep=1");
+        if (wantsDeep) deepProbes++;
+        res.setHeader("Content-Type", "application/json");
+        const healthy = !wantsDeep || deepProbes >= 2;
+        res.statusCode = healthy ? 200 : 503;
+        res.end(
+          JSON.stringify(
+            healthy
+              ? { status: "ok", session: "early-exit-worker" }
+              : { status: "error" },
+          ),
+        );
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    await new Promise<void>((r) => winner.listen(0, "127.0.0.1", () => r()));
+    const winnerPort = (winner.address() as AddressInfo).port;
+    process.env.CHROME_DEVTOOLS_AXI_PORT = String(winnerPort);
+
+    try {
+      const port = await ensureBridge(() => {
+        const loser = new EventEmitter();
+        setImmediate(() =>
+          loser.emit("exit", BRIDGE_PORT_IN_USE_EXIT_CODE, null),
+        );
+        return loser as unknown as SpawnedBridge;
+      });
+      expect(port).toBe(winnerPort);
+      expect(deepProbes).toBeGreaterThanOrEqual(2);
+    } finally {
+      await new Promise<void>((r) => winner.close(() => r()));
+    }
   });
 });
 

--- a/test/generation.test.ts
+++ b/test/generation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  bumpGeneration,
+  getCurrentGeneration,
+  resetGeneration,
+} from "../src/generation.js";
+
+describe("generation counter session-name validation", () => {
+  const saved = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_SESSION = saved;
+    }
+  });
+
+  it("rejects a dot-only session instead of reading the default session's counter", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "..";
+    expect(() => getCurrentGeneration()).toThrow(/Invalid/);
+    expect(() => bumpGeneration()).toThrow(/Invalid/);
+    expect(() => resetGeneration()).toThrow(/Invalid/);
+  });
+});

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_BASE_PORT,
+  DEFAULT_SESSION_NAME,
+  defaultPortForSession,
+  resolveSessionName,
+  resolveSessionPidFile,
+  resolveSessionPort,
+  resolveSessionStateDir,
+  validateSessionName,
+} from "../src/sessions.js";
+
+const STATE_DIR = join(homedir(), ".chrome-devtools-axi");
+
+describe("resolveSessionName", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved.CHROME_DEVTOOLS_AXI_SESSION = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+  });
+
+  afterEach(() => {
+    if (saved.CHROME_DEVTOOLS_AXI_SESSION === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_SESSION =
+        saved.CHROME_DEVTOOLS_AXI_SESSION;
+    }
+  });
+
+  it('defaults to "default" when unset', () => {
+    expect(resolveSessionName()).toBe(DEFAULT_SESSION_NAME);
+  });
+
+  it('defaults to "default" when empty or whitespace', () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "   ";
+    expect(resolveSessionName()).toBe(DEFAULT_SESSION_NAME);
+  });
+
+  it("trims the configured name", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "  worker-1  ";
+    expect(resolveSessionName()).toBe("worker-1");
+  });
+
+  it("throws on a configured-but-unsafe name", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "../escape";
+    expect(() => resolveSessionName()).toThrow(/Invalid/);
+  });
+
+  it("throws on a dot-only name that would collapse onto the default dir", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "..";
+    expect(() => resolveSessionName()).toThrow(/Invalid/);
+  });
+});
+
+describe("validateSessionName", () => {
+  it('accepts "default" and safe names', () => {
+    expect(() => validateSessionName(DEFAULT_SESSION_NAME)).not.toThrow();
+    expect(() => validateSessionName("worker-1")).not.toThrow();
+    expect(() => validateSessionName("ceo.admin_2")).not.toThrow();
+  });
+
+  it("rejects path traversal and separators", () => {
+    expect(() => validateSessionName("../escape")).toThrow(/Invalid/);
+    expect(() => validateSessionName("a/b")).toThrow(/Invalid/);
+  });
+
+  it("rejects dot-only names that would collapse onto the default dir", () => {
+    expect(() => validateSessionName(".")).toThrow(/Invalid/);
+    expect(() => validateSessionName("..")).toThrow(/Invalid/);
+    expect(() => validateSessionName("...")).toThrow(/Invalid/);
+  });
+
+  it("rejects shell metacharacters and spaces", () => {
+    expect(() => validateSessionName("a b")).toThrow(/Invalid/);
+    expect(() => validateSessionName("a;b")).toThrow(/Invalid/);
+    expect(() => validateSessionName("a$b")).toThrow(/Invalid/);
+  });
+
+  it("rejects empty and overlong names", () => {
+    expect(() => validateSessionName("")).toThrow(/Invalid/);
+    expect(() => validateSessionName("x".repeat(65))).toThrow(/Invalid/);
+  });
+});
+
+describe("defaultPortForSession", () => {
+  it("returns the base port for the default session", () => {
+    expect(defaultPortForSession(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+  });
+
+  it("is deterministic per name", () => {
+    expect(defaultPortForSession("worker-1")).toBe(
+      defaultPortForSession("worker-1"),
+    );
+  });
+
+  it("stays within the named-session range (9225..9324)", () => {
+    for (const name of ["a", "worker-1", "ceo", "x".repeat(64)]) {
+      const port = defaultPortForSession(name);
+      expect(port).toBeGreaterThanOrEqual(DEFAULT_BASE_PORT + 1);
+      expect(port).toBeLessThanOrEqual(DEFAULT_BASE_PORT + 100);
+    }
+  });
+
+  it("spreads distinct names across ports", () => {
+    const ports = new Set(["alice", "bob", "carol"].map(defaultPortForSession));
+    expect(ports.size).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("resolveSessionPort", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved.CHROME_DEVTOOLS_AXI_PORT = process.env.CHROME_DEVTOOLS_AXI_PORT;
+    delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+  });
+
+  afterEach(() => {
+    if (saved.CHROME_DEVTOOLS_AXI_PORT === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_PORT = saved.CHROME_DEVTOOLS_AXI_PORT;
+    }
+  });
+
+  it("uses the session-derived port when no explicit override", () => {
+    expect(resolveSessionPort(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+  });
+
+  it("honors an explicit CHROME_DEVTOOLS_AXI_PORT", () => {
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "9999";
+    expect(resolveSessionPort("worker-1")).toBe(9999);
+  });
+
+  it("ignores a non-numeric or non-positive override", () => {
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "nope";
+    expect(resolveSessionPort(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "0";
+    expect(resolveSessionPort(DEFAULT_SESSION_NAME)).toBe(DEFAULT_BASE_PORT);
+  });
+});
+
+describe("session state paths", () => {
+  it("keeps legacy paths for the default session", () => {
+    expect(resolveSessionStateDir(DEFAULT_SESSION_NAME)).toBe(STATE_DIR);
+    expect(resolveSessionPidFile(DEFAULT_SESSION_NAME)).toBe(
+      join(STATE_DIR, "bridge.pid"),
+    );
+  });
+
+  it("nests named sessions under sessions/<name>/", () => {
+    expect(resolveSessionStateDir("worker-1")).toBe(
+      join(STATE_DIR, "sessions", "worker-1"),
+    );
+    expect(resolveSessionPidFile("worker-1")).toBe(
+      join(STATE_DIR, "sessions", "worker-1", "bridge.pid"),
+    );
+  });
+});
+
+describe("session paths reject an unsafe CHROME_DEVTOOLS_AXI_SESSION", () => {
+  const saved = process.env.CHROME_DEVTOOLS_AXI_SESSION;
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_SESSION = saved;
+    }
+  });
+
+  it("throws from the env-default path resolvers instead of collapsing to the default dir", () => {
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "..";
+    expect(() => resolveSessionStateDir()).toThrow(/Invalid/);
+    expect(() => resolveSessionPidFile()).toThrow(/Invalid/);
+    expect(() => resolveSessionPort()).toThrow(/Invalid/);
+  });
+});

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -97,11 +97,11 @@ describe("defaultPortForSession", () => {
     );
   });
 
-  it("stays within the named-session range (9225..9324)", () => {
+  it("stays within the named-session range (9225..10224)", () => {
     for (const name of ["a", "worker-1", "ceo", "x".repeat(64)]) {
       const port = defaultPortForSession(name);
       expect(port).toBeGreaterThanOrEqual(DEFAULT_BASE_PORT + 1);
-      expect(port).toBeLessThanOrEqual(DEFAULT_BASE_PORT + 100);
+      expect(port).toBeLessThanOrEqual(DEFAULT_BASE_PORT + 1000);
     }
   });
 


### PR DESCRIPTION
## Intent

Add CHROME_DEVTOOLS_AXI_SESSION for concurrent bridge isolation. Each named session gets its own bridge process, port (FNV-1a hash of the name, overridable via CHROME_DEVTOOLS_AXI_PORT), PID file, and snapshot-generation counter under sessions/<name>/, so concurrent agents/workers/worktrees never share a bridge or clobber each other's stale-ref tracking. A session isolates ONLY the bridge - connection mode and profile are intentionally unchanged and compose. The default (unset) session is fully backward compatible (port 9224, legacy ~/.chrome-devtools-axi paths). Deliberate safety, not accidental complexity: name validation at the single resolution chokepoint rejects path-traversal and dot-only names on every entry point (incl. stop); /health is stamped with the session name and ensureBridge rejects a mismatch, so two sessions forced onto one port (a globally-exported CHROME_DEVTOOLS_AXI_PORT) fail loudly instead of silently sharing a browser; the EADDRINUSE bridge exit uses a distinct code for a fast, accurate failure; and removePidFile only unlinks when it owns the file, preventing a same-session start race from orphaning the winner's bridge. Documented in --help and README; covered by unit tests.

## What Changed

- Added `src/sessions.ts` resolving a named session (`CHROME_DEVTOOLS_AXI_SESSION`) to its own bridge port (FNV-1a hash of the name into a 1000-slot range 9225-10224, overridable via `CHROME_DEVTOOLS_AXI_PORT`) and its own state dir/PID file/snapshot-generation counter under `~/.chrome-devtools-axi/sessions/<name>/`; the default (unset) session keeps port 9224 and the legacy paths. `resolveSessionName` is the single validation chokepoint, rejecting path-traversal and dot-only names on every entry point.
- Threaded the session through the bridge and client: the spawned bridge inherits its session name, `/health` reports the session, and `checkBridgeHealth`/`ensureBridge` reject a session mismatch so two sessions forced onto one port fail loudly; the bridge exits with a distinct `BRIDGE_PORT_IN_USE_EXIT_CODE` (48) on an `EADDRINUSE` bind, and `removePidFile` only unlinks the PID file when it owns it to avoid orphaning a same-session start-race winner.
- Documented the env var in `--help` and the README, and added unit coverage in `test/sessions.test.ts`, `test/bridge.test.ts`, `test/client.test.ts`, and `test/generation.test.ts`.

## Risk Assessment

✅ Low: A well-bounded, backward-compatible concurrency feature whose process-lifecycle and race-condition edges (PID ownership, EADDRINUSE attribution, cross-session health mismatch) are deliberately reasoned about and covered by tests; the one prior actionable finding (port range) is already fixed and the other was an acknowledged info-level tradeoff the user chose to ignore.</risk_rationale>
<parameter name="testing_summary">Did not run tests (review step only). Reviewed the full diff and surrounding call sites by inspection.

## Testing

`Ran the full vitest suite via the local binary (378 tests pass; the project's corepack pnpm pin is broken on this host, so I invoked node_modules/.bin/vitest directly - node_modules was already present). Since unit tests alone aren't sufficient evidence, I exercised the feature end-to-end through the real CLI driving real headless Chrome: two named sessions ran concurrently on deterministic distinct ports with their own bridge process and browser, producing isolated snapshots and screenshots that prove no cross-talk; on-disk state (pid/port/generation under sessions/<name>/) is fully separated while the default session stays on 9224 with legacy paths; forcing two sessions onto one port via a global CHROME_DEVTOOLS_AXI_PORT failed loudly and fast with the distinct exit code 48; and unsafe session names are rejected at the CLI chokepoint including on stop. Visual evidence (per-session headless-Chrome screenshots) and a full CLI transcript were captured. I stopped my test bridges, removed only my e2eval-* session dirs, and left the worktree clean. No issues found.`

- Evidence: Session ALPHA headless Chrome (e2eval-a, port 9307) rendering its own page (local file: <code>/var/folders/6b/4tqmrzyx67n4ghpsb7cv5rzr0000gn/T/no-mistakes-evidence/01KWA9JSRZ7NEQPXX7R2ER1PF8/session-alpha.png</code>)
- Evidence: Session BETA headless Chrome (e2eval-b, port 9688) rendering its own, different page (local file: <code>/var/folders/6b/4tqmrzyx67n4ghpsb7cv5rzr0000gn/T/no-mistakes-evidence/01KWA9JSRZ7NEQPXX7R2ER1PF8/session-beta.png</code>)
<details>
<summary>Evidence: Consolidated E2E CLI transcript: concurrent isolation, on-disk state, loud port-collision failure, name validation</summary>

```text
==================================================================
 CHROME_DEVTOOLS_AXI_SESSION - concurrent bridge isolation (E2E)
 Real CLI driving real headless Chrome, captured Mon Jun 29 20:38:33 CEST 2026
==================================================================

[1] Deterministic per-session port + state-dir derivation (default stays backward-compatible)
  default    port=9224  dir=/Users/nsklyarov/.chrome-devtools-axi
  e2eval-a   port=9307  dir=/Users/nsklyarov/.chrome-devtools-axi/sessions/e2eval-a
  e2eval-b   port=9688  dir=/Users/nsklyarov/.chrome-devtools-axi/sessions/e2eval-b

[2] Two live sessions, snapshotted independently - browser content does NOT cross over
  --- session e2eval-a snapshot ---
    page:
      title: PAGE-ALPHA
      refs: 2
    snapshot:
    uid=g3:1_0 RootWebArea "PAGE-ALPHA" url="data:text/html,<title>PAGE-ALPHA</title><h1>Session ALPHA content</h1>"
      uid=g3:1_1 heading "Session ALPHA content" level="1"
    help[1]:
      Use `chrome-devtools-axi eval <expr>` for JS expressions. For multi-statement code, pass a function: `eval "() => { ...; return result }"`
  --- session e2eval-b snapshot ---
    page:
      title: PAGE-BETA
      refs: 2
    snapshot:
    uid=g3:1_0 RootWebArea "PAGE-BETA" url="data:text/html,<title>PAGE-BETA</title><h1>Session BETA content</h1>"
      uid=g3:1_1 heading "Session BETA content" level="1"
    help[1]:
      Use `chrome-devtools-axi eval <expr>` for JS expressions. For multi-statement code, pass a function: `eval "() => { ...; return result }"`

[3] On-disk isolation under ~/.chrome-devtools-axi/sessions/<name>/
  e2eval-a:  bridge.pid={"pid":61040,"port":9307}   snapshot-generation=3
  e2eval-b:  bridge.pid={"pid":61819,"port":9688}   snapshot-generation=3

[4] Two distinct bridge processes alive concurrently (different PIDs)
  e2eval-a -> pid 61040: chrome-devtools-axi-bridge.ts
  e2eval-b -> pid 61819: chrome-devtools-axi-bridge.ts

[5] Safety: forcing a 2nd session onto a port another session owns fails LOUDLY and FAST
    (global CHROME_DEVTOOLS_AXI_PORT=9307, already held by e2eval-a)
    error: "Bridge for session \"e2eval-c\" exited with code 48 before becoming ready on port 9307"
    code: BRIDGE_NOT_READY
    help[2]: "Port 9307 is already in use. It may be held by another chrome-devtools-axi session's bridge (a hashed-port collision, or a globally-exported CHROME_DEVTOOLS_AXI_PORT forcing every session onto one port), by a stale or crashed bridge that could not be reused, or by an unrelated process.","Set a distinct CHROME_DEVTOOLS_AXI_PORT for this session, unset a global CHROME_DEVTOOLS_AXI_PORT so every session derives its own, or free whatever is holding the port."

[6] Safety: unsafe session names rejected at the CLI entry point (every command, incl. stop)
    error: "Invalid CHROME_DEVTOOLS_AXI_SESSION \"../escape\": use 1-64 chars from [A-Za-z0-9._-]"
    code: UNKNOWN
    error: "Invalid CHROME_DEVTOOLS_AXI_SESSION \"..\": a name made only of dots would collapse onto the default session's state directory"
    code: UNKNOWN
```
</details>
<details>
<summary>Evidence: Loud + fast failure when two sessions are forced onto one port (exit code 48)</summary>

```text
$ CHROME_DEVTOOLS_AXI_PORT=9307 CHROME_DEVTOOLS_AXI_SESSION=e2eval-c chrome-devtools-axi snapshot
error: "Bridge for session \"e2eval-c\" exited with code 48 before becoming ready on port 9307"
code: BRIDGE_NOT_READY
help[2]: "Port 9307 is already in use ... a globally-exported CHROME_DEVTOOLS_AXI_PORT forcing every session onto one port ...","Set a distinct CHROME_DEVTOOLS_AXI_PORT for this session, unset a global CHROME_DEVTOOLS_AXI_PORT ..., or free whatever is holding the port."
(real time ~2.3s, well under the 30s deadline)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `src/sessions.ts:31` - SESSION_PORT_RANGE is only 100 (ports 9225-9324), so derived session ports are drawn from a 100-slot hash space. By the birthday paradox, ~12 concurrent named sessions already give a ~50% chance of a hash collision, and ~20 makes it near-certain. The headline use case is explicitly &#39;one per agent session, worktree, or test worker&#39;, so colliding sessions failing to start (port-in-use) is a realistic outcome at modest concurrency, and the documented remedy (set CHROME_DEVTOOLS_AXI_PORT) is awkward because exporting it globally is the discouraged path. Widening the range (e.g. 1000 slots, 9225-10224) is nearly free and would push collisions out to a far higher session count. This is an acknowledged tradeoff in the code comment, flagging for visibility.
- ℹ️ `src/client.ts:431` - On childExited, ensureBridge performs at most two consecutive deep health checks (the loop-top check plus the one inside the childExited block) and then throws buildBridgeEarlyExitError. In the intended same-session self-heal path, if the winning bridge is listening and MCP-connected but its CDP target is momentarily not ready for the deep list_pages probe, both checks can fail and the loser&#39;s CLI throws a misleading port-in-use error instead of continuing to poll within the (default 30s) deadline. The boot-before-listen ordering in runBridge makes this low-probability, but the fast-fail path forgoes the available polling budget. Consider a brief retry/backoff before throwing when the port is answering, to avoid a false collision error on a race that would have self-healed.

🔧 Fix: widen session port range to 1000 to reduce hash collisions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node_modules/.bin/vitest run` - full suite, 378 tests pass (incl. test/sessions.test.ts, test/bridge.test.ts, test/client.test.ts, test/generation.test.ts)</code>
- <code>E2E: `CHROME_DEVTOOLS_AXI_SESSION=e2eval-a/e2eval-b open &lt;data-url&gt;` then `snapshot` for each - two concurrent bridges on ports 9307/9688, isolated browser content (PAGE-ALPHA vs PAGE-BETA)</code>
- <code>E2E: `screenshot` from each session&#39;s headless Chrome - distinct rendered pages (session-alpha.png / session-beta.png)</code>
- `Inspected ~/.chrome-devtools-axi/sessions/<name>/ - distinct bridge.pid (61040/61819), ports, and snapshot-generation counters; default keeps 9224 + legacy paths`
- <code>Safety: `CHROME_DEVTOOLS_AXI_PORT=9307 CHROME_DEVTOOLS_AXI_SESSION=e2eval-c snapshot` - fails loudly in ~2.3s with exit code 48 (BRIDGE_PORT_IN_USE_EXIT_CODE) and a port-collision remedy</code>
- <code>Safety: unsafe session names (`../escape`, `..`, `a;b`, `bad name`, 65-char) rejected on real `stop`/`snapshot` commands at the CLI entry point</code>
- <code>`--help` shows the documented CHROME_DEVTOOLS_AXI_SESSION env var</code>
- `Verified deterministic port/state-dir derivation via src/sessions.ts (default=9224 legacy path, named sessions hashed into 9225..10224)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
