### PR TITLE
fix(cli): reject unknown command flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ session is active or the no-session status/help block when one is not.
 
 ### Flags
 
+`--help`, `-v`, `-V`, and `--version` are top-level options. All other flags
+are command-specific; the CLI rejects a flag that is not listed by
+`chrome-devtools-axi <command> --help`.
+
 | Flag                        | Description                                 |
 | --------------------------- | ------------------------------------------- |
 | `--help`                    | Show usage information                      |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1714,12 +1714,17 @@ function validateCommandFlags(
   command: string,
   args: string[],
   allowedFlags: readonly string[],
+  valueFlags: readonly string[],
   positionalArgsBeforeText = args.length,
 ): void {
   let positionalArgs = 0;
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
     if (positionalArgs === positionalArgsBeforeText) return;
-    if (arg === "--help" || allowedFlags.includes(arg)) continue;
+    if (arg === "--help" || allowedFlags.includes(arg)) {
+      if (valueFlags.includes(arg)) i += 1;
+      continue;
+    }
     if (arg !== "-" && arg.startsWith("-")) {
       throw new CdpError(
         `Unknown flag ${arg} for \`${command}\``,
@@ -1814,6 +1819,17 @@ const COMMAND_FLAGS: Record<string, readonly string[]> = {
   setup: [],
 };
 
+const COMMAND_VALUE_FLAGS: Partial<Record<string, readonly string[]>> = {
+  screenshot: ["--uid", "--format"],
+  emulate: COMMAND_FLAGS.emulate,
+  console: COMMAND_FLAGS.console,
+  network: COMMAND_FLAGS.network,
+  "network-get": COMMAND_FLAGS["network-get"],
+  lighthouse: COMMAND_FLAGS.lighthouse,
+  "perf-start": ["--file"],
+  "perf-stop": COMMAND_FLAGS["perf-stop"],
+};
+
 const COMMAND_POSITIONAL_TEXT_START: Partial<Record<string, number>> = {
   fill: 1,
   type: 0,
@@ -1830,6 +1846,7 @@ const COMMANDS: Record<string, CommandFn> = Object.fromEntries(
         command,
         args,
         COMMAND_FLAGS[command] ?? [],
+        COMMAND_VALUE_FLAGS[command] ?? [],
         COMMAND_POSITIONAL_TEXT_START[command],
       );
       return handler(args);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1715,6 +1715,7 @@ function validateCommandFlags(
   args: string[],
   allowedFlags: readonly string[],
   valueFlags: readonly string[],
+  dashPositionalSlots: readonly number[],
   positionalArgsBeforeText = args.length,
 ): void {
   let positionalArgs = 0;
@@ -1725,7 +1726,11 @@ function validateCommandFlags(
       if (valueFlags.includes(arg)) i += 1;
       continue;
     }
-    if (arg !== "-" && arg.startsWith("-")) {
+    if (
+      arg !== "-" &&
+      arg.startsWith("-") &&
+      (arg.startsWith("--") || !dashPositionalSlots.includes(positionalArgs))
+    ) {
       throw new CdpError(
         `Unknown flag ${arg} for \`${command}\``,
         "VALIDATION_ERROR",
@@ -1838,6 +1843,14 @@ const COMMAND_POSITIONAL_TEXT_START: Partial<Record<string, number>> = {
   dialog: 1,
 };
 
+const COMMAND_DASH_POSITIONAL_SLOTS: Partial<
+  Record<string, readonly number[]>
+> = {
+  heap: [0],
+  upload: [1],
+  screenshot: [0],
+};
+
 const COMMANDS: Record<string, CommandFn> = Object.fromEntries(
   Object.entries(COMMAND_HANDLERS).map(([command, handler]) => [
     command,
@@ -1847,6 +1860,7 @@ const COMMANDS: Record<string, CommandFn> = Object.fromEntries(
         args,
         COMMAND_FLAGS[command] ?? [],
         COMMAND_VALUE_FLAGS[command] ?? [],
+        COMMAND_DASH_POSITIONAL_SLOTS[command] ?? [],
         COMMAND_POSITIONAL_TEXT_START[command],
       );
       return handler(args);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1720,7 +1720,10 @@ function validateCommandFlags(
     .slice(0, positionalTextStart)
     .find(
       (arg) =>
-        arg.startsWith("--") && arg !== "--help" && !allowedFlags.includes(arg),
+        arg !== "-" &&
+        arg.startsWith("-") &&
+        arg !== "--help" &&
+        !allowedFlags.includes(arg),
     );
   if (unknownFlag) {
     throw new CdpError(
@@ -1817,7 +1820,9 @@ const COMMAND_FLAGS: Record<string, readonly string[]> = {
 const COMMAND_POSITIONAL_TEXT_START: Partial<Record<string, number>> = {
   fill: 1,
   type: 0,
+  wait: 0,
   eval: 0,
+  dialog: 1,
 };
 
 const COMMANDS: Record<string, CommandFn> = Object.fromEntries(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1714,11 +1714,14 @@ function validateCommandFlags(
   command: string,
   args: string[],
   allowedFlags: readonly string[],
+  positionalTextStart = args.length,
 ): void {
-  const unknownFlag = args.find(
-    (arg) =>
-      arg.startsWith("--") && arg !== "--help" && !allowedFlags.includes(arg),
-  );
+  const unknownFlag = args
+    .slice(0, positionalTextStart)
+    .find(
+      (arg) =>
+        arg.startsWith("--") && arg !== "--help" && !allowedFlags.includes(arg),
+    );
   if (unknownFlag) {
     throw new CdpError(
       `Unknown flag ${unknownFlag} for \`${command}\``,
@@ -1811,11 +1814,22 @@ const COMMAND_FLAGS: Record<string, readonly string[]> = {
   setup: [],
 };
 
+const COMMAND_POSITIONAL_TEXT_START: Partial<Record<string, number>> = {
+  fill: 1,
+  type: 0,
+  eval: 0,
+};
+
 const COMMANDS: Record<string, CommandFn> = Object.fromEntries(
   Object.entries(COMMAND_HANDLERS).map(([command, handler]) => [
     command,
     (args: string[]) => {
-      validateCommandFlags(command, args, COMMAND_FLAGS[command] ?? []);
+      validateCommandFlags(
+        command,
+        args,
+        COMMAND_FLAGS[command] ?? [],
+        COMMAND_POSITIONAL_TEXT_START[command],
+      );
       return handler(args);
     },
   ]),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1714,23 +1714,20 @@ function validateCommandFlags(
   command: string,
   args: string[],
   allowedFlags: readonly string[],
-  positionalTextStart = args.length,
+  positionalArgsBeforeText = args.length,
 ): void {
-  const unknownFlag = args
-    .slice(0, positionalTextStart)
-    .find(
-      (arg) =>
-        arg !== "-" &&
-        arg.startsWith("-") &&
-        arg !== "--help" &&
-        !allowedFlags.includes(arg),
-    );
-  if (unknownFlag) {
-    throw new CdpError(
-      `Unknown flag ${unknownFlag} for \`${command}\``,
-      "VALIDATION_ERROR",
-      [`Run \`chrome-devtools-axi ${command} --help\` to see valid flags`],
-    );
+  let positionalArgs = 0;
+  for (const arg of args) {
+    if (positionalArgs === positionalArgsBeforeText) return;
+    if (arg === "--help" || allowedFlags.includes(arg)) continue;
+    if (arg !== "-" && arg.startsWith("-")) {
+      throw new CdpError(
+        `Unknown flag ${arg} for \`${command}\``,
+        "VALIDATION_ERROR",
+        [`Run \`chrome-devtools-axi ${command} --help\` to see valid flags`],
+      );
+    }
+    positionalArgs += 1;
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1710,7 +1710,25 @@ function withoutFullFlag(
   return (args) => handler(splitFullFlag(args).args);
 }
 
-const COMMANDS: Record<string, CommandFn> = {
+function validateCommandFlags(
+  command: string,
+  args: string[],
+  allowedFlags: readonly string[],
+): void {
+  const unknownFlag = args.find(
+    (arg) =>
+      arg.startsWith("--") && arg !== "--help" && !allowedFlags.includes(arg),
+  );
+  if (unknownFlag) {
+    throw new CdpError(
+      `Unknown flag ${unknownFlag} for \`${command}\``,
+      "VALIDATION_ERROR",
+      [`Run \`chrome-devtools-axi ${command} --help\` to see valid flags`],
+    );
+  }
+}
+
+const COMMAND_HANDLERS: Record<string, CommandFn> = {
   open: withFullFlag(handleOpen),
   snapshot: async (args) => handleSnapshot(splitFullFlag(args).full),
   screenshot: withoutFullFlag(handleScreenshot),
@@ -1747,6 +1765,61 @@ const COMMANDS: Record<string, CommandFn> = {
   stop: async () => handleStop(),
   setup: withoutFullFlag(handleSetup),
 };
+
+const COMMAND_FLAGS: Record<string, readonly string[]> = {
+  open: ["--full"],
+  screenshot: ["--uid", "--full-page", "--format"],
+  snapshot: ["--full"],
+  click: ["--full"],
+  fill: ["--full"],
+  type: ["--full"],
+  press: ["--full"],
+  scroll: ["--full"],
+  back: ["--full"],
+  wait: [],
+  eval: ["--full"],
+  run: [],
+  hover: ["--full"],
+  drag: ["--full"],
+  fillform: ["--full"],
+  dialog: [],
+  upload: ["--full"],
+  pages: [],
+  newpage: ["--background", "--full"],
+  selectpage: ["--full"],
+  closepage: [],
+  resize: [],
+  emulate: [
+    "--viewport",
+    "--color-scheme",
+    "--network",
+    "--cpu",
+    "--geolocation",
+    "--user-agent",
+  ],
+  console: ["--type", "--limit", "--page"],
+  "console-get": [],
+  network: ["--type", "--limit", "--page"],
+  "network-get": ["--response-file", "--request-file"],
+  lighthouse: ["--device", "--mode", "--output-dir"],
+  "perf-start": ["--no-reload", "--no-auto-stop", "--file"],
+  "perf-stop": ["--file"],
+  "perf-insight": [],
+  heap: [],
+  start: [],
+  stop: [],
+  setup: [],
+};
+
+const COMMANDS: Record<string, CommandFn> = Object.fromEntries(
+  Object.entries(COMMAND_HANDLERS).map(([command, handler]) => [
+    command,
+    (args: string[]) => {
+      validateCommandFlags(command, args, COMMAND_FLAGS[command] ?? []);
+      return handler(args);
+    },
+  ]),
+);
 
 export async function main(
   options: MainOptions | string[] = {},

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -195,7 +195,10 @@ describe("main", () => {
 
       await main(argv);
 
-      expect(callTool).toHaveBeenCalledWith(tool, expect.objectContaining(args));
+      expect(callTool).toHaveBeenCalledWith(
+        tool,
+        expect.objectContaining(args),
+      );
       expect(process.exitCode).toBeUndefined();
     },
   );

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -107,18 +107,30 @@ describe("main", () => {
     expect(process.exitCode).toBe(2);
   });
 
-  it.each(["--zzzz", "-zzzz"])(
-    "rejects unknown command flag %s before calling MCP",
-    async (flag) => {
+  it.each([
+    {
+      argv: ["pages", "--zzzz", "nonsense"],
+      command: "pages",
+      flag: "--zzzz",
+    },
+    {
+      argv: ["pages", "-zzzz", "nonsense"],
+      command: "pages",
+      flag: "-zzzz",
+    },
+    { argv: ["heap", "--zzzz"], command: "heap", flag: "--zzzz" },
+  ])(
+    "rejects unknown command flag $flag for $command before calling MCP",
+    async ({ argv, command, flag }) => {
       const write = vi
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
 
-      await main(["pages", flag, "nonsense"]);
+      await main(argv);
 
       expect(callTool).not.toHaveBeenCalled();
       expect(String(write.mock.calls[0]?.[0])).toContain(
-        `Unknown flag ${flag} for \`pages\``,
+        `Unknown flag ${flag} for \`${command}\``,
       );
       expect(process.exitCode).toBe(2);
     },
@@ -155,6 +167,35 @@ describe("main", () => {
       await main(argv);
 
       expect(callTool.mock.calls[0]?.[0]).toBe(tool);
+      expect(process.exitCode).toBeUndefined();
+    },
+  );
+
+  it.each([
+    {
+      argv: ["heap", "-capture.heapsnapshot"],
+      tool: "take_memory_snapshot",
+      args: { filePath: resolve(process.cwd(), "-capture.heapsnapshot") },
+    },
+    {
+      argv: ["upload", "@1", "-file"],
+      tool: "upload_file",
+      args: { uid: "1", filePath: "-file" },
+    },
+    {
+      argv: ["screenshot", "-shot.png"],
+      tool: "take_screenshot",
+      args: { filePath: resolve(process.cwd(), "-shot.png") },
+    },
+  ])(
+    "passes dash-prefixed positional paths to $tool",
+    async ({ argv, tool, args }) => {
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      callTool.mockResolvedValue("");
+
+      await main(argv);
+
+      expect(callTool).toHaveBeenCalledWith(tool, expect.objectContaining(args));
       expect(process.exitCode).toBeUndefined();
     },
   );

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -174,6 +174,22 @@ describe("main", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it.each([
+    {
+      argv: ["emulate", "--user-agent", "--automation-test"],
+      tool: "emulate",
+      args: { userAgent: "--automation-test" },
+    },
+  ])("passes dash-prefixed values to $tool", async ({ argv, tool, args }) => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    callTool.mockResolvedValueOnce("");
+
+    await main(argv);
+
+    expect(callTool).toHaveBeenCalledWith(tool, args);
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("recovers open by creating a page when the browser is not yet connected", async () => {
     const write = vi
       .spyOn(process.stdout, "write")

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -107,24 +107,29 @@ describe("main", () => {
     expect(process.exitCode).toBe(2);
   });
 
-  it("rejects unknown command flags before calling MCP", async () => {
-    const write = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(() => true);
+  it.each(["--zzzz", "-zzzz"])(
+    "rejects unknown command flag %s before calling MCP",
+    async (flag) => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
 
-    await main(["pages", "--zzzz", "nonsense"]);
+      await main(["pages", flag, "nonsense"]);
 
-    expect(callTool).not.toHaveBeenCalled();
-    expect(String(write.mock.calls[0]?.[0])).toContain(
-      "Unknown flag --zzzz for `pages`",
-    );
-    expect(process.exitCode).toBe(2);
-  });
+      expect(callTool).not.toHaveBeenCalled();
+      expect(String(write.mock.calls[0]?.[0])).toContain(
+        `Unknown flag ${flag} for \`pages\``,
+      );
+      expect(process.exitCode).toBe(2);
+    },
+  );
 
   it.each([
     { argv: ["fill", "@1", "--literal"], tool: "fill" },
     { argv: ["type", "--literal"], tool: "type_text" },
+    { argv: ["wait", "--ready"], tool: "wait_for" },
     { argv: ["eval", "--counter"], tool: "evaluate_script" },
+    { argv: ["dialog", "accept", "--ready"], tool: "handle_dialog" },
   ])(
     "keeps positional text beginning with -- for $tool",
     async ({ argv, tool }) => {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -124,6 +124,20 @@ describe("main", () => {
     },
   );
 
+  it("rejects an unknown flag after fill's allowed --full flag", async () => {
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await main(["fill", "--full", "--zzzz", "value"]);
+
+    expect(callTool).not.toHaveBeenCalled();
+    expect(String(write.mock.calls[0]?.[0])).toContain(
+      "Unknown flag --zzzz for `fill`",
+    );
+    expect(process.exitCode).toBe(2);
+  });
+
   it.each([
     { argv: ["fill", "@1", "--literal"], tool: "fill" },
     { argv: ["type", "--literal"], tool: "type_text" },

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -107,6 +107,35 @@ describe("main", () => {
     expect(process.exitCode).toBe(2);
   });
 
+  it("rejects unknown command flags before calling MCP", async () => {
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await main(["pages", "--zzzz", "nonsense"]);
+
+    expect(callTool).not.toHaveBeenCalled();
+    expect(String(write.mock.calls[0]?.[0])).toContain(
+      "Unknown flag --zzzz for `pages`",
+    );
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("keeps command-specific flags available", async () => {
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    callTool.mockResolvedValueOnce("");
+
+    await main(["screenshot", "./shot.png", "--full-page"]);
+
+    expect(callTool).toHaveBeenCalledWith("take_screenshot", {
+      filePath: resolve(process.cwd(), "./shot.png"),
+      fullPage: true,
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("recovers open by creating a page when the browser is not yet connected", async () => {
     const write = vi
       .spyOn(process.stdout, "write")

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -121,6 +121,25 @@ describe("main", () => {
     expect(process.exitCode).toBe(2);
   });
 
+  it.each([
+    { argv: ["fill", "@1", "--literal"], tool: "fill" },
+    { argv: ["type", "--literal"], tool: "type_text" },
+    { argv: ["eval", "--counter"], tool: "evaluate_script" },
+  ])(
+    "keeps positional text beginning with -- for $tool",
+    async ({ argv, tool }) => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+      callTool.mockResolvedValue("");
+
+      await main(argv);
+
+      expect(callTool.mock.calls[0]?.[0]).toBe(tool);
+      expect(process.exitCode).toBeUndefined();
+    },
+  );
+
   it("keeps command-specific flags available", async () => {
     const write = vi
       .spyOn(process.stdout, "write")


### PR DESCRIPTION
## What Changed

- Validate each command against its documented flags and reject unknown options before invoking MCP.
- Preserve valid dash-prefixed positional text, paths, and option values during validation.
- Document command-specific flag handling and add coverage for valid and rejected inputs.

## Risk Assessment

✅ Low: The shared validation change is bounded, preserves the authorized dash-prefixed value and path cases, and rejects unknown flags before handler/MCP dispatch on the reviewed paths.

## Testing

The focused executable cases confirm unknown flags stop before MCP while dash-prefixed path/value inputs reach their intended MCP calls; a direct CLI run shows `heap --zzzz` returns the actionable validation error and exit code 2. This text-only CLI change has no rendered UI surface; the saved CLI transcript is the reviewer-visible evidence. The initial test command ran the single target test file more broadly than intended because of pnpm argument forwarding, then the exact targeted selector was rerun; no worktree artifacts remain.

<details>
<summary>Evidence: CLI rejects an unknown double-dash flag</summary>

```text
error: Unknown flag --zzzz for `heap`
code: VALIDATION_ERROR
help[1]: Run `chrome-devtools-axi heap --help` to see valid flags
(node:78881) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
exit_code=2
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2dd22f2d021c1f56ebe921ec7b2f6986bacbf3de","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `src/cli.ts:1723` - The validator treats a value that starts with `-` as another flag. For example, `emulate --user-agent --automation-test` accepts `--user-agent` at line 1722 but rejects its documented `&lt;string&gt;` value at line 1723 before `parseEmulateArgs` can consume it; the same regression affects path-valued options such as `--file` and `--output-dir`. Model flag arity and skip each allowed flag’s value during validation, preserving pre-change option-value behavior while still rejecting actual unknown flags.

🔧 Fix: Accept dash-prefixed command flag values
1 warning still open:

- ⚠️ `src/cli.ts:1728` - Dash-prefixed positional paths are now rejected before their handlers. For example, `heap -capture.heapsnapshot` reaches this branch and errors, although `handleHeap` accepts its first argument as a documented `&lt;path&gt;` (the same applies to `upload @uid -file` and `screenshot -shot.png`). Preserving these paths while still treating unknown `-name` tokens as flags needs an explicit CLI grammar choice, such as supporting a `--` option terminator or requiring `./-name`; decide and apply it at this shared validator boundary.

🔧 Fix: Preserve dash-prefixed positional paths
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm test test/main.test.ts -- -t &#39;…&#39;` (option forwarding ran the full `test/main.test.ts`, not the repository suite)</code>
- `pnpm exec vitest run test/main.test.ts -t 'rejects unknown command flag|rejects an unknown flag after fill|keeps positional text beginning|passes dash-prefixed positional paths|keeps command-specific flags available|passes dash-prefixed values'`
- <code>`pnpm exec tsx bin/chrome-devtools-axi.ts heap --zzzz` (CLI transcript saved as evidence)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

 