### PR TITLE
feat: add CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH to select the browser binary

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -528,6 +528,18 @@ export function buildTransportArgs(): string[] {
     args.push(`--channel=${channel}`);
   }
 
+  // --executablePath names the exact browser binary chrome-devtools-mcp launches.
+  // Without it the launch modes fall back to a Puppeteer channel lookup, which
+  // cannot resolve a browser that is not installed through a Chrome distribution
+  // (a store path, a portable build, or a custom location). It is launch-only, so
+  // it is omitted when attaching to an endpoint, with --autoConnect, or when a
+  // --channel already selects an installed distribution. A blank value is treated
+  // as unset so an empty export never forces the engine onto an empty path.
+  const executablePath = process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH?.trim();
+  if (executablePath && !browserUrl && !autoConnect && !channel) {
+    args.push(`--executablePath=${executablePath}`);
+  }
+
   const extraChromeArgs = process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
   if (extraChromeArgs) {
     for (const arg of extraChromeArgs.trim().split(/\s+/)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,12 @@ environment:
                                     canary, or dev. Selects which installed Chrome --autoConnect
                                     attaches to, and which one is launched in the default and
                                     USER_DATA_DIR modes. Ignored with CHROME_DEVTOOLS_AXI_BROWSER_URL.
+  CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH
+                                    Path to the Chrome/Chromium binary to launch, forwarded as
+                                    --executablePath. Use it when the browser is not installed as a
+                                    Chrome distribution the channel lookup can find. Launch-only:
+                                    ignored with CHROME_DEVTOOLS_AXI_BROWSER_URL, --autoConnect, or
+                                    CHROME_DEVTOOLS_AXI_CHANNEL. A blank value is treated as unset.
   CHROME_DEVTOOLS_AXI_HEADED        Set to 1 to run Chrome in headed (visible) mode
   CHROME_DEVTOOLS_AXI_CHROME_ARGS   Whitespace-separated Chrome flags forwarded to the browser
                                     (no shell-style quoting; flags with spaces are not supported)

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -93,6 +93,8 @@ describe("buildTransportArgs", () => {
       process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     savedEnv.CHROME_DEVTOOLS_AXI_CHANNEL =
       process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
+    savedEnv.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH =
+      process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH;
     delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
     delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
@@ -100,6 +102,7 @@ describe("buildTransportArgs", () => {
     delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     delete process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     delete process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
+    delete process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH;
   });
 
   afterEach(() => {
@@ -266,6 +269,54 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).toContain("--userDataDir=/path/to/.chrome-profile");
     expect(args).toContain("--channel=canary");
+  });
+
+  it("omits --executablePath by default", () => {
+    const args = buildTransportArgs();
+    expect(args.some((a) => a.startsWith("--executablePath"))).toBe(false);
+  });
+
+  it("appends --executablePath in the default launch mode", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH = "/opt/chromium/chrome";
+    const args = buildTransportArgs();
+    expect(args).toContain("--executablePath=/opt/chromium/chrome");
+  });
+
+  it("appends --executablePath alongside --userDataDir", () => {
+    process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = "/path/to/.chrome-profile";
+    process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH = "/opt/chromium/chrome";
+    const args = buildTransportArgs();
+    expect(args).toContain("--userDataDir=/path/to/.chrome-profile");
+    expect(args).toContain("--executablePath=/opt/chromium/chrome");
+  });
+
+  it("treats a blank --executablePath as unset", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH = "   ";
+    const args = buildTransportArgs();
+    expect(args.some((a) => a.startsWith("--executablePath"))).toBe(false);
+  });
+
+  it("ignores --executablePath when connecting via --browserUrl", () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+    process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH = "/opt/chromium/chrome";
+    const args = buildTransportArgs();
+    expect(args.some((a) => a.startsWith("--executablePath"))).toBe(false);
+  });
+
+  it("ignores --executablePath with --autoConnect", () => {
+    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = "1";
+    process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH = "/opt/chromium/chrome";
+    const args = buildTransportArgs();
+    expect(args).toContain("--autoConnect");
+    expect(args.some((a) => a.startsWith("--executablePath"))).toBe(false);
+  });
+
+  it("ignores --executablePath when a channel selects the browser", () => {
+    process.env.CHROME_DEVTOOLS_AXI_CHANNEL = "beta";
+    process.env.CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH = "/opt/chromium/chrome";
+    const args = buildTransportArgs();
+    expect(args).toContain("--channel=beta");
+    expect(args.some((a) => a.startsWith("--executablePath"))).toBe(false);
   });
 
   it("ignores --channel when connecting via --browserUrl", () => {


### PR DESCRIPTION

Today the launch modes can only reach a browser through a Puppeteer channel lookup, which finds
Chrome distributions installed in their standard locations.
That leaves no way to launch a browser that exists as a plain binary: a portable build, a custom
install prefix, or a package-manager store path.
On such a host every launch mode fails even though a perfectly good Chromium is present, and the
only workaround is to give up launching and attach to an already-running instance.

This adds `CHROME_DEVTOOLS_AXI_EXECUTABLE_PATH`, forwarded to `chrome-devtools-mcp` as
`--executablePath`.

Behavior follows the existing `CHROME_DEVTOOLS_AXI_CHANNEL` precedent:

- Launch-only. It is omitted with `CHROME_DEVTOOLS_AXI_BROWSER_URL`, with `--autoConnect`, and when
  `CHROME_DEVTOOLS_AXI_CHANNEL` already selects an installed distribution, since
  `chrome-devtools-mcp` rejects `--executablePath` together with those.
- A blank value is treated as unset, so an empty export never forces the engine onto an empty path.
- Validation is left to `chrome-devtools-mcp`, as with `--channel`.

Default behavior is unchanged: with the variable unset, no `--executablePath` is emitted.

## Tests

Seven cases in `test/bridge.test.ts`, matching the surrounding `--channel` tests:

- omitted by default
- appended in the default launch mode
- appended alongside `--userDataDir`
- a blank value treated as unset
- ignored when connecting via `--browserUrl`
- ignored with `--autoConnect`
- ignored when a channel selects the browser

Verified against upstream main (`aa162e8`): `pnpm vitest run test/bridge.test.ts` reports 88 passed.
