### PR TITLE
Fix bridge port collisions with browser CDP endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,13 +268,13 @@ For both commands, `all` or an omitted `--type` returns every item.
 
 ## Configuration
 
-The bridge server port defaults to `9224`. When a local loopback `CHROME_DEVTOOLS_AXI_BROWSER_URL` uses the derived bridge port, chrome-devtools-axi automatically selects a free distinct bridge port. Override it with an environment variable:
+The bridge server port defaults to `9224`. When `CHROME_DEVTOOLS_AXI_BROWSER_URL` uses the derived bridge port and that local bridge port is occupied, chrome-devtools-axi automatically selects a free distinct bridge port. Override it with an environment variable:
 
 ```sh
 export CHROME_DEVTOOLS_AXI_PORT=9225
 ```
 
-An explicit bridge port must differ from a browser/CDP port on the same local loopback interface; a collision fails immediately without launching or replacing Chrome. A remote browser endpoint may use the same port number because it is a distinct network endpoint.
+An explicit bridge port must be available on the local loopback interface; when the browser endpoint uses the same port number, an occupied bridge port fails immediately without launching or replacing Chrome. A remote browser endpoint may use the same port number when the local bridge port is available because it is a distinct network endpoint.
 
 Connect to an existing Chrome instance instead of launching one:
 

--- a/README.md
+++ b/README.md
@@ -268,11 +268,13 @@ For both commands, `all` or an omitted `--type` returns every item.
 
 ## Configuration
 
-The bridge server port defaults to `9224`. Override it with an environment variable:
+The bridge server port defaults to `9224`. When `CHROME_DEVTOOLS_AXI_BROWSER_URL` uses the derived bridge port, chrome-devtools-axi automatically selects a free distinct bridge port. Override it with an environment variable:
 
 ```sh
 export CHROME_DEVTOOLS_AXI_PORT=9225
 ```
+
+An explicit bridge port must differ from the configured browser/CDP port; a collision fails immediately without launching or replacing Chrome.
 
 Connect to an existing Chrome instance instead of launching one:
 
