### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/.no-mistakes/evidence/fm/nm-body-events-chrome-devtools-axi-r1/workflow-policy-e2e.md
+++ b/.no-mistakes/evidence/fm/nm-body-events-chrome-devtools-axi-r1/workflow-policy-e2e.md
@@ -1,0 +1,47 @@
+# PR body compliance event policy - focused E2E evidence
+
+Validated target commit `fe58abd197a2f20798041a3817d7165aef11abf1` against base
+`de1b5c5040ac657674dcb5475c0f2d90d714256d`.
+
+The harness parsed the committed `.github/workflows/no-mistakes-required.yml`,
+resolved its event policy for representative GitHub event identities, and
+executed the workflow's actual Bash signature-check step with signed, unsigned,
+and empty pull request bodies.
+
+## Resolved concurrency groups
+
+| Action | Run ID | Resolved group |
+| --- | ---: | --- |
+| `opened` | 9001 | `no-mistakes-required-417-9001` |
+| `opened` | 9002 | `no-mistakes-required-417-9002` |
+| `edited` | 9003 | `no-mistakes-required-417-9003` |
+| `edited` | 9004 | `no-mistakes-required-417-9004` |
+| `synchronize` | 9005 | `no-mistakes-required-417-head-change` |
+| `reopened` | 9006 | `no-mistakes-required-417-head-change` |
+
+Every tested body-bearing event has its own immutable run-ID group. The two
+head-change actions retain the shared `head-change` group.
+
+## Terminal signature outcomes
+
+| Event | PR body | Exit | User-visible first line |
+| --- | --- | ---: | --- |
+| `opened` | Required marker present | 0 | `Found no-mistakes signature in PR #417 body.` |
+| `edited` | Marker absent | 1 | `::error::This PR was not raised through no-mistakes.` |
+| `edited` | Empty | 1 | `::error::This PR was not raised through no-mistakes.` |
+
+## Preserved workflow contract
+
+- Trigger: `pull_request` actions `opened`, `edited`, `synchronize`, and
+  `reopened`, targeting `main`
+- Permissions: `contents: read`
+- Stable check name: `PR must be raised via no-mistakes`
+- `cancel-in-progress: true`
+- Exact deterministic marker remains unchanged
+- Exemptions remain for `github-actions[bot]`, `dependabot[bot]`, and
+  `release-please[bot]`
+- No checkout, fork-code execution, or secret reference
+- Diff remains limited to `.github/workflows/no-mistakes-required.yml`, with
+  the run-name and concurrency-policy hunks
+
+Result: **PASS**


### PR DESCRIPTION
## Intent

Implement the captain-authorized PR-body compliance-event policy exactly as specified for chrome-devtools-axi. Ensure every opened or edited PR body event receives an immutable run-id concurrency group and terminal signature-check outcome, while synchronize and reopened remain coalesced under head-change. Preserve pull_request, read-only permissions, no secrets or fork-code execution, the stable check name, marker, bot exemptions, cancel-in-progress, and all unrelated repository-specific behavior. Keep the rollout minimal to the exact workflow-only two-hunk change, ship a PR titled 'fix: execute every PR body compliance event' through no-mistakes, stop once CI is green, and do not merge.

## What Changed

- Give every `opened` and `edited` PR event an immutable run-ID concurrency group while keeping `synchronize` and `reopened` coalesced under `head-change`.
- Add descriptive workflow run names that identify the PR, event action, run number, and run ID.
- Document the passing focused E2E validation of concurrency grouping, signature-check outcomes, and preserved workflow safeguards.

## Risk Assessment

✅ Low: The workflow-only two-hunk change gives opened and edited events unique run-ID concurrency groups while preserving head-change coalescing, permissions, triggers, check identity, exemptions, signature validation, and cancel-in-progress behavior.

## Testing

Inspected the exact workflow-only two-hunk change, repaired missing locked dependencies, then verified end-to-end that opened and edited events receive unique run-ID groups, synchronize and reopened coalesce under head-change, and the actual signature step terminates successfully or unsuccessfully according to the PR body. Preserved safety and repository-specific behavior were also checked, reviewer-visible evidence was recorded, and transient dependencies were removed.

- Evidence: [Focused PR-body compliance event policy evidence](https://github.com/kunchenguid/chrome-devtools-axi/blob/c3fc7f47d736f3dd674070a74746b39330800326/.no-mistakes/evidence/fm/nm-body-events-chrome-devtools-axi-r1/workflow-policy-e2e.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=80 de1b5c5040ac657674dcb5475c0f2d90d714256d..fe58abd197a2f20798041a3817d7165aef11abf1`
- `rg -n "no-mistakes-required|Require no-mistakes|head-change|run-name|concurrency" test .github package.json pnpm-lock.yaml`
- <code>`pnpm install --frozen-lockfile` to repair missing local test dependencies</code>
- <code>Focused `node --input-type=module` YAML harness resolving opened, edited, synchronize, and reopened concurrency groups across distinct run IDs</code>
- `Execution of the workflow's actual Bash signature-check step with signed, unsigned, and empty PR bodies`
- `Manual preservation check for pull_request triggers, read-only permissions, stable check name, marker, bot exemptions, cancel-in-progress, and absence of secrets, checkout, or fork-code execution`
- <code>Removed the temporary `node_modules` dependency tree after validation</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
