### PR TITLE
feat: add Chrome extension lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ chrome-devtools-axi eval "() => { const rows = [...document.querySelectorAll('tr
 | --------- | ------------------------------- |
 | `emulate` | Emulate device/network/viewport |
 
+### Extensions
+
+| Command              | Description                      |
+| -------------------- | -------------------------------- |
+| `ext-install <path>` | Install an unpacked extension    |
+| `ext-list`           | List installed extensions        |
+| `ext-reload <id>`    | Reload an unpacked extension     |
+| `ext-trigger <id>`   | Trigger extension's toolbar action |
+| `ext-uninstall <id>` | Uninstall an extension           |
+
+Extension commands require `CHROME_DEVTOOLS_AXI_EXTENSIONS=1` and are only available in local launch mode (not with `CHROME_DEVTOOLS_AXI_BROWSER_URL` or `CHROME_DEVTOOLS_AXI_AUTO_CONNECT`).
+A persistent isolated browser is launched to host the extensions - see [Extension Mode](#extension-mode) for details.
+
 ### DevTools Debugging
 
 | Command            | Description                    |
@@ -327,6 +340,30 @@ The default (unset) session keeps port 9224 and the legacy state paths below.
 
 Do not export `CHROME_DEVTOOLS_AXI_PORT` globally when running concurrent sessions: it overrides the per-session derived port and forces every session onto the same port, so the second session fails to start - its bridge cannot bind the already-taken port, and the first session's bridge is rejected as a mismatch rather than silently shared.
 Rely on the per-session default ports instead, or set `CHROME_DEVTOOLS_AXI_PORT` only inline per command.
+
+### Extension mode
+
+Enable Chrome extension lifecycle management with `CHROME_DEVTOOLS_AXI_EXTENSIONS=1`:
+
+```sh
+export CHROME_DEVTOOLS_AXI_EXTENSIONS=1
+chrome-devtools-axi ext-list
+chrome-devtools-axi ext-install /path/to/extension
+chrome-devtools-axi ext-reload <extension-id>
+chrome-devtools-axi ext-trigger <extension-id>
+chrome-devtools-axi ext-uninstall <extension-id>
+```
+
+Extension mode:
+- Only works in local launch mode (default `--isolated` or `CHROME_DEVTOOLS_AXI_USER_DATA_DIR`)
+- Incompatible with `CHROME_DEVTOOLS_AXI_BROWSER_URL` and `CHROME_DEVTOOLS_AXI_AUTO_CONNECT`
+- Uses pipe-based communication with chrome-devtools-mcp for extension access
+- Runs in an isolated browser that does not access your regular Chrome profile
+- Follows the same keychain isolation as described above
+
+This is the recommended mode for AI agents that need to test or interact with browser extensions in an automated way.
+A new isolated browser instance is started and managed entirely by chrome-devtools-axi.
+Extensions are installed into this isolated browser and never touch the user's main Chrome profile.
 
 State is stored in `~/.chrome-devtools-axi/` (named sessions nest under `sessions/<name>/`):
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -654,6 +654,7 @@ export function buildTransportArgs(): string[] {
   const browserUrl = process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
   const userDataDir = process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR;
   const channel = process.env.CHROME_DEVTOOLS_AXI_CHANNEL?.trim();
+  const enableExtensions = process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS === "1";
 
   if (autoConnect) {
     // Chrome 144+ built-in remote debugging via chrome://inspect/#remote-debugging.
@@ -720,6 +721,18 @@ export function buildTransportArgs(): string[] {
     for (const arg of extraChromeArgs.trim().split(/\s+/)) {
       args.push(`--chrome-arg=${arg}`);
     }
+  }
+
+  // Extension support requires pipe mode in chrome-devtools-mcp.
+  // Only available when launching a new browser (not remote attach).
+  if (enableExtensions) {
+    if (autoConnect || browserUrl) {
+      throw new Error(
+        "Extension support (CHROME_DEVTOOLS_AXI_EXTENSIONS=1) is only available in local launch mode. " +
+        "Remove CHROME_DEVTOOLS_AXI_AUTO_CONNECT and CHROME_DEVTOOLS_AXI_BROWSER_URL to enable extensions.",
+      );
+    }
+    args.push("--pipe");
   }
 
   return args;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { encode } from "@toon-format/toon";
 import { runAxiCli } from "axi-sdk-js";
+import { existsSync } from "node:fs";
 import {
   CdpError,
   callTool,
@@ -53,7 +54,7 @@ export type MainOptions = {
 };
 
 export const TOP_HELP = `usage: chrome-devtools-axi [command] [args] [flags]
-commands[35]:
+commands[40]:
   open <url>, snapshot, screenshot <path>, click @<uid>, fill @<uid> <text>,
   type <text>, press <key>, scroll <dir>, back, wait <ms|text>, eval <js>,
   run,
@@ -61,7 +62,9 @@ commands[35]:
   upload @<uid> <path>, pages, newpage <url>, selectpage <id>, closepage <id>,
   resize <w> <h>, emulate, console, console-get <id>, network,
   network-get [id], lighthouse, perf-start, perf-stop,
-  perf-insight <set> <name>, heap <path>, start, stop, setup hooks
+  perf-insight <set> <name>, heap <path>,
+  ext-install <path>, ext-list, ext-reload <id>, ext-trigger <id>, ext-uninstall <id>,
+  start, stop, setup hooks
 
 flags[2]:
   --help, -v/-V/--version
@@ -99,6 +102,11 @@ environment:
                                     on slow/cold systems. Recommended:
                                       npm install -g chrome-devtools-mcp
                                       export CHROME_DEVTOOLS_AXI_MCP_PATH="\$(npm prefix -g)/lib/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+  CHROME_DEVTOOLS_AXI_EXTENSIONS    Set to 1 to enable Chrome extension lifecycle management
+                                    (ext-install, ext-list, ext-reload, ext-trigger, ext-uninstall).
+                                    Only available in local launch mode (not with BROWSER_URL or AUTO_CONNECT).
+                                    Requires an isolated browser instance for safety.
+                                    e.g. CHROME_DEVTOOLS_AXI_EXTENSIONS=1
   CHROME_DEVTOOLS_AXI_BRIDGE_TIMEOUT_MS
                                     Bridge readiness deadline in ms (default: 30000, min: 1000)
 
@@ -588,6 +596,53 @@ Install or repair agent SessionStart hooks for chrome-devtools-axi ambient conte
 
 examples:
   chrome-devtools-axi setup hooks`,
+
+  "ext-install": `usage: chrome-devtools-axi ext-install <path>
+Install an unpacked Chrome extension from a local directory.
+
+Requires CHROME_DEVTOOLS_AXI_EXTENSIONS=1 environment variable to enable extension mode.
+Only available in local launch mode (not with CHROME_DEVTOOLS_AXI_BROWSER_URL or AUTO_CONNECT).
+
+args:
+  <path>  Absolute path to the unpacked extension directory (required)
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSIONS=1 chrome-devtools-axi ext-install /path/to/extension`,
+
+  "ext-list": `usage: chrome-devtools-axi ext-list
+List all installed extensions with id, name, version, and enabled state.
+
+Requires CHROME_DEVTOOLS_AXI_EXTENSIONS=1 environment variable to enable extension mode.
+
+examples:
+  CHROME_DEVTOOLS_AXI_EXTENSIONS=1 chrome-devtools-axi ext-list`,
+
+  "ext-reload": `usage: chrome-devtools-axi ext-reload <id>
+Reload an installed unpacked extension by id.
+
+args:
+  <id>  Extension ID from ext-list (required)
+
+examples:
+  chrome-devtools-axi ext-reload jopfghbocfiapmmcjpbkcbgbefhphpkd`,
+
+  "ext-trigger": `usage: chrome-devtools-axi ext-trigger <id>
+Trigger an extension's default toolbar action.
+
+args:
+  <id>  Extension ID from ext-list (required)
+
+examples:
+  chrome-devtools-axi ext-trigger jopfghbocfiapmmcjpbkcbgbefhphpkd`,
+
+  "ext-uninstall": `usage: chrome-devtools-axi ext-uninstall <id>
+Uninstall an installed extension by id.
+
+args:
+  <id>  Extension ID from ext-list (required)
+
+examples:
+  chrome-devtools-axi ext-uninstall jopfghbocfiapmmcjpbkcbgbefhphpkd`,
 };
 
 export function getCommandHelp(command: string): string | null {
@@ -1671,6 +1726,89 @@ async function handleSetup(args: string[]): Promise<string> {
   ]);
 }
 
+// --- Extension lifecycle commands ---
+
+async function handleExtInstall(args: string[]): Promise<string> {
+  const path = args[0];
+  if (!path) {
+    throw new CdpError("Missing extension path", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi ext-install /absolute/path/to/extension`",
+    ]);
+  }
+
+  if (!path.startsWith("/")) {
+    throw new CdpError("Extension path must be absolute", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi ext-install /absolute/path/to/extension`",
+    ]);
+  }
+
+  if (!existsSync(path)) {
+    throw new CdpError(
+      `Extension path does not exist: ${path}`,
+      "VALIDATION_ERROR",
+      [
+        "Verify the path is correct and the directory exists",
+        "Run `chrome-devtools-axi ext-install /absolute/path/to/extension`",
+      ],
+    );
+  }
+
+  const result = await callTool("install_unpacked_extension", { path });
+  return formatMcpResult("extension installed", result, [
+    "Run `chrome-devtools-axi ext-list` to see the new extension's ID",
+    "Run `chrome-devtools-axi ext-trigger <id>` to activate the extension",
+  ]);
+}
+
+async function handleExtList(): Promise<string> {
+  const result = await callTool("list_extensions", {});
+  return formatMcpResult("extensions", result, [
+    "Use extension IDs with ext-reload, ext-trigger, and ext-uninstall",
+  ]);
+}
+
+async function handleExtReload(args: string[]): Promise<string> {
+  const id = args[0];
+  if (!id) {
+    throw new CdpError("Missing extension ID", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi ext-reload <id>` — get id from ext-list",
+    ]);
+  }
+
+  const result = await callTool("reload_extension", { extensionId: id });
+  return formatMcpResult("extension reloaded", result, [
+    "Run `chrome-devtools-axi ext-list` to verify the reload",
+  ]);
+}
+
+async function handleExtTrigger(args: string[]): Promise<string> {
+  const id = args[0];
+  if (!id) {
+    throw new CdpError("Missing extension ID", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi ext-trigger <id>` — get id from ext-list",
+    ]);
+  }
+
+  const result = await callTool("trigger_extension_action", { extensionId: id });
+  return formatMcpResult("extension action triggered", result, [
+    "Verify the extension's default toolbar action was activated",
+  ]);
+}
+
+async function handleExtUninstall(args: string[]): Promise<string> {
+  const id = args[0];
+  if (!id) {
+    throw new CdpError("Missing extension ID", "VALIDATION_ERROR", [
+      "Run `chrome-devtools-axi ext-uninstall <id>` — get id from ext-list",
+    ]);
+  }
+
+  const result = await callTool("uninstall_extension", { extensionId: id });
+  return formatMcpResult("extension uninstalled", result, [
+    "Run `chrome-devtools-axi ext-list` to verify the uninstall",
+  ]);
+}
+
 async function handleHome(_full: boolean): Promise<string> {
   const result = await getSessionSnapshotIfRunning();
   if (!result) {
@@ -1743,6 +1881,11 @@ const COMMANDS: Record<string, CommandFn> = {
   "perf-stop": withoutFullFlag(handlePerfStop),
   "perf-insight": withoutFullFlag(handlePerfInsight),
   heap: withoutFullFlag(handleHeap),
+  "ext-install": withoutFullFlag(handleExtInstall),
+  "ext-list": async () => handleExtList(),
+  "ext-reload": withoutFullFlag(handleExtReload),
+  "ext-trigger": withoutFullFlag(handleExtTrigger),
+  "ext-uninstall": withoutFullFlag(handleExtUninstall),
   start: async () => handleStart(),
   stop: async () => handleStop(),
   setup: withoutFullFlag(handleSetup),

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -170,6 +170,8 @@ describe("buildTransportArgs", () => {
       process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     savedEnv.CHROME_DEVTOOLS_AXI_CHANNEL =
       process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
+    savedEnv.CHROME_DEVTOOLS_AXI_EXTENSIONS =
+      process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS;
     delete process.env.CHROME_DEVTOOLS_AXI_HEADED;
     delete process.env.CHROME_DEVTOOLS_AXI_CHROME_ARGS;
     delete process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL;
@@ -177,6 +179,7 @@ describe("buildTransportArgs", () => {
     delete process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT;
     delete process.env.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     delete process.env.CHROME_DEVTOOLS_AXI_CHANNEL;
+    delete process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS;
   });
 
   afterEach(() => {
@@ -194,6 +197,8 @@ describe("buildTransportArgs", () => {
       savedEnv.CHROME_DEVTOOLS_AXI_WS_HEADERS;
     process.env.CHROME_DEVTOOLS_AXI_CHANNEL =
       savedEnv.CHROME_DEVTOOLS_AXI_CHANNEL;
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS =
+      savedEnv.CHROME_DEVTOOLS_AXI_EXTENSIONS;
   });
 
   it("defaults to headless and isolated", () => {
@@ -421,6 +426,53 @@ describe("buildTransportArgs", () => {
     const args = buildTransportArgs();
     expect(args).toContain("--browserUrl=http://127.0.0.1:9222");
     expect(args.some((a) => a.startsWith("--wsHeaders="))).toBe(false);
+  });
+
+  it("adds --pipe when CHROME_DEVTOOLS_AXI_EXTENSIONS=1 in local launch mode", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS = "1";
+    const args = buildTransportArgs();
+    expect(args).toContain("--pipe");
+    expect(args).toContain("--isolated");
+    expect(args).toContain("--headless");
+  });
+
+  it("adds --pipe with headed mode", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS = "1";
+    process.env.CHROME_DEVTOOLS_AXI_HEADED = "1";
+    const args = buildTransportArgs();
+    expect(args).toContain("--pipe");
+    expect(args).not.toContain("--headless");
+  });
+
+  it("rejects extensions mode with CHROME_DEVTOOLS_AXI_AUTO_CONNECT", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS = "1";
+    process.env.CHROME_DEVTOOLS_AXI_AUTO_CONNECT = "1";
+    expect(() => buildTransportArgs()).toThrow(
+      "Extension support (CHROME_DEVTOOLS_AXI_EXTENSIONS=1) is only available in local launch mode",
+    );
+  });
+
+  it("rejects extensions mode with CHROME_DEVTOOLS_AXI_BROWSER_URL", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS = "1";
+    process.env.CHROME_DEVTOOLS_AXI_BROWSER_URL = "http://127.0.0.1:9222";
+    expect(() => buildTransportArgs()).toThrow(
+      "Extension support (CHROME_DEVTOOLS_AXI_EXTENSIONS=1) is only available in local launch mode",
+    );
+  });
+
+  it("adds --pipe with user data dir for persistent profile", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS = "1";
+    process.env.CHROME_DEVTOOLS_AXI_USER_DATA_DIR = "/path/to/.chrome-profile";
+    const args = buildTransportArgs();
+    expect(args).toContain("--pipe");
+    expect(args).toContain("--userDataDir=/path/to/.chrome-profile");
+    expect(args).not.toContain("--isolated");
+  });
+
+  it("ignores CHROME_DEVTOOLS_AXI_EXTENSIONS when not set to '1'", () => {
+    process.env.CHROME_DEVTOOLS_AXI_EXTENSIONS = "true";
+    const args = buildTransportArgs();
+    expect(args.some((a) => a === "--pipe")).toBe(false);
   });
 });
 

--- a/test/extensions.test.ts
+++ b/test/extensions.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AxiError } from "axi-sdk-js";
+
+const { callTool } = vi.hoisted(() => ({
+  callTool: vi.fn(),
+}));
+
+vi.mock("../src/client.js", () => ({
+  CdpError: class CdpError extends AxiError {
+    constructor(
+      message: string,
+      public readonly code: string,
+      public readonly suggestions: string[] = [],
+    ) {
+      super(message, code, suggestions);
+    }
+  },
+  callTool,
+  ensureBridge: vi.fn(),
+  getSessionSnapshotIfRunning: vi.fn(),
+  stopBridge: vi.fn(),
+}));
+
+import { main } from "../src/cli.js";
+import { CdpError } from "../src/client.js";
+
+describe("extension commands", () => {
+  afterEach(() => {
+    callTool.mockReset();
+    process.exitCode = undefined;
+    vi.restoreAllMocks();
+  });
+
+  describe("ext-install", () => {
+    it("requires an extension path argument", async () => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-install"]);
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("error");
+      expect(output).toContain("Missing extension path");
+    });
+
+    it("requires an absolute path", async () => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-install", "./relative/path"]);
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("error");
+      expect(output).toContain("must be absolute");
+    });
+
+    it("validates path exists before calling MCP", async () => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-install", "/nonexistent/extension/path"]);
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("error");
+      expect(output).toContain("does not exist");
+      // Should never reach the MCP tool call for a nonexistent path
+      expect(callTool).not.toHaveBeenCalled();
+    });
+
+    it("calls install_unpacked_extension with valid absolute path", async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "ext-"));
+      try {
+        // Create a dummy extension manifest to make it look like a real extension
+        writeFileSync(join(tempDir, "manifest.json"), '{}');
+
+        callTool.mockResolvedValueOnce(
+          "extension installed\nID: jopfghbocfiapmmcjpbkcbgbefhphpkd",
+        );
+
+        const write = vi
+          .spyOn(process.stdout, "write")
+          .mockImplementation(() => true);
+
+        await main(["ext-install", tempDir]);
+
+        expect(callTool).toHaveBeenCalledWith("install_unpacked_extension", {
+          path: tempDir,
+        });
+
+        const output = String(write.mock.calls[0]?.[0]);
+        expect(output).toContain("extension installed");
+      } finally {
+        rmSync(tempDir, { recursive: true });
+      }
+    });
+  });
+
+  describe("ext-list", () => {
+    it("calls list_extensions with no arguments", async () => {
+      callTool.mockResolvedValueOnce("extensions:\nID: ext1, Name: Extension 1");
+
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-list"]);
+
+      expect(callTool).toHaveBeenCalledWith("list_extensions", {});
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("extensions");
+    });
+  });
+
+  describe("ext-reload", () => {
+    it("requires an extension ID argument", async () => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-reload"]);
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("error");
+      expect(output).toContain("Missing extension ID");
+    });
+
+    it("calls reload_extension with the provided ID", async () => {
+      callTool.mockResolvedValueOnce("extension reloaded");
+
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-reload", "jopfghbocfiapmmcjpbkcbgbefhphpkd"]);
+
+      expect(callTool).toHaveBeenCalledWith("reload_extension", {
+        extensionId: "jopfghbocfiapmmcjpbkcbgbefhphpkd",
+      });
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("extension reloaded");
+    });
+  });
+
+  describe("ext-trigger", () => {
+    it("requires an extension ID argument", async () => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-trigger"]);
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("error");
+      expect(output).toContain("Missing extension ID");
+    });
+
+    it("calls trigger_extension_action with the provided ID", async () => {
+      callTool.mockResolvedValueOnce("extension action triggered");
+
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-trigger", "jopfghbocfiapmmcjpbkcbgbefhphpkd"]);
+
+      expect(callTool).toHaveBeenCalledWith("trigger_extension_action", {
+        extensionId: "jopfghbocfiapmmcjpbkcbgbefhphpkd",
+      });
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("extension action triggered");
+    });
+  });
+
+  describe("ext-uninstall", () => {
+    it("requires an extension ID argument", async () => {
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-uninstall"]);
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("error");
+      expect(output).toContain("Missing extension ID");
+    });
+
+    it("calls uninstall_extension with the provided ID", async () => {
+      callTool.mockResolvedValueOnce("extension uninstalled");
+
+      const write = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      await main(["ext-uninstall", "jopfghbocfiapmmcjpbkcbgbefhphpkd"]);
+
+      expect(callTool).toHaveBeenCalledWith("uninstall_extension", {
+        extensionId: "jopfghbocfiapmmcjpbkcbgbefhphpkd",
+      });
+
+      const output = String(write.mock.calls[0]?.[0]);
+      expect(output).toContain("extension uninstalled");
+    });
+  });
+});


