### PR TITLE
fix: reap orphaned bridges after lease or idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ pnpm link
 
 - **Persistent bridge** — a detached process keeps the MCP session alive across commands, so Chrome doesn't restart every invocation
 - **Auto-lifecycle** — the bridge starts on first command, writes a PID file to `~/.chrome-devtools-axi/bridge.pid`, recycles stale CDP targets after a deep health check, and reaps child processes on stop
+- **Bounded lifetime** — the detached bridge receives a cryptographic lease token and reaps itself after 45 seconds without a lease refresh, or after 15 minutes without client activity. Set `CHROME_DEVTOOLS_AXI_OWNER_PID` to a stable agent supervisor PID to also reap after the owner exits. Configure these safeguards with `CHROME_DEVTOOLS_AXI_LEASE_TIMEOUT_MS` and `CHROME_DEVTOOLS_AXI_IDLE_TIMEOUT_MS`. This prevents an agent crash from leaving an immortal bridge and launched Chrome tree behind.
 - **Snapshot parsing** — accessibility tree snapshots are extracted and analyzed for interactive elements (`uid=` refs)
 - **TOON encoding** — structured metadata uses [TOON format](https://www.npmjs.com/package/@toon-format/toon) for compact, token-efficient output
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -16,6 +16,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { execSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import {
   createServer,
   type IncomingMessage,
@@ -23,6 +24,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -60,6 +62,61 @@ export interface BridgeClient {
   close(): Promise<void>;
 }
 
+export const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+export const DEFAULT_LEASE_TIMEOUT_MS = 45 * 1000;
+
+export interface BridgeLivenessState {
+  nowMs: number;
+  lastLeaseMs: number;
+  lastActivityMs: number;
+  activeRequests: number;
+  oldestActiveRequestMs?: number;
+  ownerAlive: boolean;
+}
+
+export interface BridgeReapOptions {
+  idleTimeoutMs: number;
+  leaseTimeoutMs: number;
+  maxRequestMs?: number;
+}
+
+/** Pure timeout decision used by the watchdog and unit tests. */
+export function getBridgeReapReason(
+  state: BridgeLivenessState,
+  options: BridgeReapOptions,
+): "idle" | "lease-expired" | null {
+  const requestsExpired =
+    state.activeRequests > 0 &&
+    state.oldestActiveRequestMs !== undefined &&
+    options.maxRequestMs !== undefined &&
+    state.nowMs - state.oldestActiveRequestMs >= options.maxRequestMs;
+  if (state.activeRequests > 0 && !requestsExpired) return null;
+  if (state.nowMs - state.lastActivityMs >= options.idleTimeoutMs) {
+    return "idle";
+  }
+  if (
+    !state.ownerAlive &&
+    state.nowMs - state.lastLeaseMs >= options.leaseTimeoutMs
+  ) {
+    return "lease-expired";
+  }
+  return null;
+}
+
+export function resolveLivenessTimeout(
+  name: "IDLE" | "LEASE",
+  defaultMs: number,
+): number {
+  const raw = process.env[`CHROME_DEVTOOLS_AXI_${name}_TIMEOUT_MS`];
+  if (!raw) return defaultMs;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : defaultMs;
+}
+
+export function createLeaseToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
 export async function isBridgeClientConnected(
   client: BridgeClient,
 ): Promise<boolean> {
@@ -90,10 +147,19 @@ export async function isBridgeTargetReachable(
   }
 }
 
-function writePidFile(port: number): void {
+function writePidFile(port: number, leaseToken?: string): void {
   const pidFile = resolveSessionPidFile();
   mkdirSync(dirname(pidFile), { recursive: true });
-  writeFileSync(pidFile, JSON.stringify({ pid: process.pid, port }));
+  writeFileSync(
+    pidFile,
+    JSON.stringify({
+      pid: process.pid,
+      port,
+      ...(leaseToken ? { leaseToken } : {}),
+    }),
+    { mode: 0o600 },
+  );
+  chmodSync(pidFile, 0o600);
 }
 
 /**
@@ -227,6 +293,19 @@ export function extractToolText(content: BridgeContentBlock[]): string {
     .join("\n");
 }
 
+function monotonicNowMs(): number {
+  return Number(process.hrtime.bigint()) / 1_000_000;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getToolContent(result: unknown): BridgeContentBlock[] {
   if (
     !result ||
@@ -317,12 +396,61 @@ async function handleCallRequest(
   writeJson(res, 200, { result: extractToolText(getToolContent(result)) });
 }
 
+export interface BridgeRequestHooks {
+  onActivity?: () => void;
+  onLease?: () => void;
+  onRequestStart?: () => void;
+  onRequestEnd?: () => void;
+  leaseToken?: string;
+  onOwnerChange?: (pid: number | undefined) => void;
+}
+
+async function handleLeaseRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  hooks: BridgeRequestHooks,
+): Promise<void> {
+  const body = await readRequestBody(req);
+  let payload: { token?: unknown; ownerPid?: unknown };
+  try {
+    payload = JSON.parse(body) as { token?: unknown; ownerPid?: unknown };
+  } catch {
+    writeJson(res, 400, { error: "Invalid lease request payload" });
+    return;
+  }
+  if (!hooks.leaseToken || payload.token !== hooks.leaseToken) {
+    writeJson(res, 403, { error: "Invalid lease" });
+    return;
+  }
+  if (
+    payload.ownerPid !== undefined &&
+    payload.ownerPid !== null &&
+    (typeof payload.ownerPid !== "number" ||
+      !Number.isInteger(payload.ownerPid) ||
+      payload.ownerPid <= 0)
+  ) {
+    writeJson(res, 400, { error: "Invalid owner PID" });
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, "ownerPid")) {
+    hooks.onOwnerChange?.(
+      payload.ownerPid === null
+        ? undefined
+        : (payload.ownerPid as number | undefined),
+    );
+  }
+  hooks.onLease?.();
+  hooks.onActivity?.();
+  writeJson(res, 200, { status: "ok" });
+}
+
 export async function handleBridgeRequest(
   client: BridgeClient,
   req: IncomingMessage,
   res: ServerResponse,
   sessionName?: string,
   logForbidden?: (message: string) => void,
+  hooks: BridgeRequestHooks = {},
 ): Promise<void> {
   res.setHeader("Content-Type", "application/json");
 
@@ -366,30 +494,46 @@ export async function handleBridgeRequest(
     return;
   }
 
+  hooks.onRequestStart?.();
   try {
     if (req.method === "GET" && req.url === "/tools") {
+      hooks.onActivity?.();
       await handleToolsRequest(client, res);
       return;
     }
 
     if (req.method === "POST" && req.url === "/call") {
+      hooks.onActivity?.();
       await handleCallRequest(client, req, res);
       return;
     }
+
+    if (req.method === "POST" && req.url === "/lease") {
+      await handleLeaseRequest(req, res, hooks);
+      return;
+    }
+    writeJson(res, 404, { error: "not found" });
   } catch (error) {
     writeJson(res, 500, { error: getErrorMessage(error) });
-    return;
+  } finally {
+    hooks.onRequestEnd?.();
   }
-
-  writeJson(res, 404, { error: "not found" });
 }
 
 export function createBridgeServer(
   client: BridgeClient,
   sessionName?: string,
+  hooks: BridgeRequestHooks = {},
 ): Server {
   return createServer((req, res) => {
-    void handleBridgeRequest(client, req, res, sessionName, logBridgeMessage);
+    void handleBridgeRequest(
+      client,
+      req,
+      res,
+      sessionName,
+      logBridgeMessage,
+      hooks,
+    );
   });
 }
 
@@ -652,31 +796,95 @@ export async function runBridge(port = resolveSessionPort()): Promise<void> {
   logBridgeMessage("Connected to chrome-devtools-mcp");
 
   const sessionName = resolveSessionName();
-  const server = createBridgeServer(client, sessionName);
+  const leaseToken =
+    process.env.CHROME_DEVTOOLS_AXI_LEASE_TOKEN ?? createLeaseToken();
+  let ownerPid = Number.parseInt(
+    process.env.CHROME_DEVTOOLS_AXI_OWNER_PID ?? "",
+    10,
+  );
+  let lastLeaseMs = monotonicNowMs();
+  let lastActivityMs = lastLeaseMs;
+  let activeRequests = 0;
+  let oldestActiveRequestMs: number | undefined;
+  const server = createBridgeServer(client, sessionName, {
+    leaseToken,
+    onActivity: () => {
+      lastActivityMs = monotonicNowMs();
+    },
+    onRequestStart: () => {
+      activeRequests++;
+      oldestActiveRequestMs ??= monotonicNowMs();
+    },
+    onRequestEnd: () => {
+      activeRequests = Math.max(0, activeRequests - 1);
+      if (activeRequests === 0) oldestActiveRequestMs = undefined;
+    },
+    onLease: () => {
+      lastLeaseMs = monotonicNowMs();
+    },
+    onOwnerChange: (pid) => {
+      ownerPid = pid ?? Number.NaN;
+    },
+  });
   server.on("error", (error: NodeJS.ErrnoException) => {
     handleBridgeServerError(error, port);
   });
   server.listen(port, "127.0.0.1", () => {
-    writePidFile(port);
+    writePidFile(port, leaseToken);
     logBridgeMessage(`Listening on http://127.0.0.1:${port}`);
     writeReadySignal();
   });
 
   let shuttingDown = false;
+  let watchdog: NodeJS.Timeout | undefined;
   const shutdown = async () => {
     if (shuttingDown) return;
     shuttingDown = true;
+    if (watchdog) clearInterval(watchdog);
+    const forceExit = setTimeout(() => process.exit(0), 5_000);
+    forceExit.unref();
     removePidFile();
+    server.closeAllConnections();
     await closeServer(server);
     await client.close();
     await transport.close();
+    clearTimeout(forceExit);
     process.exit(0);
   };
+
+  watchdog = setInterval(() => {
+    const ownerAlive =
+      !Number.isInteger(ownerPid) || ownerPid <= 0 || isProcessAlive(ownerPid);
+    const reason = getBridgeReapReason(
+      {
+        nowMs: monotonicNowMs(),
+        lastLeaseMs,
+        lastActivityMs,
+        activeRequests,
+        oldestActiveRequestMs,
+        ownerAlive,
+      },
+      {
+        idleTimeoutMs: resolveLivenessTimeout("IDLE", DEFAULT_IDLE_TIMEOUT_MS),
+        leaseTimeoutMs: resolveLivenessTimeout(
+          "LEASE",
+          DEFAULT_LEASE_TIMEOUT_MS,
+        ),
+        maxRequestMs: 125_000,
+      },
+    );
+    if (reason) {
+      logBridgeMessage(`Self-reaping bridge: ${reason}`);
+      void shutdown().catch(() => process.exit(1));
+    }
+  }, 1000);
+  watchdog.unref();
 
   // Kill our entire process group on exit so chrome-devtools-mcp children
   // don't survive as orphans. The bridge is spawned with detached:true,
   // making it a process group leader — all children share our PGID.
   process.on("exit", () => {
+    if (watchdog) clearInterval(watchdog);
     removePidFile();
     try {
       process.kill(-process.pid, "SIGTERM");
@@ -686,9 +894,9 @@ export async function runBridge(port = resolveSessionPort()): Promise<void> {
   });
 
   process.on("SIGTERM", () => {
-    void shutdown();
+    void shutdown().catch(() => process.exit(1));
   });
   process.on("SIGINT", () => {
-    void shutdown();
+    void shutdown().catch(() => process.exit(1));
   });
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,11 @@ import { execFileSync, spawn } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { request } from "node:http";
 import { AxiError } from "axi-sdk-js";
-import { BRIDGE_PORT_IN_USE_EXIT_CODE, resolveBridgeScript } from "./bridge.js";
+import {
+  BRIDGE_PORT_IN_USE_EXIT_CODE,
+  createLeaseToken,
+  resolveBridgeScript,
+} from "./bridge.js";
 import {
   resolveSessionName,
   resolveSessionPidFile,
@@ -17,6 +21,21 @@ const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
 const MIN_BRIDGE_TIMEOUT_MS = 1_000;
 const HEALTH_TIMEOUT_MS = 2_000;
 const DEEP_HEALTH_TIMEOUT_MS = 5_000;
+
+/**
+ * The CLI is short-lived. Use an explicit stable supervisor PID when the
+ * owner-death lease is wanted; otherwise the token lease is refreshed by CLI
+ * activity and the idle TTL remains the backstop.
+ */
+export function resolveBridgeOwnerPid(): number | undefined {
+  const configured = Number.parseInt(
+    process.env.CHROME_DEVTOOLS_AXI_OWNER_PID ?? "",
+    10,
+  );
+  return Number.isInteger(configured) && configured > 0
+    ? configured
+    : undefined;
+}
 
 /**
  * Resolve the bridge readiness deadline in milliseconds.
@@ -56,6 +75,7 @@ export class CdpError extends AxiError {
 interface PidInfo {
   pid: number;
   port: number;
+  leaseToken?: string;
 }
 
 function readPidFile(
@@ -187,6 +207,23 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+async function refreshBridgeLease(
+  port: number,
+  leaseToken: string | undefined,
+  ownerPid = resolveBridgeOwnerPid(),
+): Promise<void> {
+  if (!leaseToken) return;
+  await httpPost(
+    port,
+    "/lease",
+    {
+      token: leaseToken,
+      ownerPid: ownerPid ?? null,
+    },
+    HEALTH_TIMEOUT_MS,
+  );
+}
+
 export async function waitForProcessExit(
   pid: number,
   timeoutMs: number,
@@ -284,6 +321,8 @@ export interface SpawnedBridge {
  */
 function spawnBridgeProcess(port: number, sessionName: string): SpawnedBridge {
   const bridgeScript = resolveBridgeScript(import.meta.dirname);
+  const leaseToken = createLeaseToken();
+  const ownerPid = resolveBridgeOwnerPid();
   const script = existsSync(bridgeScript.replace(/\.js$/, ".ts"))
     ? bridgeScript.replace(/\.js$/, ".ts")
     : bridgeScript;
@@ -298,6 +337,10 @@ function spawnBridgeProcess(port: number, sessionName: string): SpawnedBridge {
         ...process.env,
         CHROME_DEVTOOLS_AXI_PORT: String(port),
         CHROME_DEVTOOLS_AXI_SESSION: sessionName,
+        CHROME_DEVTOOLS_AXI_LEASE_TOKEN: leaseToken,
+        ...(ownerPid === undefined
+          ? {}
+          : { CHROME_DEVTOOLS_AXI_OWNER_PID: String(ownerPid) }),
       },
       detached: true,
     },
@@ -387,6 +430,13 @@ export async function ensureBridge(
         expectedSession: sessionName,
       })
     ) {
+      await refreshBridgeLease(
+        pidInfo.port,
+        pidInfo.leaseToken,
+        resolveBridgeOwnerPid(),
+      ).catch(() => {
+        // A lease refresh must not prevent reuse of a healthy bridge.
+      });
       return pidInfo.port;
     }
     await terminateBridgeProcess(pidInfo.pid, {
@@ -426,6 +476,14 @@ export async function ensureBridge(
         expectedSession: sessionName,
       })
     ) {
+      const leaseInfo = readPidFile(pidFile);
+      await refreshBridgeLease(
+        port,
+        leaseInfo?.leaseToken,
+        resolveBridgeOwnerPid(),
+      ).catch(() => {
+        // A lease refresh must not prevent a healthy bridge from being used.
+      });
       return port;
     }
     if (childExited) {
@@ -435,6 +493,14 @@ export async function ensureBridge(
           expectedSession: sessionName,
         })
       ) {
+        const leaseInfo = readPidFile(pidFile);
+        await refreshBridgeLease(
+          port,
+          leaseInfo?.leaseToken,
+          resolveBridgeOwnerPid(),
+        ).catch(() => {
+          // A lease refresh must not prevent a healthy bridge from being used.
+        });
         return port;
       }
       throw buildBridgeEarlyExitError(sessionName, port, exitCode, exitSignal);

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -11,6 +11,7 @@ import {
   extractHostHeaderHostname,
   extractToolText,
   getErrorMessage,
+  getBridgeReapReason,
   handleBridgeRequest,
   isAllowedBridgeHost,
   isRequestAllowed,
@@ -24,6 +25,99 @@ import {
   resolveTransportSpec,
   type BridgeClient,
 } from "../src/bridge.js";
+
+describe("getBridgeReapReason", () => {
+  const options = { idleTimeoutMs: 100, leaseTimeoutMs: 50 };
+
+  it("reaps an idle bridge only when no request is in flight", () => {
+    expect(
+      getBridgeReapReason(
+        {
+          nowMs: 200,
+          lastLeaseMs: 190,
+          lastActivityMs: 99,
+          activeRequests: 0,
+          ownerAlive: true,
+        },
+        options,
+      ),
+    ).toBe("idle");
+    expect(
+      getBridgeReapReason(
+        {
+          nowMs: 200,
+          lastLeaseMs: 190,
+          lastActivityMs: 99,
+          activeRequests: 1,
+          ownerAlive: true,
+        },
+        options,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not reap a recent in-flight request even when the owner is dead", () => {
+    expect(
+      getBridgeReapReason(
+        {
+          nowMs: 200,
+          lastLeaseMs: 149,
+          lastActivityMs: 99,
+          activeRequests: 1,
+          oldestActiveRequestMs: 190,
+          ownerAlive: false,
+        },
+        options,
+      ),
+    ).toBeNull();
+  });
+
+  it("allows a wedged request to be reaped after the hard request limit", () => {
+    expect(
+      getBridgeReapReason(
+        {
+          nowMs: 300,
+          lastLeaseMs: 149,
+          lastActivityMs: 99,
+          activeRequests: 1,
+          oldestActiveRequestMs: 100,
+          ownerAlive: false,
+        },
+        { ...options, maxRequestMs: 100 },
+      ),
+    ).toBe("idle");
+  });
+
+  it("reaps after a dead owner's lease expires", () => {
+    expect(
+      getBridgeReapReason(
+        {
+          nowMs: 200,
+          lastLeaseMs: 149,
+          lastActivityMs: 190,
+          activeRequests: 0,
+          ownerAlive: false,
+        },
+        options,
+      ),
+    ).toBe("lease-expired");
+  });
+
+  it("keeps a live owner and recent bridge alive", () => {
+    expect(
+      getBridgeReapReason(
+        {
+          nowMs: 120,
+          lastLeaseMs: 100,
+          lastActivityMs: 100,
+          activeRequests: 0,
+          ownerAlive: true,
+        },
+        options,
+      ),
+    ).toBeNull();
+  });
+});
 
 describe("extractToolText", () => {
   it("joins text blocks and ignores non-text content", () => {
@@ -619,6 +713,54 @@ function makeResponse(): { res: ServerResponse; captured: CapturedResponse } {
   }) as typeof res.end;
   return { res, captured };
 }
+
+describe("handleBridgeRequest /lease", () => {
+  it("refreshes a valid lease and rejects a wrong token", async () => {
+    let activity = 0;
+    const client: BridgeClient = {
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => ({ content: [] }),
+      close: async () => {},
+    };
+
+    const valid = makeResponse();
+    await handleBridgeRequest(
+      client,
+      makeRequest(
+        "POST",
+        "/lease",
+        {},
+        JSON.stringify({ token: "secret", ownerPid: 123 }),
+      ),
+      valid.res,
+      undefined,
+      undefined,
+      {
+        leaseToken: "secret",
+        onActivity: () => activity++,
+        onOwnerChange: (pid) => expect(pid).toBe(123),
+      },
+    );
+    expect(valid.captured.statusCode).toBe(200);
+    expect(activity).toBe(1);
+
+    const invalid = makeResponse();
+    await handleBridgeRequest(
+      client,
+      makeRequest(
+        "POST",
+        "/lease",
+        {},
+        JSON.stringify({ token: "wrong", ownerPid: 123 }),
+      ),
+      invalid.res,
+      undefined,
+      undefined,
+      { leaseToken: "secret" },
+    );
+    expect(invalid.captured.statusCode).toBe(403);
+  });
+});
 
 describe("handleBridgeRequest /health", () => {
   it("returns 200 ok for shallow /health when MCP is connected", async () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -15,6 +15,7 @@ import {
   ensureBridge,
   getSessionSnapshotIfRunning,
   mapErrorMessage,
+  resolveBridgeOwnerPid,
   resolveBridgeTimeoutMs,
   type SpawnedBridge,
   stopBridge,
@@ -78,6 +79,26 @@ describe("unsafe session names are rejected on action entry points", () => {
   it("getSessionSnapshotIfRunning degrades an invalid session to null instead of throwing", async () => {
     process.env.CHROME_DEVTOOLS_AXI_SESSION = "..";
     await expect(getSessionSnapshotIfRunning()).resolves.toBeNull();
+  });
+});
+
+describe("resolveBridgeOwnerPid", () => {
+  const savedOwnerPid = process.env.CHROME_DEVTOOLS_AXI_OWNER_PID;
+
+  afterEach(() => {
+    if (savedOwnerPid === undefined)
+      delete process.env.CHROME_DEVTOOLS_AXI_OWNER_PID;
+    else process.env.CHROME_DEVTOOLS_AXI_OWNER_PID = savedOwnerPid;
+  });
+
+  it("uses an explicit stable supervisor PID", () => {
+    process.env.CHROME_DEVTOOLS_AXI_OWNER_PID = "12345";
+    expect(resolveBridgeOwnerPid()).toBe(12345);
+  });
+
+  it("does not infer ownership from a transient shell", () => {
+    delete process.env.CHROME_DEVTOOLS_AXI_OWNER_PID;
+    expect(resolveBridgeOwnerPid()).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- add an authenticated owner lease refresh endpoint for detached bridges
- reap bridges after the configured owner lease expires or after 15 minutes without client activity
- protect in-flight calls, add a hard request ceiling, preserve process-group cleanup, and never target externally owned browsers
- add pure reaping tests and document the orphan incident class

## Incident class

A short-lived CLI can launch a detached bridge and then disappear before it runs `stop`. The bridge has no parent-death event after detachment, so its MCP child and launched Chrome tree can remain healthy and immortal. This change adds bounded liveness so an agent crash cannot leave that process tree running indefinitely.

## Validation

- `pnpm run build`
- `pnpm test` (441 tests)
- `git diff --check`

No external browser process is killed: process-group cleanup remains limited to bridges known to be owned by this tool.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)