### PR TITLE
ci: require no-mistakes pipeline attestation in the gate

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -38,7 +38,7 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'release-please[bot]'
     steps:
-      - name: Verify no-mistakes signature in PR body
+      - name: Verify no-mistakes signature and pipeline attestation in PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -48,19 +48,179 @@ jobs:
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
-            exit 0
+          else
+            {
+              echo "::error::This PR was not raised through no-mistakes."
+              echo
+              echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+              echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+              echo "deterministic '## Pipeline' section into the PR body containing:"
+              echo
+              echo "    $marker"
+              echo
+              echo "See CONTRIBUTING.md for setup and the full workflow."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
           fi
-          {
-            echo "::error::This PR was not raised through no-mistakes."
-            echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review/test/build/CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
-            echo
-            echo "    $marker"
-            echo
-            echo "See CONTRIBUTING.md for setup and the full workflow."
-            echo
-            echo "PR author: ${PR_AUTHOR}"
-          } >&2
-          exit 1
+
+          # The signature alone only proves the pipeline wrote the body. no-mistakes
+          # >= 1.46.0 also emits a machine-readable step attestation next to it; parse
+          # that to prove review, test, and document actually ran to completion.
+          # Contract: docs/reference/pipeline-steps.md#pipeline-step-attestation in
+          # kunchenguid/no-mistakes.
+          attestation_prefix='<!-- no-mistakes-pipeline-attestation:v1 '
+          attestation_suffix=' -->'
+
+          if ! printf '%s' "${PR_BODY:-}" | grep -qF -- "$attestation_prefix"; then
+            echo "::error::This PR carries the no-mistakes signature but no pipeline attestation."
+            {
+              echo
+              echo "no-mistakes >= 1.46.0 is required (PR 670). That release writes a"
+              echo "machine-readable comment next to the signature:"
+              echo
+              echo "    ${attestation_prefix}{\"head_sha\":\"...\",\"steps\":[...]}${attestation_suffix}"
+              echo
+              echo "Upgrade no-mistakes ('no-mistakes update'), then re-run"
+              echo "'git push no-mistakes' so the PR body is rewritten with the attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Exact-substring extraction (no regex): first prefix, then the first
+          # closing token after it, mirroring how no-mistakes' own consumer test
+          # slices the payload.
+          payload="$(
+            printf '%s' "${PR_BODY:-}" | tr -d '\r' | awk -v pre="$attestation_prefix" -v suf="$attestation_suffix" '
+              found { next }
+              {
+                p = index($0, pre)
+                if (p == 0) next
+                rest = substr($0, p + length(pre))
+                s = index(rest, suf)
+                if (s == 0) next
+                print substr(rest, 1, s - 1)
+                found = 1
+              }
+            '
+          )"
+
+          if [ -z "$payload" ]; then
+            echo "::error::The no-mistakes pipeline attestation comment is malformed: no JSON payload could be extracted."
+            {
+              echo
+              echo "The '${attestation_prefix}' marker is present but is not closed by"
+              echo "'${attestation_suffix}' on the same line, or the payload is empty."
+              echo "This gate fails closed on an unreadable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Real JSON parsing. Emits one "<step>\t<verdict>\t<detail>" line per
+          # required step. A step recorded more than once must be completed in
+          # every record. Any skip-shaped sibling key (a future 'skipped',
+          # 'skip_reason', 'quota_...', '..._unavailable' field) with a meaningful
+          # value is rejected outright, so a skip can never ride along on a
+          # 'completed' status.
+          if ! report="$(
+            printf '%s' "$payload" | jq -r --argjson required '["review","test","document"]' '
+              if type != "object" then error("attestation payload is not a JSON object") else . end
+              | if (.steps | type) != "array" then error("attestation payload has no \"steps\" array") else . end
+              | . as $attestation
+              | $required[]
+              | . as $name
+              | [ $attestation.steps[] | select((type == "object") and ((.step? | tostring) == $name)) ] as $records
+              | if ($records | length) == 0 then
+                  "\($name)\tmissing\tno record in attestation"
+                else
+                  ([ $records[] | (.status? // null) | tostring ] | unique) as $statuses
+                  | ([ $records[]
+                       | to_entries[]
+                       | select((.key | ascii_downcase) | test("skip|quota|unavailable"))
+                       | select(.value != null and .value != false and .value != "")
+                       | .key ] | unique) as $skip_markers
+                  | if ($skip_markers | length) > 0 then
+                      "\($name)\tskip-marker\t\($skip_markers | join(","))"
+                    elif $statuses == ["completed"] then
+                      "\($name)\tok\tcompleted"
+                    else
+                      "\($name)\tbad\t\($statuses | join(","))"
+                    end
+                end
+            ' 2>&1
+          )"; then
+            echo "::error::The no-mistakes pipeline attestation payload could not be parsed as JSON."
+            {
+              echo
+              echo "jq reported:"
+              echo "$report"
+              echo
+              echo "Payload: $payload"
+              echo
+              echo "This gate fails closed on an unparseable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+
+          tab="$(printf '\t')"
+          gate_status=0
+          checked=0
+          while IFS="$tab" read -r name verdict detail; do
+            [ -n "$name" ] || continue
+            checked=$((checked + 1))
+            case "$verdict" in
+              ok)
+                echo "  ok: ${name} = completed"
+                ;;
+              missing)
+                echo "::error::The no-mistakes pipeline attestation has no '${name}' step record; '${name}' must be recorded as completed."
+                gate_status=1
+                ;;
+              skip-marker)
+                echo "::error::The no-mistakes pipeline attestation marks '${name}' with skip indicator(s) [${detail}]; quota-exhaustion and agent-unavailability skips are not accepted."
+                gate_status=1
+                ;;
+              *)
+                echo "::error::The no-mistakes pipeline attestation records '${name}' as '${detail}', not 'completed'."
+                gate_status=1
+                ;;
+            esac
+          done <<REPORT
+          $report
+          REPORT
+
+          # A verdict per required step is the only shape jq can emit for a payload
+          # it accepted. Assert it anyway so an unexpected empty report fails closed
+          # instead of reporting nothing and passing.
+          if [ "$checked" -ne 3 ]; then
+            echo "::error::The no-mistakes attestation gate reached a verdict for ${checked} of the 3 required steps (review, test, document); failing closed."
+            gate_status=1
+          fi
+
+          if [ "$gate_status" -ne 0 ]; then
+            {
+              echo
+              echo "The no-mistakes review, test, and document steps must all be recorded as"
+              echo "'completed'. A step that was skipped (pre-skipped with --skip, skipped at a"
+              echo "gate, or skipped because the agent was unavailable or out of quota), failed,"
+              echo "or never finished is not accepted."
+              echo
+              echo "Re-run 'git push no-mistakes' and let review, test, and document run."
+              echo
+              echo "Attestation payload: $payload"
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "no-mistakes pipeline attestation verified for PR #${PR_NUMBER}: review, test, and document all completed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ Its frontmatter includes Hermes Agent metadata from `src/skill.ts`; update the g
 - Keep `skills/chrome-devtools-axi/` in the npm `files` list when changing package contents; the skill-first install path depends on it shipping with the package.
 - `pnpm-workspace.yaml` enforces a minimum release age for dependency updates as a supply-chain guard; `axi-sdk-js` and `chrome-devtools-axi` are exempt.
 - `.airlock/lint.sh` must use pnpm (never `npm install` or `npx`); `test/airlock-lint.test.ts` enforces this.
-- Human-authored PRs to `main` must go through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes); CI enforces a deterministic signature in the PR body. See CONTRIBUTING.md.
+- Human-authored PRs to `main` must go through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes); the gate in `no-mistakes-required.yml` requires both the body signature and the `no-mistakes-pipeline-attestation:v1` comment (review/test/document all `completed`). See CONTRIBUTING.md.
+- That gate's inline `run:` script is mirrored byte-for-byte across repos (upstream: `kunchenguid/gh-axi`); only this repo's `on:`/`if:`/`concurrency` differ. `test/no-mistakes-gate.test.ts` extracts the exact block from the YAML and executes it against fixtures, so edit the script rather than the test's copy of it.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,3 @@
 <!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+
 @AGENTS.md