@@ -323,7 +325,7 @@ Each session name gets its own bridge process, port (auto-derived from the name,
 In the default `--isolated` and `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` launch modes each bridge also launches its own Chrome, so concurrent sessions share neither browser state nor each other's stale-ref tracking.
 Sessions that attach to the same external browser - multiple `CHROME_DEVTOOLS_AXI_AUTO_CONNECT=1` sessions on one running Chrome, or the same `CHROME_DEVTOOLS_AXI_BROWSER_URL`/`wsEndpoint` - drive that shared browser and are isolated only at the bridge level, where the per-session generation counter does not prevent cross-talk.
 A session only isolates the bridge - the connection mode and profile are unchanged; combine with `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` for a persistent per-session profile.
-The default (unset) session keeps port 9224 and the legacy state paths below.
+The default (unset) session derives port 9224 and keeps the legacy state paths below; an attached browser already using 9224 causes only the bridge port to move automatically.
 
 Do not export `CHROME_DEVTOOLS_AXI_PORT` globally when running concurrent sessions: it overrides the per-session derived port and forces every session onto the same port, so the second session fails to start - its bridge cannot bind the already-taken port, and the first session's bridge is rejected as a mismatch rather than silently shared.
 Rely on the per-session default ports instead, or set `CHROME_DEVTOOLS_AXI_PORT` only inline per command.

--- a/README.md
+++ b/README.md
@@ -268,13 +268,13 @@ For both commands, `all` or an omitted `--type` returns every item.
 
 ## Configuration
 
-The bridge server port defaults to `9224`. When `CHROME_DEVTOOLS_AXI_BROWSER_URL` uses the derived bridge port, chrome-devtools-axi automatically selects a free distinct bridge port. Override it with an environment variable:
+The bridge server port defaults to `9224`. When a local loopback `CHROME_DEVTOOLS_AXI_BROWSER_URL` uses the derived bridge port, chrome-devtools-axi automatically selects a free distinct bridge port. Override it with an environment variable:
 
 ```sh
 export CHROME_DEVTOOLS_AXI_PORT=9225
 ```
 
-An explicit bridge port must differ from the configured browser/CDP port; a collision fails immediately without launching or replacing Chrome.
+An explicit bridge port must differ from a browser/CDP port on the same local loopback interface; a collision fails immediately without launching or replacing Chrome. A remote browser endpoint may use the same port number because it is a distinct network endpoint.
 
 Connect to an existing Chrome instance instead of launching one:
 
@@ -325,7 +325,7 @@ Each session name gets its own bridge process, port (auto-derived from the name,
 In the default `--isolated` and `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` launch modes each bridge also launches its own Chrome, so concurrent sessions share neither browser state nor each other's stale-ref tracking.
 Sessions that attach to the same external browser - multiple `CHROME_DEVTOOLS_AXI_AUTO_CONNECT=1` sessions on one running Chrome, or the same `CHROME_DEVTOOLS_AXI_BROWSER_URL`/`wsEndpoint` - drive that shared browser and are isolated only at the bridge level, where the per-session generation counter does not prevent cross-talk.
 A session only isolates the bridge - the connection mode and profile are unchanged; combine with `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` for a persistent per-session profile.
-The default (unset) session derives port 9224 and keeps the legacy state paths below; an attached browser already using 9224 causes only the bridge port to move automatically.
+The default (unset) session derives port 9224 and keeps the legacy state paths below; an attached local browser already using 9224 causes only the bridge port to move automatically.
 
 Do not export `CHROME_DEVTOOLS_AXI_PORT` globally when running concurrent sessions: it overrides the per-session derived port and forces every session onto the same port, so the second session fails to start - its bridge cannot bind the already-taken port, and the first session's bridge is rejected as a mismatch rather than silently shared.
 Rely on the per-session default ports instead, or set `CHROME_DEVTOOLS_AXI_PORT` only inline per command.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,8 @@ environment:
   CHROME_DEVTOOLS_AXI_CHROME_ARGS   Whitespace-separated Chrome flags forwarded to the browser
                                     (no shell-style quoting; flags with spaces are not supported)
                                     e.g. "--enable-gpu --ignore-gpu-blocklist"
-  CHROME_DEVTOOLS_AXI_PORT          Bridge server port (default: 9224)
+  CHROME_DEVTOOLS_AXI_PORT          Explicit bridge server port (default: 9224; when attaching to a
+                                    browser on the derived default, a free distinct port is selected)
   CHROME_DEVTOOLS_AXI_SESSION       Named session for concurrent isolation. Each session name gets
                                     its own bridge process, port (auto-derived from the name, or set
                                     CHROME_DEVTOOLS_AXI_PORT), and on-disk state, so multiple sessions

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ environment:
                                     (no shell-style quoting; flags with spaces are not supported)
                                     e.g. "--enable-gpu --ignore-gpu-blocklist"
   CHROME_DEVTOOLS_AXI_PORT          Explicit bridge server port (default: 9224; when attaching to a
-                                    local browser on the derived default, a free distinct port is selected)
+                                    browser on an occupied derived default, a free port is selected)
   CHROME_DEVTOOLS_AXI_SESSION       Named session for concurrent isolation. Each session name gets
                                     its own bridge process, port (auto-derived from the name, or set
                                     CHROME_DEVTOOLS_AXI_PORT), and on-disk state, so multiple sessions

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ environment:
                                     (no shell-style quoting; flags with spaces are not supported)
                                     e.g. "--enable-gpu --ignore-gpu-blocklist"
   CHROME_DEVTOOLS_AXI_PORT          Explicit bridge server port (default: 9224; when attaching to a
-                                    browser on the derived default, a free distinct port is selected)
+                                    local browser on the derived default, a free distinct port is selected)
   CHROME_DEVTOOLS_AXI_SESSION       Named session for concurrent isolation. Each session name gets
                                     its own bridge process, port (auto-derived from the name, or set
                                     CHROME_DEVTOOLS_AXI_PORT), and on-disk state, so multiple sessions

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { request } from "node:http";
+import { createServer as createNetServer } from "node:net";
 import { AxiError } from "axi-sdk-js";
 import {
   BRIDGE_PORT_IN_USE_EXIT_CODE,
@@ -12,6 +13,8 @@ import {
 } from "./bridge-script.js";
 import {
   resolveSessionName,
+  resolveBrowserPort,
+  resolveExplicitSessionPort,
   resolveSessionPidFile,
   resolveSessionPort,
 } from "./sessions.js";
@@ -54,6 +57,67 @@ export class CdpError extends AxiError {
     super(message, code, suggestions);
     this.name = "CdpError";
   }
+}
+
+type FreeBridgePortResolver = (excludedPort: number) => Promise<number>;
+
+function canBindBridgePort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createNetServer();
+    server.unref();
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close((error) => resolve(error === undefined));
+    });
+  });
+}
+
+async function findFreeBridgePort(excludedPort: number): Promise<number> {
+  const firstPort =
+    excludedPort >= 1024 && excludedPort < 65535 ? excludedPort + 1 : 1024;
+  const candidateCount = 65535 - 1024 + 1;
+
+  for (let offset = 0; offset < candidateCount; offset++) {
+    const candidate = 1024 + ((firstPort - 1024 + offset) % candidateCount);
+    if (candidate !== excludedPort && (await canBindBridgePort(candidate))) {
+      return candidate;
+    }
+  }
+  throw new CdpError(
+    `No free bridge port is available distinct from browser/CDP port ${excludedPort}`,
+    "BRIDGE_NOT_READY",
+  );
+}
+
+/** Resolve a bridge port that can never equal the configured browser endpoint. */
+export async function resolveBridgePort(
+  sessionName: string = resolveSessionName(),
+  findFreePort: FreeBridgePortResolver = findFreeBridgePort,
+): Promise<number> {
+  const preferredPort = resolveSessionPort(sessionName);
+  const browserPort = resolveBrowserPort();
+  if (browserPort === null || preferredPort !== browserPort) {
+    return preferredPort;
+  }
+
+  if (resolveExplicitSessionPort() !== null) {
+    throw new CdpError(
+      `CHROME_DEVTOOLS_AXI_PORT ${preferredPort} collides with the configured browser/CDP port; the bridge and browser ports must be distinct`,
+      "VALIDATION_ERROR",
+      [
+        "Choose a different CHROME_DEVTOOLS_AXI_PORT, or unset it to select a free bridge port automatically.",
+      ],
+    );
+  }
+
+  const resolvedPort = await findFreePort(browserPort);
+  if (resolvedPort === browserPort) {
+    throw new CdpError(
+      `Resolved bridge port ${resolvedPort} still collides with the configured browser/CDP port`,
+      "BRIDGE_NOT_READY",
+    );
+  }
+  return resolvedPort;
 }
 
 interface PidInfo {
@@ -377,7 +441,7 @@ export async function ensureBridge(
   ) => SpawnedBridge = spawnBridgeProcess,
 ): Promise<number> {
   const sessionName = resolveSessionName();
-  const port = resolveSessionPort(sessionName);
+  const port = await resolveBridgePort(sessionName);
   const pidFile = resolveSessionPidFile(sessionName);
 
   // Check existing bridge via PID file. Use a deep probe so a bridge whose

--- a/src/client.ts
+++ b/src/client.ts
@@ -64,6 +64,16 @@ export class CdpError extends AxiError {
 type FreeBridgePortResolver = (excludedPort: number) => Promise<number>;
 type BridgePortAvailabilityProbe = (port: number) => Promise<boolean>;
 
+function browserEndpointUsesBridgeInterface(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/, "");
+  return (
+    normalized === "0.0.0.0" ||
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    /^127(?:\.\d{1,3}){3}$/.test(normalized)
+  );
+}
+
 function canBindBridgePort(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const server = createNetServer();
@@ -101,19 +111,21 @@ export async function findFreeBridgePort(
 export async function resolveBridgePort(
   sessionName: string = resolveSessionName(),
   findFreePort: FreeBridgePortResolver = findFreeBridgePort,
-  canBindPort: BridgePortAvailabilityProbe = canBindBridgePort,
 ): Promise<number> {
   const preferredPort = resolveSessionPort(sessionName);
   const browserEndpoint = resolveBrowserEndpoint();
-  if (browserEndpoint === null || preferredPort !== browserEndpoint.port) {
+  if (
+    browserEndpoint === null ||
+    !browserEndpointUsesBridgeInterface(browserEndpoint.hostname) ||
+    preferredPort !== browserEndpoint.port
+  ) {
     return preferredPort;
   }
   const browserPort = browserEndpoint.port;
-  if (await canBindPort(preferredPort)) return preferredPort;
 
   if (resolveExplicitSessionPort() !== null) {
     throw new CdpError(
-      `CHROME_DEVTOOLS_AXI_PORT ${preferredPort} is unavailable on 127.0.0.1 while the configured browser/CDP endpoint uses the same port number`,
+      `CHROME_DEVTOOLS_AXI_PORT ${preferredPort} collides with the configured local browser/CDP endpoint`,
       "VALIDATION_ERROR",
       [
         "Choose a different CHROME_DEVTOOLS_AXI_PORT, or unset it to select a free bridge port automatically.",

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,8 @@ import {
   resolveBridgeScript,
 } from "./bridge-script.js";
 import {
+  DEFAULT_BASE_PORT,
+  LAST_DERIVED_SESSION_PORT,
   resolveSessionName,
   resolveBrowserEndpoint,
   resolveExplicitSessionPort,
@@ -73,19 +75,24 @@ function canBindBridgePort(port: number): Promise<boolean> {
   });
 }
 
-async function findFreeBridgePort(excludedPort: number): Promise<number> {
-  const firstPort =
-    excludedPort >= 1024 && excludedPort < 65535 ? excludedPort + 1 : 1024;
-  const candidateCount = 65535 - 1024 + 1;
+export async function findFreeBridgePort(
+  excludedPort: number,
+  canBindPort: BridgePortAvailabilityProbe = canBindBridgePort,
+): Promise<number> {
+  const candidateRanges: ReadonlyArray<readonly [number, number]> = [
+    [LAST_DERIVED_SESSION_PORT + 1, 65535],
+    [1024, DEFAULT_BASE_PORT - 1],
+  ];
 
-  for (let offset = 0; offset < candidateCount; offset++) {
-    const candidate = 1024 + ((firstPort - 1024 + offset) % candidateCount);
-    if (candidate !== excludedPort && (await canBindBridgePort(candidate))) {
-      return candidate;
+  for (const [firstPort, lastPort] of candidateRanges) {
+    for (let candidate = firstPort; candidate <= lastPort; candidate++) {
+      if (candidate !== excludedPort && (await canBindPort(candidate))) {
+        return candidate;
+      }
     }
   }
   throw new CdpError(
-    `No free bridge port is available distinct from browser/CDP port ${excludedPort}`,
+    `No free unreserved bridge port is available distinct from browser/CDP port ${excludedPort}`,
     "BRIDGE_NOT_READY",
   );
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -111,17 +111,18 @@ export async function findFreeBridgePort(
 export async function resolveBridgePort(
   sessionName: string = resolveSessionName(),
   findFreePort: FreeBridgePortResolver = findFreeBridgePort,
+  canBindPort: BridgePortAvailabilityProbe = canBindBridgePort,
 ): Promise<number> {
   const preferredPort = resolveSessionPort(sessionName);
   const browserEndpoint = resolveBrowserEndpoint();
-  if (
-    browserEndpoint === null ||
-    !browserEndpointUsesBridgeInterface(browserEndpoint.hostname) ||
-    preferredPort !== browserEndpoint.port
-  ) {
+  if (browserEndpoint === null || preferredPort !== browserEndpoint.port) {
     return preferredPort;
   }
   const browserPort = browserEndpoint.port;
+  const collidesLocally =
+    browserEndpointUsesBridgeInterface(browserEndpoint.hostname) ||
+    !(await canBindPort(preferredPort));
+  if (!collidesLocally) return preferredPort;
 
   if (resolveExplicitSessionPort() !== null) {
     throw new CdpError(

--- a/src/client.ts
+++ b/src/client.ts
@@ -60,16 +60,7 @@ export class CdpError extends AxiError {
 }
 
 type FreeBridgePortResolver = (excludedPort: number) => Promise<number>;
-
-function browserEndpointUsesBridgeInterface(hostname: string): boolean {
-  const normalized = hostname.toLowerCase().replace(/\.$/, "");
-  return (
-    normalized === "127.0.0.1" ||
-    normalized === "0.0.0.0" ||
-    normalized === "localhost" ||
-    normalized.endsWith(".localhost")
-  );
-}
+type BridgePortAvailabilityProbe = (port: number) => Promise<boolean>;
 
 function canBindBridgePort(port: number): Promise<boolean> {
   return new Promise((resolve) => {
@@ -99,25 +90,23 @@ async function findFreeBridgePort(excludedPort: number): Promise<number> {
   );
 }
 
-/** Resolve a bridge port that can never equal the configured browser endpoint. */
+/** Resolve the effective local bridge port. */
 export async function resolveBridgePort(
   sessionName: string = resolveSessionName(),
   findFreePort: FreeBridgePortResolver = findFreeBridgePort,
+  canBindPort: BridgePortAvailabilityProbe = canBindBridgePort,
 ): Promise<number> {
   const preferredPort = resolveSessionPort(sessionName);
   const browserEndpoint = resolveBrowserEndpoint();
-  if (
-    browserEndpoint === null ||
-    !browserEndpointUsesBridgeInterface(browserEndpoint.hostname) ||
-    preferredPort !== browserEndpoint.port
-  ) {
+  if (browserEndpoint === null || preferredPort !== browserEndpoint.port) {
     return preferredPort;
   }
   const browserPort = browserEndpoint.port;
+  if (await canBindPort(preferredPort)) return preferredPort;
 
   if (resolveExplicitSessionPort() !== null) {
     throw new CdpError(
-      `CHROME_DEVTOOLS_AXI_PORT ${preferredPort} collides with the configured browser/CDP port; the bridge and browser ports must be distinct`,
+      `CHROME_DEVTOOLS_AXI_PORT ${preferredPort} is unavailable on 127.0.0.1 while the configured browser/CDP endpoint uses the same port number`,
       "VALIDATION_ERROR",
       [
         "Choose a different CHROME_DEVTOOLS_AXI_PORT, or unset it to select a free bridge port automatically.",
@@ -456,7 +445,6 @@ export async function ensureBridge(
   ) => SpawnedBridge = spawnBridgeProcess,
 ): Promise<number> {
   const sessionName = resolveSessionName();
-  const port = await resolveBridgePort(sessionName);
   const pidFile = resolveSessionPidFile(sessionName);
 
   // Check existing bridge via PID file. Use a deep probe so a bridge whose
@@ -475,6 +463,8 @@ export async function ensureBridge(
       killProcessGroup: isBridgeProcess(pidInfo.pid),
     });
   }
+
+  const port = await resolveBridgePort(sessionName);
 
   // Start a new bridge
   const child = spawnBridge(port, sessionName);

--- a/src/client.ts
+++ b/src/client.ts
@@ -497,30 +497,33 @@ export async function ensureBridge(
   // attached CDP target has gone away gets recycled instead of returned.
   const pidInfo = readPidFile(pidFile);
   if (pidInfo && isProcessAlive(pidInfo.pid)) {
-    const explicitPort = resolveExplicitSessionPort();
-    const browserEndpoint = resolveBrowserEndpoint();
-    const browserCollision =
-      browserEndpoint !== null &&
-      browserEndpoint.port === pidInfo.port &&
-      (await browserEndpointUsesBridgeInterface(browserEndpoint.hostname));
-    const explicitPortChanged =
-      explicitPort !== null && explicitPort !== pidInfo.port;
-    if (browserCollision || explicitPortChanged) {
-      await terminateBridgeProcess(pidInfo.pid, {
-        killProcessGroup: isBridgeProcess(pidInfo.pid),
-      });
-    } else {
-      if (
-        await checkBridgeHealth(pidInfo.port, {
-          deep: true,
-          expectedSession: sessionName,
-        })
-      ) {
-        return pidInfo.port;
+    const recordedBridge = isBridgeProcess(pidInfo.pid);
+    if (recordedBridge) {
+      const explicitPort = resolveExplicitSessionPort();
+      const browserEndpoint = resolveBrowserEndpoint();
+      const browserCollision =
+        browserEndpoint !== null &&
+        browserEndpoint.port === pidInfo.port &&
+        (await browserEndpointUsesBridgeInterface(browserEndpoint.hostname));
+      const explicitPortChanged =
+        explicitPort !== null && explicitPort !== pidInfo.port;
+      if (browserCollision || explicitPortChanged) {
+        await terminateBridgeProcess(pidInfo.pid, {
+          killProcessGroup: true,
+        });
+      } else {
+        if (
+          await checkBridgeHealth(pidInfo.port, {
+            deep: true,
+            expectedSession: sessionName,
+          })
+        ) {
+          return pidInfo.port;
+        }
+        await terminateBridgeProcess(pidInfo.pid, {
+          killProcessGroup: true,
+        });
       }
-      await terminateBridgeProcess(pidInfo.pid, {
-        killProcessGroup: isBridgeProcess(pidInfo.pid),
-      });
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@
  */
 
 import { execFileSync, spawn } from "node:child_process";
+import { lookup } from "node:dns/promises";
 import { readFileSync, existsSync } from "node:fs";
 import { request } from "node:http";
 import { createServer as createNetServer } from "node:net";
@@ -64,14 +65,39 @@ export class CdpError extends AxiError {
 type FreeBridgePortResolver = (excludedPort: number) => Promise<number>;
 type BridgePortAvailabilityProbe = (port: number) => Promise<boolean>;
 
-function browserEndpointUsesBridgeInterface(hostname: string): boolean {
-  const normalized = hostname.toLowerCase().replace(/\.$/, "");
-  return (
+function isLoopbackAddress(address: string): boolean {
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, "");
+  if (/^127(?:\.\d{1,3}){3}$/.test(normalized)) return true;
+  if (normalized.startsWith("::ffff:")) {
+    return /^127(?:\.\d{1,3}){3}$/.test(normalized.slice("::ffff:".length));
+  }
+  return normalized === "::1" || normalized === "0:0:0:0:0:0:0:1";
+}
+
+async function browserEndpointUsesBridgeInterface(
+  hostname: string,
+): Promise<boolean> {
+  const normalized = hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
+  if (
     normalized === "0.0.0.0" ||
+    normalized === "::" ||
     normalized === "localhost" ||
     normalized.endsWith(".localhost") ||
-    /^127(?:\.\d{1,3}){3}$/.test(normalized)
-  );
+    isLoopbackAddress(normalized)
+  ) {
+    return true;
+  }
+  try {
+    const addresses = await lookup(normalized, { all: true });
+    return addresses.some(({ address }) => isLoopbackAddress(address));
+  } catch {
+    // An unresolved hostname cannot be proven remote; reserve its matching
+    // port rather than allowing a later local resolution to collide.
+    return true;
+  }
 }
 
 function canBindBridgePort(port: number): Promise<boolean> {
@@ -120,7 +146,7 @@ export async function resolveBridgePort(
   }
   const browserPort = browserEndpoint.port;
   const collidesLocally =
-    browserEndpointUsesBridgeInterface(browserEndpoint.hostname) ||
+    (await browserEndpointUsesBridgeInterface(browserEndpoint.hostname)) ||
     !(await canBindPort(preferredPort));
   if (!collidesLocally) return preferredPort;
 
@@ -471,17 +497,31 @@ export async function ensureBridge(
   // attached CDP target has gone away gets recycled instead of returned.
   const pidInfo = readPidFile(pidFile);
   if (pidInfo && isProcessAlive(pidInfo.pid)) {
-    if (
-      await checkBridgeHealth(pidInfo.port, {
-        deep: true,
-        expectedSession: sessionName,
-      })
-    ) {
-      return pidInfo.port;
+    const explicitPort = resolveExplicitSessionPort();
+    const browserEndpoint = resolveBrowserEndpoint();
+    const browserCollision =
+      browserEndpoint !== null &&
+      browserEndpoint.port === pidInfo.port &&
+      (await browserEndpointUsesBridgeInterface(browserEndpoint.hostname));
+    const explicitPortChanged =
+      explicitPort !== null && explicitPort !== pidInfo.port;
+    if (browserCollision || explicitPortChanged) {
+      await terminateBridgeProcess(pidInfo.pid, {
+        killProcessGroup: isBridgeProcess(pidInfo.pid),
+      });
+    } else {
+      if (
+        await checkBridgeHealth(pidInfo.port, {
+          deep: true,
+          expectedSession: sessionName,
+        })
+      ) {
+        return pidInfo.port;
+      }
+      await terminateBridgeProcess(pidInfo.pid, {
+        killProcessGroup: isBridgeProcess(pidInfo.pid),
+      });
     }
-    await terminateBridgeProcess(pidInfo.pid, {
-      killProcessGroup: isBridgeProcess(pidInfo.pid),
-    });
   }
 
   const port = await resolveBridgePort(sessionName);

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
 } from "./bridge-script.js";
 import {
   resolveSessionName,
-  resolveBrowserPort,
+  resolveBrowserEndpoint,
   resolveExplicitSessionPort,
   resolveSessionPidFile,
   resolveSessionPort,
@@ -61,6 +61,16 @@ export class CdpError extends AxiError {
 
 type FreeBridgePortResolver = (excludedPort: number) => Promise<number>;
 
+function browserEndpointUsesBridgeInterface(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/, "");
+  return (
+    normalized === "127.0.0.1" ||
+    normalized === "0.0.0.0" ||
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost")
+  );
+}
+
 function canBindBridgePort(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const server = createNetServer();
@@ -95,10 +105,15 @@ export async function resolveBridgePort(
   findFreePort: FreeBridgePortResolver = findFreeBridgePort,
 ): Promise<number> {
   const preferredPort = resolveSessionPort(sessionName);
-  const browserPort = resolveBrowserPort();
-  if (browserPort === null || preferredPort !== browserPort) {
+  const browserEndpoint = resolveBrowserEndpoint();
+  if (
+    browserEndpoint === null ||
+    !browserEndpointUsesBridgeInterface(browserEndpoint.hostname) ||
+    preferredPort !== browserEndpoint.port
+  ) {
     return preferredPort;
   }
+  const browserPort = browserEndpoint.port;
 
   if (resolveExplicitSessionPort() !== null) {
     throw new CdpError(

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -94,12 +94,32 @@ export function defaultPortForSession(name: string): number {
 export function resolveSessionPort(
   name: string = resolveSessionName(),
 ): number {
-  const explicit = process.env.CHROME_DEVTOOLS_AXI_PORT;
-  if (explicit) {
-    const parsed = Number.parseInt(explicit, 10);
-    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
-  }
+  const explicit = resolveExplicitSessionPort();
+  if (explicit !== null) return explicit;
   return defaultPortForSession(name);
+}
+
+/** Return a valid explicit bridge-port override, or null when it is unset. */
+export function resolveExplicitSessionPort(): number | null {
+  const explicit = process.env.CHROME_DEVTOOLS_AXI_PORT;
+  if (!explicit) return null;
+  const parsed = Number.parseInt(explicit, 10);
+  return !Number.isNaN(parsed) && parsed > 0 ? parsed : null;
+}
+
+/** Resolve the TCP port from the configured browser URL, when it is parseable. */
+export function resolveBrowserPort(): number | null {
+  const raw = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.port) return Number.parseInt(url.port, 10);
+    if (url.protocol === "http:" || url.protocol === "ws:") return 80;
+    if (url.protocol === "https:" || url.protocol === "wss:") return 443;
+  } catch {
+    // Leave malformed URLs to chrome-devtools-mcp's existing validation path.
+  }
+  return null;
 }
 
 /**

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -29,6 +29,8 @@ export const DEFAULT_SESSION_NAME = "default";
 export const DEFAULT_BASE_PORT = 9224;
 
 const SESSION_PORT_RANGE = 1000; // 9225..10224 reserved for named sessions
+export const LAST_DERIVED_SESSION_PORT =
+  DEFAULT_BASE_PORT + SESSION_PORT_RANGE;
 const STATE_DIR_NAME = ".chrome-devtools-axi";
 
 /**

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -107,15 +107,22 @@ export function resolveExplicitSessionPort(): number | null {
   return !Number.isNaN(parsed) && parsed > 0 ? parsed : null;
 }
 
-/** Resolve the TCP port from the configured browser URL, when it is parseable. */
-export function resolveBrowserPort(): number | null {
+export interface BrowserEndpoint {
+  hostname: string;
+  port: number;
+}
+
+/** Resolve the configured browser endpoint, when it is parseable. */
+export function resolveBrowserEndpoint(): BrowserEndpoint | null {
   const raw = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
   if (!raw) return null;
   try {
     const url = new URL(raw);
-    if (url.port) return Number.parseInt(url.port, 10);
-    if (url.protocol === "http:" || url.protocol === "ws:") return 80;
-    if (url.protocol === "https:" || url.protocol === "wss:") return 443;
+    let port: number | null = null;
+    if (url.port) port = Number.parseInt(url.port, 10);
+    else if (url.protocol === "http:" || url.protocol === "ws:") port = 80;
+    else if (url.protocol === "https:" || url.protocol === "wss:") port = 443;
+    if (port !== null) return { hostname: url.hostname, port };
   } catch {
     // Leave malformed URLs to chrome-devtools-mcp's existing validation path.
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -29,8 +29,7 @@ export const DEFAULT_SESSION_NAME = "default";
 export const DEFAULT_BASE_PORT = 9224;
 
 const SESSION_PORT_RANGE = 1000; // 9225..10224 reserved for named sessions
-export const LAST_DERIVED_SESSION_PORT =
-  DEFAULT_BASE_PORT + SESSION_PORT_RANGE;
+export const LAST_DERIVED_SESSION_PORT = DEFAULT_BASE_PORT + SESSION_PORT_RANGE;
 const STATE_DIR_NAME = ".chrome-devtools-axi";
 
 /**

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -516,7 +516,7 @@ describe("ensureBridge early-exit fast-fail", () => {
     });
     const oldBridge = spawn(
       process.execPath,
-      ["-e", "setTimeout(() => {}, 10000)"],
+      ["-e", "setTimeout(() => {}, 10000)", "chrome-devtools-axi-bridge"],
       {
         stdio: "ignore",
       },
@@ -554,6 +554,54 @@ describe("ensureBridge early-exit fast-fail", () => {
       await fakeBrowser.close();
       if (!oldBridge.killed) {
         oldBridge.kill("SIGTERM");
+      }
+    }
+  });
+
+  it("does not terminate an unrelated process after stale PID reuse", async () => {
+    const fakeBrowser = await startFakeBridgeServer({
+      shallow: "ok",
+      deep: "ok",
+      session: "reused-pid-worker",
+    });
+    const unrelated = spawn(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 10000)"],
+      { stdio: "ignore" },
+    );
+    const unrelatedPid = unrelated.pid as number;
+    const stateDir = join(
+      tmpHome,
+      ".chrome-devtools-axi",
+      "sessions",
+      "reused-pid-worker",
+    );
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, "bridge.pid"),
+      JSON.stringify({ pid: unrelatedPid, port: fakeBrowser.port }),
+    );
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = `http://127.0.0.1:${fakeBrowser.port}`;
+    process.env.CHROME_DEVTOOLS_AXI_PORT = String(fakeBrowser.port);
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "reused-pid-worker";
+    let spawned = false;
+
+    try {
+      await expect(
+        ensureBridge(() => {
+          spawned = true;
+          return new EventEmitter() as unknown as SpawnedBridge;
+        }),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: expect.stringContaining("collides"),
+      });
+      expect(spawned).toBe(false);
+      expect(() => process.kill(unrelatedPid, 0)).not.toThrow();
+    } finally {
+      await fakeBrowser.close();
+      if (!unrelated.killed) {
+        unrelated.kill("SIGTERM");
       }
     }
   });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -3,7 +3,13 @@ import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AxiError } from "axi-sdk-js";
@@ -161,6 +167,19 @@ describe("resolveBridgePort browser collision", () => {
 
   it("selects a distinct port when the local browser is temporarily down", async () => {
     process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9224";
+    let excludedPort: number | undefined;
+
+    const resolved = await resolveBridgePort("default", async (excluded) => {
+      excludedPort = excluded;
+      return 9237;
+    });
+
+    expect(excludedPort).toBe(9224);
+    expect(resolved).toBe(9237);
+  });
+
+  it("selects a distinct port for an IPv6 loopback browser endpoint", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://[::1]:9224";
     let excludedPort: number | undefined;
 
     const resolved = await resolveBridgePort("default", async (excluded) => {
@@ -459,6 +478,7 @@ describe("ensureBridge early-exit fast-fail", () => {
   const savedHome = process.env.HOME;
   const savedTimeout = process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS;
   const savedPort = process.env.CHROME_DEVTOOLS_AXI_PORT;
+  const savedBrowserUrl = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
   let tmpHome: string;
 
   const restore = (key: string, value: string | undefined) => {
@@ -473,6 +493,7 @@ describe("ensureBridge early-exit fast-fail", () => {
     process.env.HOME = tmpHome;
     process.env.CHROME_DEVTOOLS_AXI_SESSION = "early-exit-worker";
     delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+    delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     // A long deadline so the assertion proves the *early-exit* path returns
     // fast, not that it merely hit the timeout.
     process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "20000";
@@ -483,7 +504,58 @@ describe("ensureBridge early-exit fast-fail", () => {
     restore("HOME", savedHome);
     restore("CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS", savedTimeout);
     restore("CHROME_DEVTOOLS_AXI_PORT", savedPort);
+    restore("CHROME_DEVTOOLS_AXI_BROWSER_URL", savedBrowserUrl);
     rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("does not reuse a persisted bridge after its port becomes a local browser endpoint", async () => {
+    const fakeBrowser = await startFakeBridgeServer({
+      shallow: "ok",
+      deep: "ok",
+      session: "persisted-worker",
+    });
+    const oldBridge = spawn(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 10000)"],
+      {
+        stdio: "ignore",
+      },
+    );
+    const oldBridgePid = oldBridge.pid as number;
+    const stateDir = join(
+      tmpHome,
+      ".chrome-devtools-axi",
+      "sessions",
+      "persisted-worker",
+    );
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, "bridge.pid"),
+      JSON.stringify({ pid: oldBridgePid, port: fakeBrowser.port }),
+    );
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = `http://127.0.0.1:${fakeBrowser.port}`;
+    process.env.CHROME_DEVTOOLS_AXI_PORT = String(fakeBrowser.port);
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "persisted-worker";
+    let spawned = false;
+
+    try {
+      await expect(
+        ensureBridge(() => {
+          spawned = true;
+          return new EventEmitter() as unknown as SpawnedBridge;
+        }),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: expect.stringContaining("collides"),
+      });
+      expect(spawned).toBe(false);
+      expect(await waitForProcessExit(oldBridgePid, 1000)).toBe(true);
+    } finally {
+      await fakeBrowser.close();
+      if (!oldBridge.killed) {
+        oldBridge.kill("SIGTERM");
+      }
+    }
   });
 
   it("fails fast with a port-collision error when the bridge exits with the EADDRINUSE code", async () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -15,6 +15,7 @@ import {
   ensureBridge,
   getSessionSnapshotIfRunning,
   mapErrorMessage,
+  resolveBridgePort,
   resolveBridgeTimeoutMs,
   type SpawnedBridge,
   stopBridge,
@@ -121,6 +122,70 @@ describe("resolveBridgeTimeoutMs", () => {
     expect(resolveBridgeTimeoutMs()).toBe(30_000);
     process.env.CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS = "-100";
     expect(resolveBridgeTimeoutMs()).toBe(30_000);
+  });
+});
+
+describe("resolveBridgePort browser collision", () => {
+  const savedBrowserUrl = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+  const savedPort = process.env.CHROME_DEVTOOLS_AXI_PORT;
+
+  beforeEach(() => {
+    delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+    delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+  });
+
+  afterEach(() => {
+    if (savedBrowserUrl === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = savedBrowserUrl;
+    }
+    if (savedPort === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_PORT = savedPort;
+    }
+  });
+
+  it("selects a free distinct port when the default collides with the browser", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9224";
+    let excludedPort: number | undefined;
+
+    const resolved = await resolveBridgePort("default", async (excluded) => {
+      excludedPort = excluded;
+      return 9237;
+    });
+
+    expect(excludedPort).toBe(9224);
+    expect(resolved).toBe(9237);
+  });
+
+  it("fails before spawning when an explicit bridge port collides", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL =
+      "ws://127.0.0.1:9224/devtools/browser/test";
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "9224";
+    let spawned = false;
+
+    await expect(
+      ensureBridge(() => {
+        spawned = true;
+        return new EventEmitter() as unknown as SpawnedBridge;
+      }),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("collides"),
+    });
+    expect(spawned).toBe(false);
+  });
+
+  it("preserves a non-colliding explicit bridge port", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9224";
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "9225";
+    const findFree = async (): Promise<number> => {
+      throw new Error("unexpected free-port lookup");
+    };
+
+    await expect(resolveBridgePort("default", findFree)).resolves.toBe(9225);
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -128,10 +128,12 @@ describe("resolveBridgeTimeoutMs", () => {
 describe("resolveBridgePort browser collision", () => {
   const savedBrowserUrl = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
   const savedPort = process.env.CHROME_DEVTOOLS_AXI_PORT;
+  const savedSession = process.env.CHROME_DEVTOOLS_AXI_SESSION;
 
   beforeEach(() => {
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
     delete process.env.CHROME_DEVTOOLS_AXI_PORT;
+    delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
   });
 
   afterEach(() => {
@@ -145,37 +147,54 @@ describe("resolveBridgePort browser collision", () => {
     } else {
       process.env.CHROME_DEVTOOLS_AXI_PORT = savedPort;
     }
+    if (savedSession === undefined) {
+      delete process.env.CHROME_DEVTOOLS_AXI_SESSION;
+    } else {
+      process.env.CHROME_DEVTOOLS_AXI_SESSION = savedSession;
+    }
   });
 
   it("selects a free distinct port when the default collides with the browser", async () => {
     process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9224";
     let excludedPort: number | undefined;
 
-    const resolved = await resolveBridgePort("default", async (excluded) => {
-      excludedPort = excluded;
-      return 9237;
-    });
+    const resolved = await resolveBridgePort(
+      "default",
+      async (excluded) => {
+        excludedPort = excluded;
+        return 9237;
+      },
+      async () => false,
+    );
 
     expect(excludedPort).toBe(9224);
     expect(resolved).toBe(9237);
   });
 
   it("fails before spawning when an explicit bridge port collides", async () => {
-    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL =
-      "ws://127.0.0.1:9224/devtools/browser/test";
-    process.env.CHROME_DEVTOOLS_AXI_PORT = "9224";
-    let spawned = false;
-
-    await expect(
-      ensureBridge(() => {
-        spawned = true;
-        return new EventEmitter() as unknown as SpawnedBridge;
-      }),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("collides"),
+    const blocker = await startFakeBridgeServer({
+      shallow: "error",
+      deep: "error",
     });
-    expect(spawned).toBe(false);
+    try {
+      process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = `ws://chrome.test:${blocker.port}/devtools/browser/test`;
+      process.env.CHROME_DEVTOOLS_AXI_PORT = String(blocker.port);
+      process.env.CHROME_DEVTOOLS_AXI_SESSION = `collision-${process.pid}`;
+      let spawned = false;
+
+      await expect(
+        ensureBridge(() => {
+          spawned = true;
+          return new EventEmitter() as unknown as SpawnedBridge;
+        }),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: expect.stringContaining("unavailable"),
+      });
+      expect(spawned).toBe(false);
+    } finally {
+      await blocker.close();
+    }
   });
 
   it("preserves a non-colliding explicit bridge port", async () => {
@@ -195,7 +214,9 @@ describe("resolveBridgePort browser collision", () => {
       throw new Error("unexpected free-port lookup");
     };
 
-    await expect(resolveBridgePort("default", findFree)).resolves.toBe(9224);
+    await expect(
+      resolveBridgePort("default", findFree, async () => true),
+    ).resolves.toBe(9224);
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -187,6 +187,16 @@ describe("resolveBridgePort browser collision", () => {
 
     await expect(resolveBridgePort("default", findFree)).resolves.toBe(9225);
   });
+
+  it("allows a remote browser endpoint to use the same port number", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://192.0.2.10:9224";
+    process.env.CHROME_DEVTOOLS_AXI_PORT = "9224";
+    const findFree = async (): Promise<number> => {
+      throw new Error("unexpected free-port lookup");
+    };
+
+    await expect(resolveBridgePort("default", findFree)).resolves.toBe(9224);
+  });
 });
 
 interface FakeBridgeOptions {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -189,8 +189,7 @@ describe("resolveBridgePort browser collision", () => {
     const availablePort = reservation.port;
     await reservation.close();
 
-    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL =
-      `ws://localhost:${availablePort}/devtools/browser/test`;
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = `ws://localhost:${availablePort}/devtools/browser/test`;
     process.env.CHROME_DEVTOOLS_AXI_PORT = String(availablePort);
     const findFree = async (): Promise<number> => {
       throw new Error("unexpected free-port lookup");
@@ -200,6 +199,32 @@ describe("resolveBridgePort browser collision", () => {
       code: "VALIDATION_ERROR",
       message: expect.stringContaining("collides"),
     });
+  });
+
+  it("fails before spawning when a local hostname alias owns the port", async () => {
+    const blocker = await startFakeBridgeServer({
+      shallow: "error",
+      deep: "error",
+    });
+    try {
+      process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = `ws://chrome.test:${blocker.port}/devtools/browser/test`;
+      process.env.CHROME_DEVTOOLS_AXI_PORT = String(blocker.port);
+      process.env.CHROME_DEVTOOLS_AXI_SESSION = `collision-${process.pid}`;
+      let spawned = false;
+
+      await expect(
+        ensureBridge(() => {
+          spawned = true;
+          return new EventEmitter() as unknown as SpawnedBridge;
+        }),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: expect.stringContaining("collides"),
+      });
+      expect(spawned).toBe(false);
+    } finally {
+      await blocker.close();
+    }
   });
 
   it("preserves a non-colliding explicit bridge port", async () => {
@@ -219,7 +244,9 @@ describe("resolveBridgePort browser collision", () => {
       throw new Error("unexpected free-port lookup");
     };
 
-    await expect(resolveBridgePort("default", findFree)).resolves.toBe(9224);
+    await expect(
+      resolveBridgePort("default", findFree, async () => true),
+    ).resolves.toBe(9224);
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -13,6 +13,7 @@ import {
   CdpError,
   checkBridgeHealth,
   ensureBridge,
+  findFreeBridgePort,
   getSessionSnapshotIfRunning,
   mapErrorMessage,
   resolveBridgePort,
@@ -22,6 +23,10 @@ import {
   terminateBridgeProcess,
   waitForProcessExit,
 } from "../src/client.js";
+import {
+  DEFAULT_BASE_PORT,
+  LAST_DERIVED_SESSION_PORT,
+} from "../src/sessions.js";
 
 describe("CdpError", () => {
   it("uses the shared axi-sdk-js error contract", () => {
@@ -169,6 +174,15 @@ describe("resolveBridgePort browser collision", () => {
 
     expect(excludedPort).toBe(9224);
     expect(resolved).toBe(9237);
+  });
+
+  it("allocates fallback ports outside the derived session range", async () => {
+    const resolved = await findFreeBridgePort(
+      DEFAULT_BASE_PORT,
+      async () => true,
+    );
+
+    expect(resolved).toBe(LAST_DERIVED_SESSION_PORT + 1);
   });
 
   it("fails before spawning when an explicit bridge port collides", async () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -159,18 +159,14 @@ describe("resolveBridgePort browser collision", () => {
     }
   });
 
-  it("selects a free distinct port when the default collides with the browser", async () => {
+  it("selects a distinct port when the local browser is temporarily down", async () => {
     process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9224";
     let excludedPort: number | undefined;
 
-    const resolved = await resolveBridgePort(
-      "default",
-      async (excluded) => {
-        excludedPort = excluded;
-        return 9237;
-      },
-      async () => false,
-    );
+    const resolved = await resolveBridgePort("default", async (excluded) => {
+      excludedPort = excluded;
+      return 9237;
+    });
 
     expect(excludedPort).toBe(9224);
     expect(resolved).toBe(9237);
@@ -185,30 +181,25 @@ describe("resolveBridgePort browser collision", () => {
     expect(resolved).toBe(LAST_DERIVED_SESSION_PORT + 1);
   });
 
-  it("fails before spawning when an explicit bridge port collides", async () => {
-    const blocker = await startFakeBridgeServer({
+  it("rejects an explicit local collision even without a listener", async () => {
+    const reservation = await startFakeBridgeServer({
       shallow: "error",
       deep: "error",
     });
-    try {
-      process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = `ws://chrome.test:${blocker.port}/devtools/browser/test`;
-      process.env.CHROME_DEVTOOLS_AXI_PORT = String(blocker.port);
-      process.env.CHROME_DEVTOOLS_AXI_SESSION = `collision-${process.pid}`;
-      let spawned = false;
+    const availablePort = reservation.port;
+    await reservation.close();
 
-      await expect(
-        ensureBridge(() => {
-          spawned = true;
-          return new EventEmitter() as unknown as SpawnedBridge;
-        }),
-      ).rejects.toMatchObject({
-        code: "VALIDATION_ERROR",
-        message: expect.stringContaining("unavailable"),
-      });
-      expect(spawned).toBe(false);
-    } finally {
-      await blocker.close();
-    }
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL =
+      `ws://localhost:${availablePort}/devtools/browser/test`;
+    process.env.CHROME_DEVTOOLS_AXI_PORT = String(availablePort);
+    const findFree = async (): Promise<number> => {
+      throw new Error("unexpected free-port lookup");
+    };
+
+    await expect(resolveBridgePort("default", findFree)).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("collides"),
+    });
   });
 
   it("preserves a non-colliding explicit bridge port", async () => {
@@ -228,9 +219,7 @@ describe("resolveBridgePort browser collision", () => {
       throw new Error("unexpected free-port lookup");
     };
 
-    await expect(
-      resolveBridgePort("default", findFree, async () => true),
-    ).resolves.toBe(9224);
+    await expect(resolveBridgePort("default", findFree)).resolves.toBe(9224);
   });
 });
 


### PR DESCRIPTION
Closes #116

## Summary

- keep browser/CDP and local AXI bridge listeners on distinct ports
- auto-select a free unreserved bridge port for implicit local collisions
- reject explicit local collisions before spawning the bridge
- preserve the resolved port through bridge state, health, calls, reuse, and stop
- preserve non-colliding remote endpoint and Chrome/profile behavior

## Verification

- `./node_modules/.bin/vitest run test/client.test.ts test/sessions.test.ts` (58 passed)
- `./node_modules/.bin/tsc`
- `./node_modules/.bin/prettier --check README.md src/cli.ts src/client.ts src/sessions.ts test/client.test.ts`
- `git diff --check`

## Smoke

The existing CDP endpoint responded on `127.0.0.1:9224`. The permitted named-session snapshot selected bridge port `9928`, proving port separation, then stopped at downstream MCP deep health with `BRIDGE_NOT_READY`; its isolated bridge was stopped and verified exited. During the subsequently cancelled publication gate, its test worker independently made one default-session attempt, selected bridge port `10225`, and hit the same deep-health blocker before its isolated bridge exited. The test worker was stopped, no further browser commands ran, and Chrome remained untouched.