### PR DESCRIPTION
Add Chrome extension lifecycle management capabilities to chrome-devtools-axi for AI-agent end-to-end testing.

## What's New

This PR adds five new commands for managing Chrome extensions:
- `ext-install <path>` - Install an unpacked extension from an absolute path
- `ext-list` - List installed extensions with ID, name, version, and enabled state
- `ext-reload <id>` - Reload an unpacked extension by ID
- `ext-trigger <id>` - Trigger an extension's default toolbar action
- `ext-uninstall <id>` - Uninstall an extension by ID

## Opt-in Extension Mode

Extension support is enabled via an explicit environment variable:
```sh
CHROME_DEVTOOLS_AXI_EXTENSIONS=1 chrome-devtools-axi ext-list
```

The extension mode:
- Only works in local launch mode (default `--isolated` or `CHROME_DEVTOOLS_AXI_USER_DATA_DIR`)
- Is incompatible with remote attach modes (`CHROME_DEVTOOLS_AXI_BROWSER_URL`, `CHROME_DEVTOOLS_AXI_AUTO_CONNECT`)
- Uses the official chrome-devtools-mcp extension tools via the `--pipe` protocol
- Runs in an isolated, disposable browser instance that never touches the user's main Chrome profile
- Follows the same keychain isolation as existing launch modes

## Backwards Compatibility

- All existing commands, output contracts, and CLI behavior are preserved
- Existing users need not change any commands
- Extension commands are entirely opt-in via the environment variable
- All existing tests pass (601 tests, no regressions)

## Testing

- Added 11 new unit tests for extension command parsing, validation, and tool forwarding
- Added 6 new tests for extension mode in bridge transport argument building
- Tests cover mode incompatibility errors, path validation, command parsing
- All existing 584 tests continue to pass
- Build and formatting checks pass

## Documentation

- Updated README.md with new Extension section in CLI Reference
- Added Extension mode configuration documentation with usage examples
- Included security guidance on isolated profiles and keychain isolation
- Documented the pipe-only limitation and when extension mode is available

## Implementation Details

- Commands use `formatMcpResult` for consistent TOON-formatted output
- Path validation for `ext-install` is done before MCP tool call
- ID validation relies on MCP tool error reporting for consistency
- Suggestions provided in output guide users to next steps
- Environment variable validation in bridge prevents silent failures
