### PR TITLE
fix(bridge): block DNS-rebinding requests

### DIFF
--- a/.no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-e2e.ts
+++ b/.no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-e2e.ts
@@ -1,0 +1,82 @@
+import { createServer, request } from "node:http";
+import { handleBridgeRequest, type BridgeClient } from "../../../../src/bridge.ts";
+
+const calls: string[] = [];
+const client: BridgeClient = {
+  listTools: async () => ({ tools: [{ name: "take_snapshot" }] }),
+  callTool: async ({ name }) => {
+    calls.push(name);
+    return { content: [{ type: "text", text: "ok" }] };
+  },
+  close: async () => {},
+};
+
+const server = createServer((req, res) => {
+  void handleBridgeRequest(client, req, res, "evidence");
+});
+
+await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+const address = server.address();
+if (address === null || typeof address === "string") throw new Error("no port");
+
+async function probe(
+  label: string,
+  method: "GET" | "POST",
+  path: string,
+  headers: Record<string, string>,
+) {
+  const body = method === "POST" ? JSON.stringify({ name: "take_snapshot" }) : "";
+  const result = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+    const req = request(
+      {
+        hostname: "127.0.0.1",
+        port: address.port,
+        method,
+        path,
+        headers: { ...headers, "content-length": Buffer.byteLength(body) },
+      },
+      (res) => {
+        let responseBody = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => (responseBody += chunk));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: responseBody }));
+      },
+    );
+    req.on("error", reject);
+    req.end(body);
+  });
+  console.log(`${label}: ${result.status} ${result.body}`);
+}
+
+try {
+  console.log("DNS rebinding bridge validation through real HTTP requests");
+  await probe("forged Host GET /health", "GET", "/health", { host: "evil.attacker.com" });
+  await probe("forged Host GET /tools", "GET", "/tools", { host: "evil.attacker.com" });
+  await probe("forged Host POST /call", "POST", "/call", { host: "evil.attacker.com" });
+  console.log(`CDP calls after forged /call: ${calls.length}`);
+  await probe("forged Origin POST /call", "POST", "/call", {
+    host: `127.0.0.1:${address.port}`,
+    origin: "https://evil.attacker.com",
+  });
+  console.log(`CDP calls after forged Origin: ${calls.length}`);
+  await probe("present empty Origin POST /call", "POST", "/call", {
+    host: `127.0.0.1:${address.port}`,
+    origin: "",
+  });
+  console.log(`CDP calls after present empty Origin: ${calls.length}`);
+  await probe("CLI-shaped 127.0.0.1 /health", "GET", "/health", {
+    host: `127.0.0.1:${address.port}`,
+  });
+  await probe("localhost + loopback Origin /tools", "GET", "/tools", {
+    host: `localhost:${address.port}`,
+    origin: `http://localhost:${address.port}`,
+  });
+  await probe("IPv6 Host, missing Origin POST /call", "POST", "/call", {
+    host: `[::1]:${address.port}`,
+  });
+  console.log(`CDP calls after legitimate /call: ${calls.length}`);
+} finally {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+}

