### PR TITLE
ci: bind the no-mistakes attestation to the current PR head

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -43,6 +43,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
@@ -169,7 +170,31 @@ jobs:
             exit 1
           fi
 
-          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+          attested_head="$(printf '%s' "$payload" | jq -r '.head_sha // ""')"
+          echo "Attestation head_sha: ${attested_head:-(absent)}"
+
+          # Head binding. The attestation describes the commit no-mistakes ran
+          # its steps on; a later push moves the PR head without rewriting the
+          # body, so an attestation that does not name the current head proves
+          # nothing about the code being merged. A `synchronize` whose body was
+          # NOT rewritten by no-mistakes going red is the intended contract, not
+          # a false positive.
+          if [ -z "$attested_head" ] || [ -z "${PR_HEAD_SHA:-}" ] || [ "$attested_head" != "$PR_HEAD_SHA" ]; then
+            echo "::error::The no-mistakes pipeline attestation is STALE for the current head of PR #${PR_NUMBER}."
+            {
+              echo
+              echo "Attestation head_sha: ${attested_head:-(absent)}"
+              echo "PR head sha:          ${PR_HEAD_SHA:-(absent)}"
+              echo
+              echo "A commit was pushed after the no-mistakes run, so the attestation does not"
+              echo "describe the code this PR now proposes to merge."
+              echo
+              echo "Re-run 'git push no-mistakes' to refresh it."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
 
           tab="$(printf '\t')"
           gate_status=0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ Its frontmatter includes Hermes Agent metadata from `src/skill.ts`; update the g
 - Keep `skills/chrome-devtools-axi/` in the npm `files` list when changing package contents; the skill-first install path depends on it shipping with the package.
 - `pnpm-workspace.yaml` enforces a minimum release age for dependency updates as a supply-chain guard; `axi-sdk-js` and `chrome-devtools-axi` are exempt.
 - `.airlock/lint.sh` must use pnpm (never `npm install` or `npx`); `test/airlock-lint.test.ts` enforces this.
-- Human-authored PRs to `main` must go through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes); the gate in `no-mistakes-required.yml` requires both the body signature and the `no-mistakes-pipeline-attestation:v1` comment (review/test/document all `completed`). See CONTRIBUTING.md.
-- That gate's inline `run:` script is mirrored byte-for-byte across repos (upstream: `kunchenguid/gh-axi`); only this repo's `on:`/`if:`/`concurrency` differ. `test/no-mistakes-gate.test.ts` extracts the exact block from the YAML and executes it against fixtures, so edit the script rather than the test's copy of it.
+- Human-authored PRs to `main` must go through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes) (>= 1.46.0); the gate in `no-mistakes-required.yml` requires the body signature, the `no-mistakes-pipeline-attestation:v1` comment (review/test/document all `completed`), and the attested `head_sha` to equal the PR's current head. A `synchronize` whose body was not rewritten by no-mistakes going red is intended. See CONTRIBUTING.md.
+- That gate's inline `run:` script is mirrored byte-for-byte across repos (upstream: `kunchenguid/gh-axi`, plus the head binding); only this repo's `on:`/`if:`/`concurrency` differ. `test/no-mistakes-gate.test.ts` extracts the exact block from the YAML and executes it against fixtures, so edit the script rather than the test's copy of it.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,9 @@ We require this to reduce the maintainer's burden of reviewing and merging contr
 Pushing through it runs an AI-driven review/test/build pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
-The release and dependency bots are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
+It also requires the machine-readable pipeline attestation that no-mistakes >= 1.46.0 writes next to that signature: the `review`, `test`, and `document` steps must all be recorded as `completed`, and the attested `head_sha` must be the PR's current head.
+So pushing a commit after the pipeline ran turns the check red until you `git push no-mistakes` again and the body is rewritten for the new head.
+The release and dependency bots are exempt so their automation keeps working, but regular contributor PRs without the signature and a current attestation will not be reviewed or merged.
 
 ## Workflow
 

--- a/test/no-mistakes-gate.test.ts
+++ b/test/no-mistakes-gate.test.ts
@@ -46,13 +46,17 @@ if (process.env.CI && !runnable) {
   );
 }
 
