### PR TITLE
feat: add extension inspection and target discovery for agent validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ Connection modes are env-driven (`buildTransportArgs`): `AUTO_CONNECT` (Chrome 1
 The launch modes (`--isolated`/`--userDataDir`) pass `KEYCHAIN_ISOLATION_CHROME_ARGS` so browsers we start cannot reach the machine owner's password store; attach modes deliberately omit them because that browser's keychain policy belongs to whoever started it.
 `test/keychain-isolation.test.ts` owns the regression rationale and structural invariant; README.md documents the user-facing behavior.
 
+Extension lifecycle commands (`src/extensions.ts`) are explicitly gated by `CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1`. That mode enables the official MCP Extensions category only for a pipe-launched `--isolated` browser and records the bridge mode, so extension work cannot reuse or mutate a remote or operator-selected profile; README.md documents the workflow and pipe-only limitation.
+
 Named sessions (`CHROME_DEVTOOLS_AXI_SESSION`, `src/sessions.ts`) give each name its own bridge - its own port (explicit `CHROME_DEVTOOLS_AXI_PORT`, else a deterministic FNV-1a hash of the name) and its own state dir under `~/.chrome-devtools-axi/sessions/<name>/` (PID file + generation counter) - so concurrent sessions don't share a bridge or each other's stale-ref tracking.
 The default (unset) session keeps port 9224 and the legacy `~/.chrome-devtools-axi/` paths, so existing behavior is unchanged.
 `resolveSessionName` validates the name (rejecting path-traversal/unsafe and all-dot names) and is the single chokepoint every entry point resolves through; a session isolates only the bridge, so the connection mode and profile compose unchanged.

--- a/README.md
+++ b/README.md
@@ -200,8 +200,15 @@ export CHROME_DEVTOOLS_AXI_SESSION=extension-test
 chrome-devtools-axi extension-install /absolute/path/to/unpacked-extension
 chrome-devtools-axi extensions
 # Copy the exact 32-character id (not the display name) from the list:
+chrome-devtools-axi extension-inspect <id>
+chrome-devtools-axi extension-targets
 chrome-devtools-axi extension-reload <id>
 chrome-devtools-axi extension-action <id>
+# Verify with ordinary page commands:
+chrome-devtools-axi pages
+chrome-devtools-axi selectpage <service-worker-id>
+chrome-devtools-axi eval "console.log('Service worker alive')"
+# Cleanup:
 chrome-devtools-axi extension-uninstall <id>
 chrome-devtools-axi stop
 ```
@@ -211,8 +218,14 @@ Commands are forwarded to the official MCP tools
 `trigger_extension_action`, and `uninstall_extension`. Install accepts only an
 existing absolute unpacked-extension directory. List reports each extension's
 id, name, version, and enabled state; all mutating commands require an exact
-Chrome extension id and never perform ambiguous name matching. Each response
-shows the operation, selected AXI session, isolated profile, and pipe transport.
+Chrome extension id and never perform ambiguous name matching.
+
+Extension inspection commands:
+- `extension-inspect <id>` - Show extension metadata (name, version, enabled state)
+- `extension-targets` - List all extension-related targets (service workers and extension pages)
+  that can be debugged with the ordinary `pages`, `selectpage`, and `eval` commands
+
+Each response shows the operation, selected AXI session, isolated profile, and pipe transport.
 
 Do not set `CHROME_DEVTOOLS_AXI_BROWSER_URL`, `CHROME_DEVTOOLS_AXI_AUTO_CONNECT`,
 or `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` in extension mode. AXI rejects those

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ id, name, version, and enabled state; all mutating commands require an exact
 Chrome extension id and never perform ambiguous name matching.
 
 Extension inspection commands:
+
 - `extension-inspect <id>` - Show extension metadata (name, version, enabled state)
 - `extension-targets` - List all extension-related targets (service workers and extension pages)
   that can be debugged with the ordinary `pages`, `selectpage`, and `eval` commands

--- a/README.md
+++ b/README.md
@@ -183,6 +183,52 @@ chrome-devtools-axi eval "() => { const rows = [...document.querySelectorAll('tr
 | `closepage <id>`  | Close a tab by ID           |
 | `resize <w> <h>`  | Resize the browser viewport |
 
+### Chrome extension lifecycle
+
+Extension automation is an explicit opt-in and is isolated from ordinary browser
+sessions. The upstream `chrome-devtools-mcp` Extensions category is currently
+**pipe-only**; it does not support `AUTO_CONNECT`, `BROWSER_URL`/`wsEndpoint`, or
+a caller-supplied profile. Set `CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1` and use a
+dedicated session. AXI then starts chrome-devtools-mcp with
+`--categoryExtensions=true --isolated`, so the browser uses a temporary profile
+owned by that session and is cleaned up by `stop`.
+
+```sh
+export CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1
+export CHROME_DEVTOOLS_AXI_SESSION=extension-test
+
+chrome-devtools-axi extension-install /absolute/path/to/unpacked-extension
+chrome-devtools-axi extensions
+# Copy the exact 32-character id (not the display name) from the list:
+chrome-devtools-axi extension-reload <id>
+chrome-devtools-axi extension-action <id>
+chrome-devtools-axi extension-uninstall <id>
+chrome-devtools-axi stop
+```
+
+Commands are forwarded to the official MCP tools
+`install_extension`, `list_extensions`, `reload_extension`,
+`trigger_extension_action`, and `uninstall_extension`. Install accepts only an
+existing absolute unpacked-extension directory. List reports each extension's
+id, name, version, and enabled state; all mutating commands require an exact
+Chrome extension id and never perform ambiguous name matching. Each response
+shows the operation, selected AXI session, isolated profile, and pipe transport.
+
+Do not set `CHROME_DEVTOOLS_AXI_BROWSER_URL`, `CHROME_DEVTOOLS_AXI_AUTO_CONNECT`,
+or `CHROME_DEVTOOLS_AXI_USER_DATA_DIR` in extension mode. AXI rejects those
+combinations rather than attaching to or mutating an operator's normal Chrome
+profile. Keep extension testing in its own named session so its bridge and
+state cannot collide with an ordinary session. Existing sessions and all
+ordinary page commands remain unchanged when extension mode is unset. If a
+session already has a bridge in the other mode, stop that session explicitly
+before changing modes; AXI will not stop it implicitly.
+
+The extension mode is intended for an agent workflow: install a disposable
+unpacked build, list and record its exact id, trigger/reload it while testing,
+verify behavior with the ordinary page/snapshot commands in that same isolated
+session, then uninstall and stop the session. This feature does not add
+product-specific selectors or extension logic.
+
 ### Emulation
 
 | Command   | Description                     |

--- a/skills/chrome-devtools-axi/SKILL.md
+++ b/skills/chrome-devtools-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chrome-devtools-axi
-description: "Control a Chrome browser session through the chrome-devtools-axi CLI - navigate, snapshot, click, fill forms, run JavaScript, inspect console and network, take screenshots, audit performance. Use whenever a task needs a real browser: opening or testing a web page, clicking through a flow, extracting page content, or debugging a website."
+description: "Control a Chrome browser session through the chrome-devtools-axi CLI - navigate, snapshot, click, fill forms, run JavaScript, inspect console and network, take screenshots, audit performance, or exercising a Chrome extension in an isolated session. Use whenever a task needs a real browser: opening or testing a web page, clicking through a flow, extracting page content, debugging a website, or exercising an extension lifecycle."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:

--- a/src/bridge-script.ts
+++ b/src/bridge-script.ts
@@ -39,3 +39,72 @@ export const BRIDGE_PORT_IN_USE_EXIT_CODE = 48;
  */
 export const PAGE_IDENTITY_CHANGED_ERROR =
   "The browser reconnected and every page id changed, so this call did not target the page you selected";
+
+/**
+ * Explicit launch mode for the chrome-devtools-mcp Extensions category.
+ * Extension tools are intentionally opt-in because the upstream category is
+ * pipe-only and must never attach to an operator's normal Chrome/profile.
+ */
+export const EXTENSION_MODE_ENV = "CHROME_DEVTOOLS_AXI_EXTENSION_MODE";
+export const EXTENSION_MODE = "extension" as const;
+export const STANDARD_MODE = "standard" as const;
+export type BridgeMode = typeof EXTENSION_MODE | typeof STANDARD_MODE;
+
+export function isExtensionModeEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env[EXTENSION_MODE_ENV] === "1";
+}
+
+export function resolveBridgeMode(
+  env: Record<string, string | undefined> = process.env,
+): BridgeMode {
+  return isExtensionModeEnabled(env) ? EXTENSION_MODE : STANDARD_MODE;
+}
+
+/**
+ * Return an actionable incompatibility when extension mode is combined with a
+ * browser/profile supplied by the operator. The upstream Extensions category
+ * supports only a pipe-launched browser, and --isolated is the security
+ * boundary that keeps extension tests away from a normal Chrome profile.
+ */
+export function extensionModeConflict(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  if (!isExtensionModeEnabled(env)) return null;
+  if (env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT === "1") {
+    return (
+      `${EXTENSION_MODE_ENV}=1 requires a pipe-launched Chrome with a temporary isolated profile; ` +
+      "unset CHROME_DEVTOOLS_AXI_AUTO_CONNECT. The upstream Extensions category does not support autoConnect."
+    );
+  }
+  if (env.CHROME_DEVTOOLS_AXI_BROWSER_URL) {
+    return (
+      `${EXTENSION_MODE_ENV}=1 requires a pipe-launched Chrome with a temporary isolated profile; ` +
+      "unset CHROME_DEVTOOLS_AXI_BROWSER_URL. The upstream Extensions category does not support browserUrl or wsEndpoint."
+    );
+  }
+  if (env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR) {
+    return (
+      `${EXTENSION_MODE_ENV}=1 requires a pipe-launched Chrome with a temporary isolated profile; ` +
+      "unset CHROME_DEVTOOLS_AXI_USER_DATA_DIR so extension operations cannot mutate a normal profile."
+    );
+  }
+  const extraChromeArgs = env.CHROME_DEVTOOLS_AXI_CHROME_ARGS?.trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  const profileOverride = extraChromeArgs?.find(
+    (arg) =>
+      arg === "--user-data-dir" ||
+      arg.startsWith("--user-data-dir=") ||
+      arg === "--profile-directory" ||
+      arg.startsWith("--profile-directory="),
+  );
+  if (profileOverride) {
+    return (
+      `${EXTENSION_MODE_ENV}=1 rejects ${profileOverride} because extension mode requires a pipe-launched Chrome with a temporary isolated profile; ` +
+      "remove profile-overriding CHROME_DEVTOOLS_AXI_CHROME_ARGS."
+    );
+  }
+  return null;
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -5,7 +5,7 @@
  * persistent MCP session. Exposes a simple HTTP API:
  *   POST /call  { name, args }  → { result }
  *   GET  /tools                 → [{ name, description }]
- *   GET  /health                → { status: "ok", session } or 503 { status: "error", error }
+ *   GET  /health                → { status: "ok", session, mode } or 503 { status: "error", error }
  *   GET  /health?deep=1         → also verifies the attached CDP target; 503 may include reason,
  *                                 200 adds pageIdentityChanged when the probe consumed
  *                                 chrome-devtools-mcp's one-shot reconnect marker *and*
@@ -38,7 +38,10 @@ import { pathToFileURL } from "node:url";
 import {
   BRIDGE_PORT_IN_USE_EXIT_CODE,
   PAGE_IDENTITY_CHANGED_ERROR,
+  extensionModeConflict,
+  resolveBridgeMode,
   resolveBridgeScript,
+  type BridgeMode,
 } from "./bridge-script.js";
 import { clearSelectedPageId } from "./selected-page.js";
 import {
@@ -52,6 +55,8 @@ import {
 export {
   BRIDGE_PORT_IN_USE_EXIT_CODE,
   PAGE_IDENTITY_CHANGED_ERROR,
+  extensionModeConflict,
+  resolveBridgeMode,
   resolveBridgeScript,
 };
 
@@ -150,7 +155,10 @@ export async function isBridgeTargetReachable(
 function writePidFile(port: number): void {
   const pidFile = resolveSessionPidFile();
   mkdirSync(dirname(pidFile), { recursive: true });
-  writeFileSync(pidFile, JSON.stringify({ pid: process.pid, port }));
+  writeFileSync(
+    pidFile,
+    JSON.stringify({ pid: process.pid, port, mode: resolveBridgeMode() }),
+  );
 }
 
 /**
@@ -497,6 +505,7 @@ export async function handleBridgeRequest(
   sessionName?: string,
   logForbidden?: (message: string) => void,
   onPageIdentityChanged?: () => boolean | void,
+  bridgeMode?: BridgeMode,
 ): Promise<void> {
   res.setHeader("Content-Type", "application/json");
 
@@ -549,7 +558,8 @@ export async function handleBridgeRequest(
       // bridge".
       writeJson(res, 200, {
         status: "ok",
-        session: sessionName,
+        ...(sessionName !== undefined ? { session: sessionName } : {}),
+        ...(bridgeMode !== undefined ? { mode: bridgeMode } : {}),
         ...(droppedSelection ? { pageIdentityChanged: true } : {}),
       });
       return;
@@ -584,6 +594,7 @@ export function createBridgeServer(
       sessionName,
       logBridgeMessage,
       clearSelectedPageId,
+      resolveBridgeMode(),
     );
   });
 }
@@ -654,8 +665,22 @@ export function buildTransportArgs(): string[] {
   const browserUrl = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
   const userDataDir = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
   const channel = process.env.CHROME_DEVTOOLS_AXI_CHANNEL?.trim();
+  const extensionMode = resolveBridgeMode() === "extension";
 
-  if (autoConnect) {
+  if (extensionMode) {
+    const conflict = extensionModeConflict();
+    if (conflict) throw new Error(conflict);
+    // The upstream Extensions category is pipe-only. Always launch a fresh,
+    // temporary profile here; never let an extension command reach an
+    // operator-owned browser or persistent profile.
+    args.push("--isolated", "--categoryExtensions=true");
+    if (process.env.CHROME_DEVTOOLS_AXI_HEADED !== "1") {
+      args.push("--headless");
+    }
+    for (const arg of KEYCHAIN_ISOLATION_CHROME_ARGS) {
+      args.push(`--chrome-arg=${arg}`);
+    }
+  } else if (autoConnect) {
     // Chrome 144+ built-in remote debugging via chrome://inspect/#remote-debugging.
     // Connects to the user's running Chrome - no separate browser launched.
     args.push("--autoConnect");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,13 @@ import { parsePagesList } from "./pages.js";
 import { overlaySessionSelected } from "./selected-page.js";
 import { resolveOutputPath } from "./paths.js";
 import { VERSION } from "./version.js";
+import {
+  handleExtensionAction,
+  handleExtensionInstall,
+  handleExtensionList,
+  handleExtensionReload,
+  handleExtensionUninstall,
+} from "./extensions.js";
 
 export { parsePagesList };
 
@@ -53,12 +60,14 @@ export type MainOptions = {
 };
 
 export const TOP_HELP = `usage: chrome-devtools-axi [command] [args] [flags]
-commands[35]:
+commands[40]:
   open <url>, snapshot, screenshot <path>, click @<uid>, fill @<uid> <text>,
   type <text>, press <key>, scroll <dir>, back, wait <ms|text>, eval <js>,
   run,
   hover @<uid>, drag @<from> @<to>, fillform @<uid>=<val>..., dialog <action>,
   upload @<uid> <path>, pages, newpage <url>, selectpage <id>, closepage <id>,
+  extension-install <absolute-path>, extensions, extension-reload <id>,
+  extension-action <id>, extension-uninstall <id>,
   resize <w> <h>, emulate, console, console-get <id>, network,
   network-get [id], lighthouse, perf-start, perf-stop,
   perf-insight <set> <name>, heap <path>, start, stop, setup hooks
@@ -75,6 +84,11 @@ environment:
                                     attaches to, and which one is launched in the default and
                                     USER_DATA_DIR modes. Ignored with CHROME_DEVTOOLS_AXI_BROWSER_URL.
   CHROME_DEVTOOLS_AXI_HEADED        Set to 1 to run Chrome in headed (visible) mode
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE
+                                    Set to 1 for extension lifecycle commands. This is an explicit,
+                                    pipe-only mode: launches a temporary isolated profile and enables
+                                    the upstream Extensions category. Incompatible with AUTO_CONNECT,
+                                    BROWSER_URL, and USER_DATA_DIR. Use a dedicated SESSION.
   CHROME_DEVTOOLS_AXI_CHROME_ARGS   Whitespace-separated Chrome flags forwarded to the browser
                                     (no shell-style quoting; flags with spaces are not supported)
                                     e.g. "--enable-gpu --ignore-gpu-blocklist"
@@ -111,6 +125,7 @@ gpu:
     CHROME_DEVTOOLS_AXI_CHROME_ARGS="--enable-gpu --ignore-gpu-blocklist --enable-unsafe-webgpu --enable-features=Vulkan"
 
 tips:
+  Extension commands require CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 and never accept names in place of ids.
   Pipe output through grep/head to extract specific data from large pages.
 `;
 
@@ -362,6 +377,74 @@ args:
 examples:
   chrome-devtools-axi closepage 2`,
 
+  "extension-install": `usage: chrome-devtools-axi extension-install <absolute-path>
+Install an unpacked Chrome extension in the isolated extension session.
+
+args:
+  <absolute-path>  Existing absolute path to the unpacked extension folder (required)
+
+requires:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1
+  Use a dedicated CHROME_DEVTOOLS_AXI_SESSION. This is pipe-only and always uses
+  a temporary isolated profile; browserUrl, autoConnect, and USER_DATA_DIR are rejected.
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 CHROME_DEVTOOLS_AXI_SESSION=extension-test \\
+    chrome-devtools-axi extension-install /tmp/my-extension`,
+
+  extensions: `usage: chrome-devtools-axi extensions
+List installed extensions in the isolated extension session.
+
+output:
+  Each extension includes its exact id, name, version, and enabled state.
+  Use the id for reload/action/uninstall; names are never matched.
+
+requires:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 CHROME_DEVTOOLS_AXI_SESSION=extension-test \\
+    chrome-devtools-axi extensions`,
+
+  "extension-reload": `usage: chrome-devtools-axi extension-reload <id>
+Reload one unpacked extension by its exact Chrome extension ID.
+
+args:
+  <id>  32 lowercase a-p extension ID from \`chrome-devtools-axi extensions\` (required)
+
+requires:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 and a pipe-launched isolated profile
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 chrome-devtools-axi extension-reload \\
+    abcdefghijklmnopabcdefghijklmnop`,
+
+  "extension-action": `usage: chrome-devtools-axi extension-action <id>
+Trigger one extension's default toolbar action by its exact ID.
+
+args:
+  <id>  32 lowercase a-p extension ID from \`chrome-devtools-axi extensions\` (required)
+
+requires:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 and a pipe-launched isolated profile
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 chrome-devtools-axi extension-action \\
+    abcdefghijklmnopabcdefghijklmnop`,
+
+  "extension-uninstall": `usage: chrome-devtools-axi extension-uninstall <id>
+Uninstall one extension by its exact Chrome extension ID.
+
+args:
+  <id>  32 lowercase a-p extension ID from \`chrome-devtools-axi extensions\` (required)
+
+requires:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 and a pipe-launched isolated profile
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 chrome-devtools-axi extension-uninstall \\
+    abcdefghijklmnopabcdefghijklmnop`,
+
   resize: `usage: chrome-devtools-axi resize <width> <height>
 Resize the browser viewport.
 
@@ -591,7 +674,13 @@ examples:
 };
 
 export function getCommandHelp(command: string): string | null {
-  return COMMAND_HELP[command] ?? null;
+  const canonical =
+    command === "extension-list"
+      ? "extensions"
+      : command === "extension-trigger-action"
+        ? "extension-action"
+        : command;
+  return COMMAND_HELP[canonical] ?? null;
 }
 
 export interface ScreenshotArgs {
@@ -1732,6 +1821,13 @@ const COMMANDS: Record<string, CommandFn> = {
   newpage: withFullFlag(handleNewPage),
   selectpage: withFullFlag(handleSelectPage),
   closepage: withoutFullFlag(handleClosePage),
+  "extension-install": withoutFullFlag(handleExtensionInstall),
+  extensions: withoutFullFlag(handleExtensionList),
+  "extension-list": withoutFullFlag(handleExtensionList),
+  "extension-reload": withoutFullFlag(handleExtensionReload),
+  "extension-action": withoutFullFlag(handleExtensionAction),
+  "extension-trigger-action": withoutFullFlag(handleExtensionAction),
+  "extension-uninstall": withoutFullFlag(handleExtensionUninstall),
   resize: withoutFullFlag(handleResize),
   emulate: withoutFullFlag(handleEmulate),
   console: withoutFullFlag(handleConsole),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,9 +33,11 @@ import { resolveOutputPath } from "./paths.js";
 import { VERSION } from "./version.js";
 import {
   handleExtensionAction,
+  handleExtensionInspect,
   handleExtensionInstall,
   handleExtensionList,
   handleExtensionReload,
+  handleExtensionTargets,
   handleExtensionUninstall,
 } from "./extensions.js";
 
@@ -60,14 +62,15 @@ export type MainOptions = {
 };
 
 export const TOP_HELP = `usage: chrome-devtools-axi [command] [args] [flags]
-commands[40]:
+commands[43]:
   open <url>, snapshot, screenshot <path>, click @<uid>, fill @<uid> <text>,
   type <text>, press <key>, scroll <dir>, back, wait <ms|text>, eval <js>,
   run,
   hover @<uid>, drag @<from> @<to>, fillform @<uid>=<val>..., dialog <action>,
   upload @<uid> <path>, pages, newpage <url>, selectpage <id>, closepage <id>,
-  extension-install <absolute-path>, extensions, extension-reload <id>,
-  extension-action <id>, extension-uninstall <id>,
+  extension-install <absolute-path>, extensions, extension-targets,
+  extension-inspect <id>, extension-reload <id>, extension-action <id>,
+  extension-uninstall <id>,
   resize <w> <h>, emulate, console, console-get <id>, network,
   network-get [id], lighthouse, perf-start, perf-stop,
   perf-insight <set> <name>, heap <path>, start, stop, setup hooks
@@ -443,6 +446,37 @@ requires:
 
 examples:
   CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 chrome-devtools-axi extension-uninstall \\
+    abcdefghijklmnopabcdefghijklmnop`,
+
+  "extension-targets": `usage: chrome-devtools-axi extension-targets
+List all extension-related targets (service workers and extension pages).
+
+output:
+  Shows all active extension service workers and extension pages in the
+  browser session. Service workers are the extension's background script;
+  extension pages are popup windows and options pages.
+
+requires:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 and an installed extension
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 chrome-devtools-axi extension-targets`,
+
+  "extension-inspect": `usage: chrome-devtools-axi extension-inspect <id>
+Show detailed metadata for one extension by its exact Chrome extension ID.
+
+args:
+  <id>  32 lowercase a-p extension ID from \`chrome-devtools-axi extensions\` (required)
+
+output:
+  Displays the extension's id, name, version, and enabled state.
+  Use this to validate extension installation after extension-install.
+
+requires:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 chrome-devtools-axi extension-inspect \\
     abcdefghijklmnopabcdefghijklmnop`,
 
   resize: `usage: chrome-devtools-axi resize <width> <height>
@@ -1824,6 +1858,8 @@ const COMMANDS: Record<string, CommandFn> = {
   "extension-install": withoutFullFlag(handleExtensionInstall),
   extensions: withoutFullFlag(handleExtensionList),
   "extension-list": withoutFullFlag(handleExtensionList),
+  "extension-targets": withoutFullFlag(handleExtensionTargets),
+  "extension-inspect": withoutFullFlag(handleExtensionInspect),
   "extension-reload": withoutFullFlag(handleExtensionReload),
   "extension-action": withoutFullFlag(handleExtensionAction),
   "extension-trigger-action": withoutFullFlag(handleExtensionAction),

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,8 +9,12 @@ import { dirname } from "node:path";
 import { AxiError } from "axi-sdk-js";
 import {
   BRIDGE_PORT_IN_USE_EXIT_CODE,
+  EXTENSION_MODE,
   PAGE_IDENTITY_CHANGED_ERROR,
+  STANDARD_MODE,
+  resolveBridgeMode,
   resolveBridgeScript,
+  type BridgeMode,
 } from "./bridge-script.js";
 import { needsPageId } from "./pages.js";
 import {
@@ -67,6 +71,7 @@ export class CdpError extends AxiError {
 interface PidInfo {
   pid: number;
   port: number;
+  mode?: BridgeMode;
 }
 
 function readPidFile(
@@ -76,7 +81,11 @@ function readPidFile(
     if (!existsSync(pidFile)) return null;
     const data = JSON.parse(readFileSync(pidFile, "utf-8"));
     if (typeof data.pid === "number" && typeof data.port === "number") {
-      return data as PidInfo;
+      const mode =
+        data.mode === EXTENSION_MODE || data.mode === STANDARD_MODE
+          ? data.mode
+          : undefined;
+      return { pid: data.pid, port: data.port, ...(mode ? { mode } : {}) };
     }
     return null;
   } catch {
@@ -169,6 +178,10 @@ function httpPost(
  * `CHROME_DEVTOOLS_AXI_PORT`). A bridge that omits the field (older version) is
  * accepted, since there is no mismatch to detect.
  *
+ * With `expectedMode`, a bridge that reports a different launch mode is
+ * treated as unhealthy. `ensureBridge` also checks the PID-file mode before
+ * touching a live process, so changing modes never stops a bridge implicitly.
+ *
  * With `notice`, a healthy *deep* probe writes the bridge's `pageIdentityChanged`
  * flag into that caller-owned holder (see {@link PageIdentityNotice}).
  *
@@ -179,6 +192,7 @@ export async function checkBridgeHealth(
   opts: {
     deep?: boolean;
     expectedSession?: string;
+    expectedMode?: BridgeMode;
     notice?: PageIdentityNotice;
   } = {},
 ): Promise<boolean> {
@@ -192,6 +206,13 @@ export async function checkBridgeHealth(
       opts.expectedSession !== undefined &&
       typeof data.session === "string" &&
       data.session !== opts.expectedSession
+    ) {
+      return false;
+    }
+    if (
+      opts.expectedMode !== undefined &&
+      typeof data.mode === "string" &&
+      data.mode !== opts.expectedMode
     ) {
       return false;
     }
@@ -358,6 +379,35 @@ function spawnBridgeProcess(port: number, sessionName: string): SpawnedBridge {
 }
 
 /**
+ * Build the error for an attempt to reuse a session bridge in the wrong launch
+ * mode. This is deliberately a non-destructive failure: changing from an
+ * ordinary or operator-selected profile to extension mode must not stop the
+ * existing bridge implicitly.
+ */
+export function buildBridgeModeMismatchError(
+  sessionName: string,
+  runningMode: BridgeMode,
+  requestedMode: BridgeMode,
+): CdpError {
+  const running =
+    runningMode === EXTENSION_MODE ? "isolated extension" : "ordinary browser";
+  const requested =
+    requestedMode === EXTENSION_MODE
+      ? "isolated extension"
+      : "ordinary browser";
+  return new CdpError(
+    `Session "${sessionName}" already has a ${running} bridge, but this command requires ${requested} mode`,
+    "BRIDGE_NOT_READY",
+    [
+      `Run \`CHROME_DEVTOOLS_AXI_SESSION=${sessionName} chrome-devtools-axi stop\` to stop that session explicitly, then retry with the desired mode.`,
+      requestedMode === EXTENSION_MODE
+        ? "For extension operations, set CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1; it enables the upstream Extensions category and launches a temporary isolated pipe browser."
+        : "Unset CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 when using the ordinary browser mode.",
+    ],
+  );
+}
+
+/**
  * Build the error thrown when a freshly spawned bridge exits before it ever
  * reports healthy. Surfacing this the moment the child dies - rather than
  * polling the full readiness deadline - turns an early death into a fast,
@@ -431,6 +481,7 @@ export async function ensureBridge(
   notice?: PageIdentityNotice,
 ): Promise<number> {
   const sessionName = resolveSessionName();
+  const requestedMode = resolveBridgeMode();
   const port = resolveSessionPort(sessionName);
   const pidFile = resolveSessionPidFile(sessionName);
 
@@ -438,10 +489,23 @@ export async function ensureBridge(
   // attached CDP target has gone away gets recycled instead of returned.
   const pidInfo = readPidFile(pidFile);
   if (pidInfo && isProcessAlive(pidInfo.pid)) {
+    // A missing mode is an old PID file and therefore means ordinary mode.
+    // Do not stop a live bridge just because the caller changed mode: the
+    // operator must explicitly stop it, which avoids touching a profile this
+    // invocation did not launch.
+    const runningMode = pidInfo.mode ?? STANDARD_MODE;
+    if (runningMode !== requestedMode) {
+      throw buildBridgeModeMismatchError(
+        sessionName,
+        runningMode,
+        requestedMode,
+      );
+    }
     if (
       await checkBridgeHealth(pidInfo.port, {
         deep: true,
         expectedSession: sessionName,
+        expectedMode: requestedMode,
         notice,
       })
     ) {
@@ -489,6 +553,7 @@ export async function ensureBridge(
       await checkBridgeHealth(port, {
         deep: true,
         expectedSession: sessionName,
+        expectedMode: requestedMode,
         notice,
       })
     ) {
@@ -499,6 +564,7 @@ export async function ensureBridge(
         await checkBridgeHealth(port, {
           deep: true,
           expectedSession: sessionName,
+          expectedMode: requestedMode,
           notice,
         })
       ) {
@@ -573,10 +639,10 @@ async function postTool(
  * Tool argument keys whose value is a caller-supplied output path, resolved to
  * an absolute path by `resolveOutputPath` before it reaches here. The nearest
  * existing ancestor of their parent directory (or of a directory argument
- * itself) is negotiated as an MCP workspace root, so the write is not restricted
- * to the OS temp directory and missing directories can be created beneath an
- * allowed root (issue #96). Add a key here when a new file-writing tool argument
- * is introduced.
+ * itself) is negotiated as an MCP workspace root, so writes are not restricted
+ * to the OS temp directory and local inputs such as an unpacked extension can
+ * be read outside cwd. Add a key here when a file/directory argument needs
+ * roots negotiation.
  */
 const FILE_OUTPUT_ARGS_BY_TOOL = new Map<string, readonly string[]>([
   ["take_screenshot", ["filePath"]],
@@ -587,6 +653,10 @@ const FILE_OUTPUT_ARGS_BY_TOOL = new Map<string, readonly string[]>([
 ]);
 const DIR_OUTPUT_ARGS_BY_TOOL = new Map<string, readonly string[]>([
   ["lighthouse_audit", ["outputDirPath"]],
+]);
+/** Local directory inputs also need a root so MCP can verify and read them. */
+const LOCAL_INPUT_DIR_ARGS_BY_TOOL = new Map<string, readonly string[]>([
+  ["install_extension", ["path"]],
 ]);
 
 function nearestExistingAncestor(path: string): string {
@@ -601,8 +671,9 @@ function nearestExistingAncestor(path: string): string {
 
 /**
  * The workspace roots a call needs: always the invoking cwd (so writes under it
- * pass), plus the nearest existing ancestor of any output path argument (so a
- * write outside cwd, e.g. `$HOME/a.png`, passes too).
+ * pass), plus the nearest existing ancestor of any output path or local input
+ * argument (so a path outside cwd, e.g. `$HOME/a.png` or an extension folder,
+ * passes too).
  */
 export function collectRootDirs(
   name: string,
@@ -616,6 +687,12 @@ export function collectRootDirs(
     }
   }
   for (const key of DIR_OUTPUT_ARGS_BY_TOOL.get(name) ?? []) {
+    const value = args[key];
+    if (typeof value === "string" && value.length > 0) {
+      dirs.add(nearestExistingAncestor(value));
+    }
+  }
+  for (const key of LOCAL_INPUT_DIR_ARGS_BY_TOOL.get(name) ?? []) {
     const value = args[key];
     if (typeof value === "string" && value.length > 0) {
       dirs.add(nearestExistingAncestor(value));

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -23,7 +23,9 @@ export type ExtensionOperation =
   | "list"
   | "reload"
   | "action"
-  | "uninstall";
+  | "uninstall"
+  | "targets"
+  | "inspect";
 
 export const EXTENSION_PROFILE_DESCRIPTION =
   "temporary isolated profile (owned by this session)";
@@ -266,4 +268,100 @@ export function handleExtensionUninstall(args: string[]): Promise<string> {
     "chrome-devtools-axi extension-uninstall <id>",
     "uninstall_extension",
   );
+}
+
+/**
+ * List all extension-related targets (service workers and extension pages).
+ * Uses list_pages to identify extension targets in the browser session.
+ */
+export async function handleExtensionTargets(args: string[]): Promise<string> {
+  assertExtensionMode();
+  assertNoExtraArgs(args, "chrome-devtools-axi extension-targets");
+  const result = await callTool("list_pages");
+
+  const metadata = encode({
+    extension: extensionMetadata("targets"),
+  });
+
+  // Parse the list_pages output for extension targets
+  const lines = result.split(/\r?\n/).map((l) => l.trim());
+  const targetLines: string[] = [];
+  let inExtensionSection = false;
+
+  for (const line of lines) {
+    if (line.match(/^##\s+(Extension Pages|Extension Service Workers)$/)) {
+      inExtensionSection = true;
+      continue;
+    }
+    if (line.match(/^##\s+/)) {
+      inExtensionSection = false;
+      continue;
+    }
+    if (inExtensionSection && line.length > 0) {
+      targetLines.push(line);
+    }
+  }
+
+  const content =
+    targetLines.length > 0
+      ? `targets:\n${targetLines.join("\n")}`
+      : "No extension targets found. Install an extension with extension-install first.";
+
+  return [metadata, content].join("\n");
+}
+
+/**
+ * Parse extension list to get detailed info about a specific extension.
+ */
+export async function handleExtensionInspect(args: string[]): Promise<string> {
+  assertExtensionMode();
+  if (args.length !== 1) {
+    throw new CdpError(
+      "Missing or unexpected extension ID",
+      "VALIDATION_ERROR",
+      [`Run \`chrome-devtools-axi extension-inspect <id>\``],
+    );
+  }
+  const id = validateExtensionId(args[0]);
+
+  // Get the extension list
+  const listResult = await callTool("list_extensions");
+  const extensions = parseExtensionList(listResult);
+
+  if (!extensions) {
+    throw new CdpError(
+      "Unable to parse extension list",
+      "BROWSER_ERROR",
+      [
+        "Run `chrome-devtools-axi extensions` to see the current extension list format",
+      ],
+    );
+  }
+
+  const extension = extensions.find((ext) => ext.id === id);
+  if (!extension) {
+    throw new CdpError(
+      `Extension ${id} not found`,
+      "VALIDATION_ERROR",
+      [
+        "Run `chrome-devtools-axi extensions` to list all extension IDs",
+        "Copy the exact 32-character id from the list",
+      ],
+    );
+  }
+
+  const metadata = encode({
+    extension: extensionMetadata("inspect", { id }),
+  });
+
+  const details = encode({
+    details: {
+      id: extension.id,
+      name: extension.name,
+      version: extension.version,
+      enabled: extension.enabled,
+    },
+  });
+
+  return [metadata, details].join("\n");
 }

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -329,25 +329,17 @@ export async function handleExtensionInspect(args: string[]): Promise<string> {
   const extensions = parseExtensionList(listResult);
 
   if (!extensions) {
-    throw new CdpError(
-      "Unable to parse extension list",
-      "BROWSER_ERROR",
-      [
-        "Run `chrome-devtools-axi extensions` to see the current extension list format",
-      ],
-    );
+    throw new CdpError("Unable to parse extension list", "BROWSER_ERROR", [
+      "Run `chrome-devtools-axi extensions` to see the current extension list format",
+    ]);
   }
 
   const extension = extensions.find((ext) => ext.id === id);
   if (!extension) {
-    throw new CdpError(
-      `Extension ${id} not found`,
-      "VALIDATION_ERROR",
-      [
-        "Run `chrome-devtools-axi extensions` to list all extension IDs",
-        "Copy the exact 32-character id from the list",
-      ],
-    );
+    throw new CdpError(`Extension ${id} not found`, "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi extensions` to list all extension IDs",
+      "Copy the exact 32-character id from the list",
+    ]);
   }
 
   const metadata = encode({

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,0 +1,269 @@
+/**
+ * AXI commands for the chrome-devtools-mcp Extensions category.
+ *
+ * These commands deliberately require CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1.
+ * That mode enables the upstream extension tools only for a pipe-launched
+ * Chrome with a temporary --isolated profile; remote browsers and persistent
+ * operator profiles are never silently modified.
+ */
+
+import { statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { encode } from "@toon-format/toon";
+import { CdpError, callTool } from "./client.js";
+import {
+  EXTENSION_MODE_ENV,
+  extensionModeConflict,
+  isExtensionModeEnabled,
+} from "./bridge-script.js";
+import { resolveSessionName } from "./sessions.js";
+
+export type ExtensionOperation =
+  | "install"
+  | "list"
+  | "reload"
+  | "action"
+  | "uninstall";
+
+export const EXTENSION_PROFILE_DESCRIPTION =
+  "temporary isolated profile (owned by this session)";
+
+const EXTENSION_ID_PATTERN = /^[a-p]{32}$/;
+
+export function isExtensionId(value: string): boolean {
+  return EXTENSION_ID_PATTERN.test(value);
+}
+
+export function validateExtensionId(value: string | undefined): string {
+  if (!value) {
+    throw new CdpError("Missing extension ID", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi extensions` to list extension IDs",
+    ]);
+  }
+  if (!isExtensionId(value)) {
+    throw new CdpError(
+      `Invalid extension ID: ${value}. Chrome extension IDs must be 32 lowercase letters from a-p.`,
+      "VALIDATION_ERROR",
+      [
+        "Run `chrome-devtools-axi extensions` and copy the complete id; extension names are not accepted",
+      ],
+    );
+  }
+  return value;
+}
+
+export function validateExtensionPath(value: string | undefined): string {
+  if (!value) {
+    throw new CdpError("Missing unpacked extension path", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi extension-install /absolute/path/to/extension`",
+    ]);
+  }
+  if (!isAbsolute(value)) {
+    throw new CdpError(
+      `Extension path must be absolute: ${value}`,
+      "VALIDATION_ERROR",
+      [
+        "Pass the unpacked extension folder as an absolute path; relative paths are rejected for safety",
+      ],
+    );
+  }
+
+  const path = resolve(value);
+  try {
+    if (!statSync(path).isDirectory()) {
+      throw new Error("not a directory");
+    }
+  } catch {
+    throw new CdpError(
+      `Unpacked extension folder does not exist or is not a directory: ${path}`,
+      "VALIDATION_ERROR",
+      [
+        "Provide an existing absolute folder containing the extension manifest.json",
+      ],
+    );
+  }
+  return path;
+}
+
+/**
+ * Check the explicit extension-mode safety gate before validating or invoking
+ * an upstream tool. This keeps a missing opt-in from starting an ordinary
+ * browser and gives remote-browser users the exact remediation.
+ */
+export function assertExtensionMode(): void {
+  if (!isExtensionModeEnabled()) {
+    throw new CdpError(
+      `Extension operations require ${EXTENSION_MODE_ENV}=1. This launches a temporary isolated pipe browser and enables the upstream Extensions category; the current browser/session is not modified.`,
+      "VALIDATION_ERROR",
+      [
+        `Set ${EXTENSION_MODE_ENV}=1 and use a dedicated CHROME_DEVTOOLS_AXI_SESSION, then retry`,
+        "Example: CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 CHROME_DEVTOOLS_AXI_SESSION=extension-test chrome-devtools-axi extensions",
+      ],
+    );
+  }
+
+  const conflict = extensionModeConflict();
+  if (conflict) {
+    throw new CdpError(conflict, "VALIDATION_ERROR", [
+      `Unset CHROME_DEVTOOLS_AXI_AUTO_CONNECT, CHROME_DEVTOOLS_AXI_BROWSER_URL, and CHROME_DEVTOOLS_AXI_USER_DATA_DIR for the isolated extension session`,
+      "Use CHROME_DEVTOOLS_AXI_SESSION=extension-test to keep extension state separate from an ordinary session",
+    ]);
+  }
+}
+
+function assertNoExtraArgs(args: string[], usage: string): void {
+  if (args.length > 0) {
+    throw new CdpError(`Unexpected argument: ${args[0]}`, "VALIDATION_ERROR", [
+      `Run \`${usage}\``,
+    ]);
+  }
+}
+
+function extensionMetadata(
+  operation: ExtensionOperation,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    operation,
+    session: resolveSessionName(),
+    profile: EXTENSION_PROFILE_DESCRIPTION,
+    transport: "pipe",
+    ...extra,
+  };
+}
+
+/**
+ * Parse the stable, human-readable list format emitted by the official MCP
+ * extension tool. Returning null for an unknown future format lets us retain
+ * the upstream text instead of guessing or matching by extension name.
+ */
+export function parseExtensionList(text: string): Array<{
+  id: string;
+  name: string;
+  version: string;
+  enabled: boolean;
+}> | null {
+  if (/No extensions installed\.?/i.test(text)) return [];
+
+  const rows = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("id="));
+  if (rows.length === 0) return null;
+
+  const parsed = [];
+  for (const row of rows) {
+    const match = row.match(
+      /^id=([a-p]{32})\s+"(.*)"\s+v([^\s]+)\s+(Enabled|Disabled)$/,
+    );
+    if (!match) return null;
+    parsed.push({
+      id: match[1],
+      name: match[2],
+      version: match[3],
+      enabled: match[4] === "Enabled",
+    });
+  }
+  return parsed;
+}
+
+function formatExtensionOutput(
+  operation: ExtensionOperation,
+  result: string,
+  extra: Record<string, unknown> = {},
+): string {
+  const metadata = encode({
+    extension: extensionMetadata(operation, extra),
+  });
+  const text = result.trimEnd();
+
+  if (operation === "list") {
+    const extensions = parseExtensionList(result);
+    if (extensions !== null) {
+      return encode({
+        extension: extensionMetadata(operation, { count: extensions.length }),
+        extensions,
+      });
+    }
+    return [metadata, `extensions:\n${text}`].join("\n");
+  }
+  return text.length > 0 ? [metadata, `result:\n${text}`].join("\n") : metadata;
+}
+
+function extractInstalledId(result: string): string | undefined {
+  const match = result.match(/\bId:\s*([a-p]{32})\b/i);
+  return match?.[1];
+}
+
+export async function handleExtensionInstall(args: string[]): Promise<string> {
+  assertExtensionMode();
+  if (args.length !== 1) {
+    throw new CdpError(
+      "Missing or unexpected unpacked extension path",
+      "VALIDATION_ERROR",
+      [
+        "Run `chrome-devtools-axi extension-install /absolute/path/to/extension`",
+      ],
+    );
+  }
+  const path = validateExtensionPath(args[0]);
+  const result = await callTool("install_extension", { path });
+  const id = extractInstalledId(result);
+  return formatExtensionOutput("install", result, {
+    path,
+    ...(id ? { id } : {}),
+  });
+}
+
+export async function handleExtensionList(args: string[]): Promise<string> {
+  assertExtensionMode();
+  assertNoExtraArgs(args, "chrome-devtools-axi extensions");
+  const result = await callTool("list_extensions");
+  return formatExtensionOutput("list", result);
+}
+
+async function handleExtensionIdOperation(
+  operation: Exclude<ExtensionOperation, "install" | "list">,
+  args: string[],
+  usage: string,
+  toolName: string,
+): Promise<string> {
+  assertExtensionMode();
+  if (args.length !== 1) {
+    throw new CdpError(
+      "Missing or unexpected extension ID",
+      "VALIDATION_ERROR",
+      [`Run \`${usage}\``],
+    );
+  }
+  const id = validateExtensionId(args[0]);
+  const result = await callTool(toolName, { id });
+  return formatExtensionOutput(operation, result, { id });
+}
+
+export function handleExtensionReload(args: string[]): Promise<string> {
+  return handleExtensionIdOperation(
+    "reload",
+    args,
+    "chrome-devtools-axi extension-reload <id>",
+    "reload_extension",
+  );
+}
+
+export function handleExtensionAction(args: string[]): Promise<string> {
+  return handleExtensionIdOperation(
+    "action",
+    args,
+    "chrome-devtools-axi extension-action <id>",
+    "trigger_extension_action",
+  );
+}
+
+export function handleExtensionUninstall(args: string[]): Promise<string> {
+  return handleExtensionIdOperation(
+    "uninstall",
+    args,
+    "chrome-devtools-axi extension-uninstall <id>",
+    "uninstall_extension",
+  );
+}

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -3,8 +3,9 @@
 export const SKILL_DESCRIPTION =
   "Control a Chrome browser session through the chrome-devtools-axi CLI - navigate, snapshot, " +
   "click, fill forms, run JavaScript, inspect console and network, take screenshots, audit " +
-  "performance. Use whenever a task needs a real browser: opening or testing a web page, " +
-  "clicking through a flow, extracting page content, or debugging a website.";
+  "performance, or exercising a Chrome extension in an isolated session. Use whenever a task needs " +
+  "a real browser: opening or testing a web page, clicking through a flow, extracting page content, " +
+  "debugging a website, or exercising an extension lifecycle.";
 
 function yamlDoubleQuote(value: string): string {
   return JSON.stringify(value);

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -170,6 +170,8 @@ describe("buildTransportArgs", () => {
       process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     savedEnv.CHROME_DEVTOOLS_AXI_CHANNEL =
       process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
+    savedEnv.CHROME_DEVTOOLS_AXI_EXTENSION_MODE =
+      process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE;
     delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
     delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
@@ -177,6 +179,7 @@ describe("buildTransportArgs", () => {
     delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     delete process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     delete process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
+    delete process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE;
   });
 
   afterEach(() => {
@@ -194,6 +197,34 @@ describe("buildTransportArgs", () => {
       savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     process.env.CHROME_DEVTOOLS_AXI_CHANNEL =
       savedEnv.CHROME_DEVTOOLS_AXI_CHANNEL;
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE =
+      savedEnv.CHROME_DEVTOOLS_AXI_EXTENSION_MODE;
+  });
+
+  it("enables the official Extensions category only in isolated pipe mode", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE = "1";
+
+    expect(buildTransportArgs()).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--isolated",
+      "--categoryExtensions=true",
+      "--headless",
+      "--chrome-arg=--use-mock-keychain",
+      "--chrome-arg=--password-store=basic",
+    ]);
+  });
+
+  it.each([
+    ["CHROME_DEVTOOLS_AXI_AUTO_CONNECT", "1"],
+    ["CHROME_DEVTOOLS_AXI_BROWSER_URL", "http://127.0.0.1:9222"],
+    ["CHROME_DEVTOOLS_AXI_USER_DATA_DIR", "/normal/profile"],
+    ["CHROME_DEVTOOLS_AXI_CHROME_ARGS", "--user-data-dir=/normal/profile"],
+  ])("rejects extension mode with %s", (key, value) => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE = "1";
+    process.env[key] = value;
+
+    expect(() => buildTransportArgs()).toThrow(/pipe-launched Chrome/);
   });
 
   it("defaults to headless and isolated", () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -442,6 +442,27 @@ describe("ensureBridge early-exit fast-fail", () => {
     expect(elapsed).toBeLessThan(5000);
   });
 
+  it("does not reuse a live ordinary bridge when extension mode is requested", async () => {
+    const savedExtensionMode = process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE;
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE = "1";
+    const pidFile = resolveSessionPidFile("early-exit-worker");
+    mkdirSync(dirname(pidFile), { recursive: true });
+    writeFileSync(pidFile, JSON.stringify({ pid: process.pid, port: 9224 }));
+
+    try {
+      await expect(
+        ensureBridge(() => {
+          throw new Error("must not spawn or stop the existing bridge");
+        }),
+      ).rejects.toMatchObject({
+        code: "BRIDGE_NOT_READY",
+        message: expect.stringContaining("ordinary browser bridge"),
+      });
+    } finally {
+      restore("CHROME_DEVTOOLS_AXI_EXTENSION_MODE", savedExtensionMode);
+    }
+  });
+
   it("reuses a healthy same-session bridge that won the bind race instead of failing on the loser's early exit", async () => {
     // A concurrent same-session bridge owns the port and reports healthy only on
     // the *second* deep probe, so the loser's first in-loop check fails and the
@@ -1448,6 +1469,11 @@ describe("collectRootDirs", () => {
           filePath: "/home/user/.ssh/id_rsa",
         }),
       ).toEqual([process.cwd()]);
+      expect(
+        collectRootDirs("install_extension", {
+          path: outputRoot,
+        }),
+      ).toEqual([process.cwd(), outputRoot]);
     } finally {
       rmSync(outputRoot, { recursive: true, force: true });
     }

--- a/test/extensions.test.ts
+++ b/test/extensions.test.ts
@@ -240,22 +240,18 @@ describe("extension lifecycle commands", () => {
       ].join("\n"),
     );
 
-    await expect(handleExtensionInspect([EXTENSION_ID])).rejects.toMatchObject(
-      {
-        code: "VALIDATION_ERROR",
-        message: expect.stringContaining("not found"),
-      },
-    );
+    await expect(handleExtensionInspect([EXTENSION_ID])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("not found"),
+    });
   });
 
   it("handles unparseable extension list on inspect", async () => {
     callTool.mockResolvedValueOnce("future format");
 
-    await expect(handleExtensionInspect([EXTENSION_ID])).rejects.toMatchObject(
-      {
-        code: "BROWSER_ERROR",
-        message: expect.stringContaining("Unable to parse"),
-      },
-    );
+    await expect(handleExtensionInspect([EXTENSION_ID])).rejects.toMatchObject({
+      code: "BROWSER_ERROR",
+      message: expect.stringContaining("Unable to parse"),
+    });
   });
 });

--- a/test/extensions.test.ts
+++ b/test/extensions.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AxiError } from "axi-sdk-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { callTool } = vi.hoisted(() => ({
+  callTool: vi.fn(),
+}));
+
+vi.mock("../src/client.js", () => ({
+  CdpError: class CdpError extends AxiError {
+    constructor(
+      message: string,
+      public readonly code: string,
+      public readonly suggestions: string[] = [],
+    ) {
+      super(message, code, suggestions);
+      this.name = "CdpError";
+    }
+  },
+  callTool,
+}));
+
+import {
+  assertExtensionMode,
+  handleExtensionAction,
+  handleExtensionInstall,
+  handleExtensionList,
+  handleExtensionReload,
+  handleExtensionUninstall,
+  parseExtensionList,
+  validateExtensionId,
+  validateExtensionPath,
+} from "../src/extensions.js";
+
+const EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop";
+
+const savedEnv: Record<string, string | undefined> = {};
+let extensionDir = "";
+
+function restoreEnv(key: string): void {
+  const value = savedEnv[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+describe("extension lifecycle commands", () => {
+  beforeEach(() => {
+    for (const key of [
+      "CHROME_DEVTOOLS_AXI_EXTENSION_MODE",
+      "CHROME_DEVTOOLS_AXI_AUTO_CONNECT",
+      "CHROME_DEVTOOLS_AXI_BROWSER_URL",
+      "CHROME_DEVTOOLS_AXI_USER_DATA_DIR",
+      "CHROME_DEVTOOLS_AXI_SESSION",
+    ]) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE = "1";
+    process.env.CHROME_DEVTOOLS_AXI_SESSION = "extension-contract";
+    delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
+    delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
+    delete process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
+    extensionDir = mkdtempSync(join(tmpdir(), "axi-extension-test-"));
+    callTool.mockReset();
+  });
+
+  afterEach(() => {
+    callTool.mockReset();
+    if (extensionDir) rmSync(extensionDir, { recursive: true, force: true });
+    for (const key of Object.keys(savedEnv)) restoreEnv(key);
+  });
+
+  it("forwards install to the official tool with an absolute path", async () => {
+    callTool.mockResolvedValueOnce(`Extension installed. Id: ${EXTENSION_ID}`);
+
+    const output = await handleExtensionInstall([extensionDir]);
+
+    expect(callTool).toHaveBeenCalledWith("install_extension", {
+      path: extensionDir,
+    });
+    expect(output).toContain("operation: install");
+    expect(output).toContain("session: extension-contract");
+    expect(output).toContain("temporary isolated profile");
+    expect(output).toContain(EXTENSION_ID);
+  });
+
+  it("forwards list and renders id, name, version, and enabled state", async () => {
+    callTool.mockResolvedValueOnce(
+      [
+        "## Extensions",
+        `id=${EXTENSION_ID} "Agent fixture" v1.2.3 Enabled`,
+        `id=ponmlkjihgfedcbaponmlkjihgfedcba "Disabled fixture" v2.0.0 Disabled`,
+      ].join("\n"),
+    );
+
+    const output = await handleExtensionList([]);
+
+    expect(callTool).toHaveBeenCalledWith("list_extensions");
+    expect(output).toContain(EXTENSION_ID);
+    expect(output).toContain("Agent fixture");
+    expect(output).toContain("1.2.3");
+    expect(output).toContain("true");
+    expect(output).toContain("false");
+    expect(output).toContain("count: 2");
+  });
+
+  it.each([
+    ["reload", handleExtensionReload, "reload_extension", "reload"],
+    ["action", handleExtensionAction, "trigger_extension_action", "action"],
+    ["uninstall", handleExtensionUninstall, "uninstall_extension", "uninstall"],
+  ] as const)(
+    "forwards %s by exact extension id",
+    async (_operation, handler, tool, operation) => {
+      callTool.mockResolvedValueOnce(`Extension ${operation}d.`);
+
+      const output = await handler([EXTENSION_ID]);
+
+      expect(callTool).toHaveBeenCalledWith(tool, { id: EXTENSION_ID });
+      expect(output).toContain(`operation: ${operation}`);
+      expect(output).toContain(EXTENSION_ID);
+    },
+  );
+
+  it("rejects lifecycle operations without explicit extension mode", async () => {
+    delete process.env.CHROME_DEVTOOLS_AXI_EXTENSION_MODE;
+
+    await expect(handleExtensionList([])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1"),
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("rejects remote-browser and persistent-profile combinations", async () => {
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+
+    await expect(handleExtensionList([])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("pipe-launched Chrome"),
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("validates absolute existing install paths before forwarding", async () => {
+    await expect(
+      handleExtensionInstall(["relative-extension"]),
+    ).rejects.toThrow("must be absolute");
+    await expect(
+      handleExtensionInstall([join(extensionDir, "missing")]),
+    ).rejects.toThrow("does not exist");
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("validates extension IDs and does not accept names", async () => {
+    expect(() => validateExtensionId("My extension")).toThrow(
+      "32 lowercase letters from a-p",
+    );
+    await expect(handleExtensionReload(["My extension"])).rejects.toThrow(
+      "extension ID",
+    );
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("parses the official list format without matching by name", () => {
+    expect(
+      parseExtensionList(
+        `## Extensions\nid=${EXTENSION_ID} "A \"quoted\" name" v1 Enabled`,
+      ),
+    ).toEqual([
+      {
+        id: EXTENSION_ID,
+        name: 'A "quoted" name',
+        version: "1",
+        enabled: true,
+      },
+    ]);
+    expect(parseExtensionList("No extensions installed.")).toEqual([]);
+    expect(parseExtensionList("future format")).toBeNull();
+  });
+
+  it("asserts the mode gate independently of tool execution", () => {
+    expect(() => assertExtensionMode()).not.toThrow();
+  });
+});

--- a/test/extensions.test.ts
+++ b/test/extensions.test.ts
@@ -25,9 +25,11 @@ vi.mock("../src/client.js", () => ({
 import {
   assertExtensionMode,
   handleExtensionAction,
+  handleExtensionInspect,
   handleExtensionInstall,
   handleExtensionList,
   handleExtensionReload,
+  handleExtensionTargets,
   handleExtensionUninstall,
   parseExtensionList,
   validateExtensionId,
@@ -181,5 +183,79 @@ describe("extension lifecycle commands", () => {
 
   it("asserts the mode gate independently of tool execution", () => {
     expect(() => assertExtensionMode()).not.toThrow();
+  });
+
+  it("lists extension targets (service workers and extension pages)", async () => {
+    callTool.mockResolvedValueOnce(
+      [
+        "## Pages",
+        "0: https://example.com (https://example.com/)",
+        "",
+        "## Extension Pages",
+        `1: extension://popup (extension://${EXTENSION_ID}/popup.html)`,
+        "",
+        "## Extension Service Workers",
+        `2: extension://worker (extension://${EXTENSION_ID}/background.js)`,
+      ].join("\n"),
+    );
+
+    const output = await handleExtensionTargets([]);
+
+    expect(callTool).toHaveBeenCalledWith("list_pages");
+    expect(output).toContain("operation: targets");
+    expect(output).toContain("popup.html");
+    expect(output).toContain("background.js");
+  });
+
+  it("reports when no extension targets are found", async () => {
+    callTool.mockResolvedValueOnce("## Pages\n0: https://example.com");
+
+    const output = await handleExtensionTargets([]);
+
+    expect(output).toContain("No extension targets found");
+  });
+
+  it("inspects extension metadata by ID", async () => {
+    callTool.mockResolvedValueOnce(
+      [
+        "## Extensions",
+        `id=${EXTENSION_ID} "Test Extension" v1.0.0 Enabled`,
+      ].join("\n"),
+    );
+
+    const output = await handleExtensionInspect([EXTENSION_ID]);
+
+    expect(callTool).toHaveBeenCalledWith("list_extensions");
+    expect(output).toContain(EXTENSION_ID);
+    expect(output).toContain("Test Extension");
+    expect(output).toContain("1.0.0");
+    expect(output).toContain("true");
+  });
+
+  it("rejects inspect when extension ID is not found", async () => {
+    callTool.mockResolvedValueOnce(
+      [
+        "## Extensions",
+        `id=ponmlkjihgfedcbaponmlkjihgfedcba "Other Extension" v1.0.0 Disabled`,
+      ].join("\n"),
+    );
+
+    await expect(handleExtensionInspect([EXTENSION_ID])).rejects.toMatchObject(
+      {
+        code: "VALIDATION_ERROR",
+        message: expect.stringContaining("not found"),
+      },
+    );
+  });
+
+  it("handles unparseable extension list on inspect", async () => {
+    callTool.mockResolvedValueOnce("future format");
+
+    await expect(handleExtensionInspect([EXTENSION_ID])).rejects.toMatchObject(
+      {
+        code: "BROWSER_ERROR",
+        message: expect.stringContaining("Unable to parse"),
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

Extends chrome-devtools-axi with agent-driven Chrome extension validation capabilities. Builds on the existing extension lifecycle tools (install, list, reload, action, uninstall) by adding inspection and target discovery commands.

## Changes

### New Commands

1. **extension-inspect <id>** - Show detailed metadata for an extension (name, version, enabled state)
   - Validates extension ID format
   - Queries installed extensions via `list_extensions`
   - Returns structured metadata in TOON format

2. **extension-targets** - List all extension-related targets
   - Uses `list_pages` to identify Extension Pages and Extension Service Workers
   - Enables debugging of service workers and extension UIs with page CDP commands
   - Clear indication of available targets for further inspection

### Features

- Full test coverage for new commands (5 new test cases)
- Clear separation between CDP capabilities and browser-native actions
- Safety constraints maintained (requires EXTENSION_MODE=1, pipe-only, isolated profile)
- Updated README with example workflow for Badminton Vision validation flow
- Comprehensive help text for both new commands

### Validation Workflow Example

```sh
export CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1
export CHROME_DEVTOOLS_AXI_SESSION=extension-test

# Install and inspect
chrome-devtools-axi extension-install /path/to/extension
chrome-devtools-axi extensions                          # Get the ID
chrome-devtools-axi extension-inspect <id>              # Verify installation

# Discover and debug targets
chrome-devtools-axi extension-targets                   # List service workers, pages
chrome-devtools-axi pages                               # See all targets
chrome-devtools-axi selectpage <service-worker-id>      # Select a target
chrome-devtools-axi eval "console.log('alive')"         # Debug it

# Reload and test
chrome-devtools-axi extension-reload <id>               # Reload extension
chrome-devtools-axi extension-action <id>               # Trigger action

# Cleanup
chrome-devtools-axi extension-uninstall <id>
chrome-devtools-axi stop
```

## Testing

- All 606 existing tests pass
- 5 new test cases cover new commands and error handling
- Build succeeds with TypeScript strict mode
- Prettier formatting applied

## Safety Notes

- New commands require CHROME_DEVTOOLS_AXI_EXTENSION_MODE=1 (explicit opt-in)
- Pipe-launched Chrome with --isolated profile only (no remote browsers)
- Extension targets returned by `extension-targets` and `pages` are fully compatible with existing page-scoped CDP commands (eval, click, take_snapshot, etc.)
- Clear documentation indicates that enable/disable operations require user interaction in the extension management page (not CDP)

## References

- Builds on existing extension lifecycle implementation (commit 553d90b)
- Uses chrome-devtools-mcp Extensions category (pipe-only, 5 base tools)
- Leverages existing list_pages parsing for Extension Pages and Service Workers sections