--- a/.no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-http-transcript.txt
+++ b/.no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-http-transcript.txt
@@ -1,0 +1,13 @@
+DNS rebinding bridge validation through real HTTP requests
+forged Host GET /health: 403 {"error":"Forbidden host"}
+forged Host GET /tools: 403 {"error":"Forbidden host"}
+forged Host POST /call: 403 {"error":"Forbidden host"}
+CDP calls after forged /call: 0
+forged Origin POST /call: 403 {"error":"Forbidden host"}
+CDP calls after forged Origin: 0
+present empty Origin POST /call: 200 {"result":"ok"}
+CDP calls after present empty Origin: 1
+CLI-shaped 127.0.0.1 /health: 200 {"status":"ok","session":"evidence"}
+localhost + loopback Origin /tools: 200 [{"name":"take_snapshot"}]
+IPv6 Host, missing Origin POST /call: 200 {"result":"ok"}
+CDP calls after legitimate /call: 2

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -129,6 +129,97 @@ export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Hostnames that identify the loopback interface. The bridge is a persistent
+ * unauthenticated loopback service on a known port, so it is the target of
+ * DNS-rebinding: a malicious page rebinds its own domain to 127.0.0.1 and the
+ * browser then issues same-origin requests that hit the bridge. Binding to
+ * 127.0.0.1 does NOT stop this - the packets still arrive on loopback. The one
+ * thing a rebound request cannot hide is that it carries the attacker's own
+ * domain in the `Host` (and `Origin`) header, and those are forbidden headers
+ * page JavaScript cannot forge. Requiring both to name loopback is therefore
+ * THE anti-rebinding control (see GHSA-x439-jhfh-v9x2).
+ */
+const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "::1"]);
+
+function isLoopbackHostname(hostname: string): boolean {
+  // Node's URL parser keeps IPv6 hostnames bracketed (`[::1]`); strip the
+  // brackets so the bare literal matches LOOPBACK_HOSTNAMES.
+  const normalized = hostname
+    .replace(/^\[/, "")
+    .replace(/\]$/, "")
+    .toLowerCase();
+  return LOOPBACK_HOSTNAMES.has(normalized);
+}
+
+/**
+ * Extract the hostname from a `Host` header value, dropping any `:port` suffix.
+ * Handles bracketed IPv6 (`[::1]:9224` -> `::1`) and bare IPv6 literals
+ * (`::1`). Returns null for an empty/whitespace-only value.
+ */
+export function extractHostHeaderHostname(hostHeader: string): string | null {
+  const trimmed = hostHeader.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end === -1) return null;
+    // Anything after the closing bracket must be a `:port` suffix. Reject
+    // trailing garbage (e.g. "[::1]evil.com") instead of treating it as the
+    // loopback literal "::1" - this keeps the Host parser as strict as the
+    // Origin path (new URL(...).hostname), which already rejects the analogue.
+    const rest = trimmed.slice(end + 1);
+    if (rest.length > 0 && !rest.startsWith(":")) return null;
+    return trimmed.slice(1, end);
+  }
+  const firstColon = trimmed.indexOf(":");
+  if (firstColon === -1) return trimmed;
+  // A second colon means this is a bare (unbracketed) IPv6 literal with no
+  // port, not a host:port pair - keep the whole string as the hostname.
+  if (trimmed.indexOf(":", firstColon + 1) !== -1) return trimmed;
+  return trimmed.slice(0, firstColon);
+}
+
+/**
+ * True when the `Host` header is present and names the loopback interface.
+ * A missing Host, or one naming any other host (e.g. a rebound
+ * `evil.attacker.com`), is rejected.
+ */
+export function isAllowedBridgeHost(host: string | undefined): boolean {
+  if (host === undefined) return false;
+  const hostname = extractHostHeaderHostname(host);
+  if (hostname === null) return false;
+  return isLoopbackHostname(hostname);
+}
+
+/**
+ * True when the request carries no `Origin` (the CLI client sends none) or an
+ * `Origin` whose hostname is loopback. A present-but-non-loopback or
+ * unparseable Origin is rejected.
+ */
+export function isRequestOriginAllowed(req: IncomingMessage): boolean {
+  const rawOrigin = req.headers.origin;
+  if (rawOrigin === undefined) return true;
+  const origin = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
+  if (origin === undefined || origin.length === 0) return true;
+  let hostname: string;
+  try {
+    hostname = new URL(origin).hostname;
+  } catch {
+    return false;
+  }
+  return isLoopbackHostname(hostname);
+}
+
+/**
+ * Anti-rebinding gate: a request is allowed only when its `Host` header names
+ * loopback and any `Origin` header also names loopback. Checked FIRST on every
+ * route (health included) so a rebound request is refused before any CDP tool
+ * can run.
+ */
+export function isRequestAllowed(req: IncomingMessage): boolean {
+  return isAllowedBridgeHost(req.headers.host) && isRequestOriginAllowed(req);
+}
+
 export function extractToolText(content: BridgeContentBlock[]): string {
   return content
     .filter((block) => block.type === "text" && typeof block.text === "string")
@@ -231,8 +322,25 @@ export async function handleBridgeRequest(
   req: IncomingMessage,
   res: ServerResponse,
   sessionName?: string,
+  logForbidden?: (message: string) => void,
 ): Promise<void> {
   res.setHeader("Content-Type", "application/json");
+
+  // Reject rebound requests before any routing - see isRequestAllowed and
+  // GHSA-x439-jhfh-v9x2. This gate covers /health, /tools, and /call alike.
+  if (!isRequestAllowed(req)) {
+    // Log the refusal so an operator can tell a mis-configured client apart
+    // from an actual rebinding attempt. Injected (not a direct
+    // logBridgeMessage call) so unit tests stay quiet unless they opt in.
+    const rawOrigin = req.headers.origin;
+    const origin = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
+    logForbidden?.(
+      `Rejected request with disallowed host: host=${req.headers.host ?? ""} ` +
+        `origin=${origin ?? ""} ${req.method ?? ""} ${req.url ?? ""}`,
+    );
+    writeJson(res, 403, { error: "Forbidden host" });
+    return;
+  }
 
   if (
     req.method === "GET" &&
@@ -281,7 +389,7 @@ export function createBridgeServer(
   sessionName?: string,
 ): Server {
   return createServer((req, res) => {
-    void handleBridgeRequest(client, req, res, sessionName);
+    void handleBridgeRequest(client, req, res, sessionName, logBridgeMessage);
   });
 }
 

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -8,9 +8,13 @@ import {
   BRIDGE_PORT_IN_USE_EXIT_CODE,
   buildTransportArgs,
   detectGlobalMcpPath,
+  extractHostHeaderHostname,
   extractToolText,
   getErrorMessage,
   handleBridgeRequest,
+  isAllowedBridgeHost,
+  isRequestAllowed,
+  isRequestOriginAllowed,
   handleBridgeServerError,
   isBridgeClientConnected,
   isBridgeTargetReachable,
@@ -554,10 +558,25 @@ describe("isBridgeTargetReachable", () => {
   });
 });
 
-function makeRequest(method: string, url: string): IncomingMessage {
+function makeRequest(
+  method: string,
+  url: string,
+  headers: Record<string, string> = {},
+  body?: string,
+): IncomingMessage {
   const req = new IncomingMessage(new Socket());
   req.method = method;
   req.url = url;
+  // Real requests always carry a Host header; the CLI client sends
+  // "127.0.0.1:<port>". Default to loopback so the anti-rebinding gate lets
+  // these through, and let callers override to exercise rejection.
+  req.headers = { host: "127.0.0.1:9224", ...headers };
+  // Feed a request body so handlers that read the stream (e.g. /call) don't
+  // hang waiting on EOF. Rejected requests short-circuit before reading it.
+  if (body !== undefined) {
+    req.push(body);
+    req.push(null);
+  }
   return req;
 }
 
@@ -705,6 +724,244 @@ describe("handleBridgeRequest /health", () => {
 
     expect(captured.statusCode).toBe(200);
     expect(callToolCalls).toBe(0);
+  });
+});
+
+describe("extractHostHeaderHostname", () => {
+  it("drops the :port suffix from a host:port value", () => {
+    expect(extractHostHeaderHostname("127.0.0.1:9224")).toBe("127.0.0.1");
+    expect(extractHostHeaderHostname("localhost:9224")).toBe("localhost");
+  });
+
+  it("returns the bare hostname when no port is present", () => {
+    expect(extractHostHeaderHostname("localhost")).toBe("localhost");
+  });
+
+  it("unwraps a bracketed IPv6 host, with or without a port", () => {
+    expect(extractHostHeaderHostname("[::1]:9224")).toBe("::1");
+    expect(extractHostHeaderHostname("[::1]")).toBe("::1");
+  });
+
+  it("keeps a bare unbracketed IPv6 literal intact", () => {
+    expect(extractHostHeaderHostname("::1")).toBe("::1");
+  });
+
+  it("rejects trailing garbage after a bracketed IPv6 host", () => {
+    // "[::1]evil.com" must not be read as the loopback literal "::1".
+    expect(extractHostHeaderHostname("[::1]evil.com")).toBeNull();
+    expect(extractHostHeaderHostname("[::1]:9224evil")).toBe("::1");
+    expect(isAllowedBridgeHost("[::1]evil.com")).toBe(false);
+  });
+
+  it("returns null for an empty or whitespace-only value", () => {
+    expect(extractHostHeaderHostname("")).toBeNull();
+    expect(extractHostHeaderHostname("   ")).toBeNull();
+  });
+});
+
+describe("isAllowedBridgeHost", () => {
+  it("accepts loopback hosts (with and without port, any case)", () => {
+    expect(isAllowedBridgeHost("127.0.0.1:9224")).toBe(true);
+    expect(isAllowedBridgeHost("localhost:9224")).toBe(true);
+    expect(isAllowedBridgeHost("LOCALHOST")).toBe(true);
+    expect(isAllowedBridgeHost("[::1]:9224")).toBe(true);
+    expect(isAllowedBridgeHost("::1")).toBe(true);
+  });
+
+  it("rejects a missing Host header", () => {
+    expect(isAllowedBridgeHost(undefined)).toBe(false);
+  });
+
+  it("rejects a rebound attacker domain", () => {
+    expect(isAllowedBridgeHost("evil.attacker.com")).toBe(false);
+    expect(isAllowedBridgeHost("evil.attacker.com:9224")).toBe(false);
+    // A hostname that merely embeds a loopback label must not pass.
+    expect(isAllowedBridgeHost("127.0.0.1.evil.com")).toBe(false);
+    expect(isAllowedBridgeHost("localhost.evil.com")).toBe(false);
+  });
+});
+
+describe("isRequestOriginAllowed", () => {
+  it("allows a missing Origin (the CLI client sends none)", () => {
+    expect(isRequestOriginAllowed(makeRequest("POST", "/call"))).toBe(true);
+  });
+
+  it("allows an Origin whose hostname is loopback", () => {
+    expect(
+      isRequestOriginAllowed(
+        makeRequest("POST", "/call", { origin: "http://127.0.0.1:9224" }),
+      ),
+    ).toBe(true);
+    expect(
+      isRequestOriginAllowed(
+        makeRequest("POST", "/call", { origin: "http://localhost" }),
+      ),
+    ).toBe(true);
+    expect(
+      isRequestOriginAllowed(
+        makeRequest("POST", "/call", { origin: "http://[::1]:9224" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a present non-loopback Origin", () => {
+    expect(
+      isRequestOriginAllowed(
+        makeRequest("POST", "/call", {
+          origin: "https://evil.attacker.com",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects an unparseable Origin", () => {
+    expect(
+      isRequestOriginAllowed(
+        makeRequest("POST", "/call", { origin: "not a url" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("handleBridgeRequest anti-rebinding gate", () => {
+  const client: BridgeClient = {
+    listTools: async () => ({ tools: [{ name: "take_snapshot" }] }),
+    callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    close: async () => {},
+  };
+
+  it("rejects a forged non-loopback Host with 403 on every route", async () => {
+    for (const [method, url] of [
+      ["GET", "/health"],
+      ["GET", "/tools"],
+      ["POST", "/call"],
+    ] as const) {
+      const { res, captured } = makeResponse();
+      await handleBridgeRequest(
+        client,
+        makeRequest(method, url, { host: "evil.attacker.com" }),
+        res,
+      );
+      expect(captured.statusCode).toBe(403);
+      expect(JSON.parse(captured.body)).toEqual({ error: "Forbidden host" });
+    }
+  });
+
+  it("rejects a request with no Host header", async () => {
+    const req = makeRequest("GET", "/health");
+    delete req.headers.host;
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(client, req, res);
+
+    expect(captured.statusCode).toBe(403);
+    expect(JSON.parse(captured.body)).toEqual({ error: "Forbidden host" });
+  });
+
+  it("rejects a forged non-loopback Origin even when Host is loopback", async () => {
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest("POST", "/call", {
+        host: "127.0.0.1:9224",
+        origin: "https://evil.attacker.com",
+      }),
+      res,
+    );
+
+    expect(captured.statusCode).toBe(403);
+    expect(JSON.parse(captured.body)).toEqual({ error: "Forbidden host" });
+  });
+
+  it("does not invoke any CDP tool when a request is rejected", async () => {
+    let callToolCalls = 0;
+    const spyClient: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => {
+        callToolCalls++;
+        return { content: [] };
+      },
+      close: async () => {},
+    };
+    const { res } = makeResponse();
+
+    await handleBridgeRequest(
+      spyClient,
+      makeRequest("POST", "/call", { host: "evil.attacker.com" }),
+      res,
+    );
+
+    expect(callToolCalls).toBe(0);
+  });
+
+  it("allows a loopback Host with no Origin through to /call", async () => {
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest(
+        "POST",
+        "/call",
+        { host: "127.0.0.1:9224" },
+        JSON.stringify({ name: "take_snapshot" }),
+      ),
+      res,
+    );
+
+    expect(captured.statusCode).toBe(200);
+    expect(JSON.parse(captured.body)).toEqual({ result: "ok" });
+  });
+
+  it("logs the refusal (host/origin/route) when a request is rejected", async () => {
+    const logs: string[] = [];
+    const { res } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest("POST", "/call", {
+        host: "evil.attacker.com",
+        origin: "https://evil.attacker.com",
+      }),
+      res,
+      undefined,
+      (message) => logs.push(message),
+    );
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("evil.attacker.com");
+    expect(logs[0]).toContain("/call");
+  });
+
+  it("does not log when a request is allowed", async () => {
+    const logs: string[] = [];
+    const { res } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest("GET", "/tools", { host: "127.0.0.1:9224" }),
+      res,
+      undefined,
+      (message) => logs.push(message),
+    );
+
+    expect(logs).toHaveLength(0);
+  });
+
+  it("allows a loopback Host + loopback Origin through to /tools", async () => {
+    const { res, captured } = makeResponse();
+
+    await handleBridgeRequest(
+      client,
+      makeRequest("GET", "/tools", {
+        host: "localhost:9224",
+        origin: "http://localhost:9224",
+      }),
+      res,
+    );
+
+    expect(captured.statusCode).toBe(200);
+    expect(isRequestAllowed(makeRequest("GET", "/tools"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Intent

Ship the reviewed Christopher La Rose contributor fix for GHSA-x439-jhfh-v9x2 (DNS rebinding against the chrome-devtools-axi local bridge). Public validation of one immutable cherry-picked commit that makes handleBridgeRequest reject non-loopback Host and Origin before any /health, /tools, or /call dispatch, returning 403 Forbidden host, while keeping legitimate CLI traffic (Host 127.0.0.1/localhost/::1, missing Origin) working. Do not change the reviewed security patch logic or invent Lavish-style operator knobs (ALLOWED_HOSTS, non-loopback bind, X-Forwarded-Host, wildcard opt-out) that Chrome does not have. Preserve Christopher La Rose <cjlarose@gmail.com> as Author on the contributor commit; do not squash, amend, reword, or add an agent co-author to that commit. This is half of a coordinated all-or-nothing public disclosure with lavish-axi; open a public PR only, do not merge.

## What Changed

- Reject bridge requests with missing or non-loopback `Host` headers or non-loopback `Origin` headers before dispatching `/health`, `/tools`, or `/call`, returning `403 Forbidden host` and logging rejected requests.
- Preserve bridge access for loopback IPv4, `localhost`, IPv6, and CLI requests without an `Origin` header.
- Add unit coverage and HTTP-level validation evidence for DNS-rebinding rejection and legitimate loopback traffic.

## Risk Assessment

🚨 High: The security implementation is well-scoped, but the immutable target commit directly violates a required authorship constraint and needs explicit human resolution before merge.

## Testing

The targeted bridge tests passed. Live localhost HTTP probes confirmed 403 responses before dispatch for forged Host across `/health`, `/tools`, and `/call`, 403 for a forged Origin, zero rejected CDP calls, and successful legitimate 127.0.0.1, localhost, and ::1 traffic. However, a present empty Origin reached `/call`, and commit inspection found the forbidden agent co-author trailer. The single-commit scope and absence of prohibited operator knobs were also verified; transient dependencies were removed afterward.

- Evidence: [Live bridge HTTP transcript](https://github.com/kunchenguid/chrome-devtools-axi/blob/30b1ab6efb185e658fb51b7099642ec153e0e86a/.no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-http-transcript.txt)
- Evidence: [Reproducible HTTP evidence harness](https://github.com/kunchenguid/chrome-devtools-axi/blob/30b1ab6efb185e658fb51b7099642ec153e0e86a/.no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-e2e.ts)
- Outcome: ⚠️ 2 errors across 1 run (3m11s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 Intent requires “do not ... add an agent co-author to that commit,” but the target commit message ends with `Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;`. Because removing it would amend the required immutable contributor commit, resolve the conflicting metadata requirements before merge.

</details>

<details>
<summary>⚠️ **Test** - 2 errors</summary>

- 🚨 `src/bridge.ts:203` - A present but empty Origin is treated like a missing header, reaches `/call`, and invokes the CDP tool. The acceptance criteria allow only a missing Origin; every present Origin must identify loopback. The immutable reviewed patch therefore fails this literal requirement.
- 🚨 The target commit preserves Christopher La Rose as Author but includes `Co-Authored-By: Claude Opus 4.8`, violating the explicit prohibition on an agent co-author. Fixing this would require replacing or amending the immutable commit, which validation was forbidden to do.
- `pnpm test test/bridge.test.ts -- -t 'extractHostHeaderHostname|isAllowedBridgeHost|isRequestOriginAllowed|handleBridgeRequest anti-rebinding gate'`
- `pnpm exec tsx .no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-e2e.ts | tee .no-mistakes/evidence/fm/chrome-ghsa-public-ship-s1/bridge-rebinding-http-transcript.txt`
- `git rev-list --count cc740e87c02590fdb63b235f2dc584801f514e8c..9321665ef40a01576ce5664ff0111e32a83e6fe8`
- `git diff --name-only cc740e87c02590fdb63b235f2dc584801f514e8c..9321665ef40a01576ce5664ff0111e32a83e6fe8`
- `rg -n 'ALLOWED_HOSTS|X-Forwarded-Host|0\.0\.0\.0|wildcard|allowedHosts' src/bridge.ts test/bridge.test.ts`
- `git show -s --format='%H%n%P%n%an <%ae>%n%B' 9321665ef40a01576ce5664ff0111e32a83e6fe8`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