-function runGate(body: string): { code: number; output: string } {
+function runGate(
+  body: string,
+  headSha: string = HEAD_SHA,
+): { code: number; output: string } {
   const result = spawnSync("bash", [scriptPath], {
     env: {
       ...process.env,
       PR_BODY: body,
       PR_AUTHOR: "somedev",
       PR_NUMBER: "42",
+      PR_HEAD_SHA: headSha,
     },
     encoding: "utf8",
   });
@@ -81,9 +85,12 @@ function prBody(attestationPayload?: string): string {
   ].join("\n");
 }
 
-function attestation(steps: Array<[string, string]>): string {
+function attestation(
+  steps: Array<[string, string]>,
+  headSha: string = HEAD_SHA,
+): string {
   return JSON.stringify({
-    head_sha: HEAD_SHA,
+    head_sha: headSha,
     steps: steps.map(([step, status]) => ({ step, status })),
   });
 }
@@ -180,6 +187,49 @@ describe.runIf(runnable)("no-mistakes PR gate", () => {
       expect(output).toContain(`skip indicator(s) [${key}]`);
     });
   }
+
+  // Head binding: the attestation describes the commit no-mistakes ran on, so
+  // an attestation naming any other commit says nothing about what is being
+  // merged. A synchronize whose body was not rewritten by no-mistakes going red
+  // is the contract, not a false positive.
+  it("accepts an attestation whose head_sha is the PR's current head", () => {
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, HEAD_SHA)),
+      HEAD_SHA,
+    );
+    expect(code).toBe(0);
+    expect(output).toContain(`Attestation head_sha: ${HEAD_SHA}`);
+  });
+
+  it("rejects an attestation whose head_sha is not the PR's current head", () => {
+    const staleSha = "0000000000000000000000000000000000000000";
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, staleSha)),
+      HEAD_SHA,
+    );
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toContain("Re-run 'git push no-mistakes' to refresh it");
+    expect(output).toContain(staleSha);
+    expect(output).toContain(HEAD_SHA);
+  });
+
+  it("fails closed when the attestation carries no head_sha at all", () => {
+    const payload = JSON.stringify({
+      steps: HEALTHY_STEPS.map(([step, status]) => ({ step, status })),
+    });
+    const { code, output } = runGate(prBody(payload), HEAD_SHA);
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toContain("Attestation head_sha: (absent)");
+  });
+
+  it("fails closed when the PR head sha is unavailable", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)), "");
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toMatch(/PR head sha: +\(absent\)/);
+  });
 
   it("fails closed on an attestation payload that is not valid JSON", () => {
     const { code, output } = runGate(


### PR DESCRIPTION
## What Changed

Binds the `no-mistakes-pipeline-attestation:v1` gate to the PR's **current head commit**, mirroring the head-binding merged on lavish-axi `main` (PR #271).

Before this, the gate extracted the attestation's `head_sha` and only printed it. A commit pushed directly *after* a no-mistakes run still passed the gate on a stale attestation - the attestation described a commit that is no longer what the PR proposes to merge.

- `.github/workflows/no-mistakes-required.yml`
  - Adds `PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}` to the gate step's `env:`.
  - After parsing the attestation, fails with an `::error::` when `head_sha` is absent, `PR_HEAD_SHA` is absent, or the two differ - reporting both shas and telling the contributor to re-run `git push no-mistakes`.
  - The check runs *before* the per-step verdict loop, so a stale attestation fails fast.
  - The inline `run:` script is now **byte-for-byte identical** to lavish-axi `main`'s (verified by extracting both blocks and comparing). Only this repo's `on:`/`if:`/`concurrency`/`paths-ignore` differ, as before.
- `test/no-mistakes-gate.test.ts` - four new cases (this repo's Vitest style, mirroring lavish's `node:test` versions): matching head passes; stale head fails; missing `head_sha` fails closed; missing `PR_HEAD_SHA` fails closed. `runGate`/`attestation` take an optional head sha.
- `AGENTS.md` / `CONTRIBUTING.md` - document the head binding and that it is the contract, not a false positive.

### Intended behavior

A `synchronize` event whose PR body was **not** rewritten by no-mistakes now goes red. That is the point: the attestation must name the commit being merged.

## Test transcript

```
$ pnpm exec prettier --check .
Checking formatting...
All matched files use Prettier code style!

$ pnpm run build
$ tsc && chmod +x dist/bin/chrome-devtools-axi.js

$ pnpm test
 ✓ test/no-mistakes-gate.test.ts (21 tests) 584ms
 ✓ test/version-path.test.ts (9 tests) 631ms
 ✓ test/client.test.ts (32 tests) 6979ms
 ...
 Test Files  24 passed (24)
      Tests  463 passed (463)
   Duration  7.30s
```

Gate suite went from 17 to 21 tests; all 463 tests across 24 files pass.

> Note: this is a direct PR raised without the no-mistakes pipeline (internal CI tooling change), so the advisory `Require no-mistakes` check will fail - expected and non-blocking. The real checks (build/test/guard) must be green.