--- a/test/no-mistakes-gate.test.ts
+++ b/test/no-mistakes-gate.test.ts
@@ -1,0 +1,210 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const workflowPath = join(
+  root,
+  ".github",
+  "workflows",
+  "no-mistakes-required.yml",
+);
+
+/**
+ * The gate lives as an inline `run:` block so the whole file can be mirrored
+ * into sibling repositories as one unit. Extract that exact block and execute
+ * it, so these tests exercise what CI runs rather than a copy of it.
+ */
+function extractGateScript(): string {
+  const doc = parse(readFileSync(workflowPath, "utf8")) as {
+    jobs: { check: { steps: Array<{ run?: string }> } };
+  };
+  const script = doc.jobs.check.steps[0]?.run;
+  if (!script) throw new Error("no-mistakes gate step has no run block");
+  return script;
+}
+
+const scriptPath = join(mkdtempSync(join(tmpdir(), "nm-gate-")), "gate.sh");
+writeFileSync(scriptPath, extractGateScript());
+
+function hasCommand(command: string): boolean {
+  return spawnSync("sh", ["-c", `command -v ${command}`]).status === 0;
+}
+
+// The gate is a bash script that parses JSON with jq, exactly as the
+// ubuntu-latest runner does. Never skip on CI: a silently skipped gate test is
+// worse than no test. Locally, skip when jq is absent rather than failing a
+// contributor's `pnpm test` over an unrelated missing tool.
+const runnable = hasCommand("bash") && hasCommand("jq");
+if (process.env.CI && !runnable) {
+  throw new Error(
+    "CI must provide bash and jq to exercise the no-mistakes gate",
+  );
+}
+
+function runGate(body: string): { code: number; output: string } {
+  const result = spawnSync("bash", [scriptPath], {
+    env: {
+      ...process.env,
+      PR_BODY: body,
+      PR_AUTHOR: "somedev",
+      PR_NUMBER: "42",
+    },
+    encoding: "utf8",
+  });
+  return {
+    code: result.status ?? -1,
+    output: `${result.stdout}${result.stderr}`,
+  };
+}
+
+const SIGNATURE =
+  "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)";
+const ATTESTATION_PREFIX = "<!-- no-mistakes-pipeline-attestation:v1 ";
+const ATTESTATION_SUFFIX = " -->";
+const HEAD_SHA = "12df13109c6ad8d64646b85ac7170b23afe6e9bf";
+
+/** A PR body shaped like the one no-mistakes writes. */
+function prBody(attestationPayload?: string): string {
+  const attestation =
+    attestationPayload === undefined
+      ? ""
+      : `${ATTESTATION_PREFIX}${attestationPayload}${ATTESTATION_SUFFIX}\n\n`;
+  return [
+    "## What Changed\n\n- something\n",
+    `## Pipeline\n\n${SIGNATURE}\n\n${attestation}`,
+    "<details>\n<summary>Review</summary>\n\nok\n\n</details>\n",
+  ].join("\n");
+}
+
+function attestation(steps: Array<[string, string]>): string {
+  return JSON.stringify({
+    head_sha: HEAD_SHA,
+    steps: steps.map(([step, status]) => ({ step, status })),
+  });
+}
+
+/** The step snapshot a healthy run produces when the PR body is written. */
+const HEALTHY_STEPS: Array<[string, string]> = [
+  ["intent", "completed"],
+  ["rebase", "completed"],
+  ["review", "completed"],
+  ["test", "completed"],
+  ["document", "completed"],
+  ["lint", "completed"],
+  ["push", "completed"],
+  ["pr", "running"],
+  ["ci", "pending"],
+];
+
+function withStatus(step: string, status: string): Array<[string, string]> {
+  return HEALTHY_STEPS.map(([name, current]) =>
+    name === step ? [name, status] : [name, current],
+  ) as Array<[string, string]>;
+}
+
+describe.runIf(runnable)("no-mistakes PR gate", () => {
+  it("accepts a body whose attestation completes review, test, and document", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)));
+    expect(code).toBe(0);
+    expect(output).toContain("review, test, and document all completed");
+  });
+
+  it("still rejects a body with no no-mistakes signature", () => {
+    const { code, output } = runGate("## Intent\n\nhand-written body\n");
+    expect(code).toBe(1);
+    expect(output).toContain("was not raised through no-mistakes");
+    expect(output).toContain("git push no-mistakes");
+  });
+
+  it("rejects a signed body with no attestation and names the required version", () => {
+    const { code, output } = runGate(prBody());
+    expect(code).toBe(1);
+    expect(output).toContain("no pipeline attestation");
+    expect(output).toContain("no-mistakes >= 1.46.0 is required (PR 670)");
+  });
+
+  // Every skip route no-mistakes has - `--skip`, a user skip at a gate, an
+  // automatic pipeline skip, or a run that ran out of agent quota - lands on
+  // the raw `skipped` status, and an unavailable agent surfaces as `failed`.
+  for (const status of ["skipped", "failed", "running", "pending"]) {
+    it(`rejects an attestation whose test step is ${status}`, () => {
+      const { code, output } = runGate(
+        prBody(attestation(withStatus("test", status))),
+      );
+      expect(code).toBe(1);
+      expect(output).toContain(`records 'test' as '${status}'`);
+    });
+  }
+
+  it("rejects an attestation that omits a required step entirely", () => {
+    const steps = HEALTHY_STEPS.filter(([name]) => name !== "document");
+    const { code, output } = runGate(prBody(attestation(steps)));
+    expect(code).toBe(1);
+    expect(output).toContain("no 'document' step record");
+  });
+
+  it("rejects a required step recorded twice unless every record completed", () => {
+    const steps: Array<[string, string]> = [
+      ...HEALTHY_STEPS,
+      ["review", "skipped"],
+    ];
+    const { code, output } = runGate(prBody(attestation(steps)));
+    expect(code).toBe(1);
+    expect(output).toContain("records 'review' as 'completed,skipped'");
+  });
+
+  // v1 carries no skip sibling field, so `status` is the only skip channel
+  // today. Fail closed if a later schema ever hangs a skip reason off an
+  // otherwise-completed step instead of widening the gate silently.
+  for (const marker of [
+    { skip_reason: "quota exhausted" },
+    { skipped: true },
+    { agent_unavailable: true },
+    { quota_exhausted: true },
+  ]) {
+    const key = Object.keys(marker)[0];
+    it(`rejects a completed step carrying a ${key} marker`, () => {
+      const payload = JSON.stringify({
+        head_sha: HEAD_SHA,
+        steps: HEALTHY_STEPS.map(([step, status]) =>
+          step === "review" ? { step, status, ...marker } : { step, status },
+        ),
+      });
+      const { code, output } = runGate(prBody(payload));
+      expect(code).toBe(1);
+      expect(output).toContain(`skip indicator(s) [${key}]`);
+    });
+  }
+
+  it("fails closed on an attestation payload that is not valid JSON", () => {
+    const { code, output } = runGate(
+      prBody('{"head_sha":"abc","steps":[{"step":"review",'),
+    );
+    expect(code).toBe(1);
+    expect(output).toContain("could not be parsed as JSON");
+  });
+
+  it("fails closed when the payload has no steps array", () => {
+    const { code, output } = runGate(prBody('{"head_sha":"abc"}'));
+    expect(code).toBe(1);
+    expect(output).toContain("could not be parsed as JSON");
+  });
+
+  it("fails closed when the attestation comment is never closed", () => {
+    const body = `## Pipeline\n\n${SIGNATURE}\n\n${ATTESTATION_PREFIX}{"head_sha":"abc","steps":[]}\n`;
+    const { code, output } = runGate(body);
+    expect(code).toBe(1);
+    expect(output).toContain("no JSON payload could be extracted");
+  });
+
+  it("accepts a CRLF body", () => {
+    const body = prBody(attestation(HEALTHY_STEPS)).replace(/\n/g, "\r\n");
+    const { code } = runGate(body);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## What changed

Mirrors the attestation gate that landed on [gh-axi `main` (PR #111)](https://github.com/kunchenguid/gh-axi/pull/111) into this repo.

The `Require no-mistakes` gate only checked for the human-readable signature, which proves the pipeline wrote the PR body but says nothing about which steps actually ran. no-mistakes >= 1.46.0 (PR 670) also writes a machine-readable `<!-- no-mistakes-pipeline-attestation:v1 {...} -->` comment recording every step's raw status.

The gate step's `run:` script is now the reference block **byte-for-byte**:

- signature check first (existing failure path preserved);
- signature present but attestation missing -> fail with the `no-mistakes >= 1.46.0 is required (PR 670)` upgrade message;
- exact-substring payload extraction (no regex), failing closed on an unclosed/empty comment;
- `jq` parse of `steps[]` requiring `review`, `test`, `document` to all be `status == "completed"` (a step recorded twice must be completed in every record);
- any skip-shaped sibling key (`skipped`, `skip_reason`, `quota_*`, `*_unavailable`) rejected outright, so a skip can never ride along on a `completed` status;
- malformed JSON, a missing `steps` array, or a verdict count != 3 fails closed.

**This repo's own configuration is untouched**: `on:` (types/branches/`paths-ignore`), `concurrency`, `permissions`, the author/exemption `if:` list, and the job name (`PR must be raised via no-mistakes`) are byte-identical to before. Only the step's name and script body changed.

One wording drift comes with the byte-for-byte mirror: the signature-missing error now says `review/test/lint/CI` (gh-axi's phrasing) where it previously said `review/test/build/CI`. Keeping the script identical across repos is worth more than that one word.

## Tests

`test/no-mistakes-gate.test.ts` (mirrored from gh-axi's) parses the workflow YAML, extracts the **exact** inline `run:` block, writes it to a temp script, and executes it under `bash` with fixture `PR_BODY` values - so the tests exercise what CI runs rather than a copy of it. It throws on CI if `bash`/`jq` are absent rather than silently skipping.

```
 RUN  v3.2.4 /Users/kunchen/.treehouse/chrome-devtools-axi-7b314a/1/chrome-devtools-axi

 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > accepts a body whose attestation completes review, test, and document 22ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > still rejects a body with no no-mistakes signature 7ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects a signed body with no attestation and names the required version 10ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects an attestation whose test step is skipped 22ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects an attestation whose test step is failed 23ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects an attestation whose test step is running 22ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects an attestation whose test step is pending 22ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects an attestation that omits a required step entirely 22ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects a required step recorded twice unless every record completed 22ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects a completed step carrying a skip_reason marker 21ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects a completed step carrying a skipped marker 20ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects a completed step carrying a agent_unavailable marker 21ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > rejects a completed step carrying a quota_exhausted marker 20ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > fails closed on an attestation payload that is not valid JSON 16ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > fails closed when the payload has no steps array 17ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > fails closed when the attestation comment is never closed 12ms
 ✓ test/no-mistakes-gate.test.ts > no-mistakes PR gate > accepts a CRLF body 20ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  18:15:14
   Duration  522ms (transform 22ms, setup 0ms, collect 47ms, tests 319ms, environment 0ms, prepare 30ms)

```

Full suite, build, and formatting:

```
Test Files  24 passed (24)
     Tests  459 passed (459)
```

`pnpm run build` clean; `pnpm exec prettier --check .` clean (this PR also fixes a pre-existing CLAUDE.md formatting failure).

## Notes

- Raised as a direct PR (internal CI tooling), so the advisory `Require no-mistakes` check on **this** PR will fail for lack of a signature - expected and non-blocking. The real checks (build/test/guard) must be green.
- `AGENTS.md` records that the gate script is mirrored byte-for-byte from gh-axi and that the test extracts it from the YAML, so future edits go to the script, not to a copy.
