### PR TITLE
fix(cli): restore controlled fills and stale ref safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,8 @@ Both fixes live at the single `callTool`/`handleCallRequest` chokepoint, so ever
 ### Snapshot generations and STALE_REF
 
 Snapshots are accessibility trees whose interactive elements carry `uid=` refs.
-Because CLI processes are short-lived, a generation counter persists in the active session's state dir as `snapshot-generation` (`~/.chrome-devtools-axi/snapshot-generation` by default; `src/generation.ts`); every fresh snapshot bumps it and `stampSnapshotGeneration` (`src/snapshot.ts`) rewrites `uid=X` to `uid=g<N>:X`.
-Action commands parse refs through `parseUidFresh` (`src/cli.ts`), which fails loudly with `STALE_REF` instead of letting upstream MCP silently no-op against a stale tree.
-`stampFresh` also installs a MutationObserver in the page (`markPageSnapshotGeneration`), so the effective page generation is `snapshot generation + observed mutations` - a re-render invalidates refs even without a newer snapshot.
+Because CLI processes are short-lived, a generation counter persists in the active session's state dir as `snapshot-generation` (`~/.chrome-devtools-axi/snapshot-generation` by default; `src/generation.ts`). `captureFreshSnapshot` (`src/uid-freshness.ts`) starts its page MutationObserver before capture, recaptures once if a mutation occurs during capture, and stamps the resulting tree from `uid=X` to `uid=g<N>:X`.
+Action commands and `run` UID actions parse refs through `parseUidFresh` (`src/uid-freshness.ts`), which requires the observer state to match the persisted snapshot generation with zero mutations. Missing or unusable observer state, a generation mismatch, or a mutation fails loudly with `STALE_REF` instead of letting upstream MCP silently no-op against a stale tree.
 
 ### CLI output and AXI integration
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ snapshot:
 ...
 ```
 
-Refs in snapshot output carry a `g<N>:` generation prefix that bumps every time a new accessibility tree is captured. Pass refs back exactly as printed - if the page re-rendered between snapshot and action, the action fails loudly with `STALE_REF` instead of silently no-op'ing, so the agent re-snapshots and retries.
+Refs in snapshot output carry a `g<N>:` generation prefix that bumps every time a new accessibility tree is captured. Pass refs back exactly as printed. UID actions also verify that the tracked page has not mutated since that snapshot; if freshness cannot be confirmed (including for a legacy untagged ref), they fail loudly with `STALE_REF` instead of silently no-op'ing, so the agent re-snapshots and retries.
 The skill also instructs agents to verify state-changing actions with a fresh snapshot, `eval`, or screenshot before reporting success, because a current ref can still produce no visible page change.
 
 ## Other Ways to Install

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,8 +29,8 @@ import { overlaySessionSelected } from "./selected-page.js";
 import { resolveOutputPath } from "./paths.js";
 import { VERSION } from "./version.js";
 import {
+  captureFreshSnapshot,
   parseUidFresh as parseUidFreshShared,
-  stampFreshSnapshot,
   type ToolCaller,
 } from "./uid-freshness.js";
 
@@ -914,24 +914,6 @@ function shouldRenderFullHome(argv: string[]): boolean {
   return argv.length === 1 && argv[0] === "--full";
 }
 
-/**
- * Parse snapshot from an includeSnapshot response.
- * The response contains a "## Latest page snapshot" section.
- */
-function parseSnapshotFromResponse(response: string): string | null {
-  const marker = "## Latest page snapshot";
-  const idx = response.indexOf(marker);
-  if (idx === -1) return null;
-  const after = response.slice(idx + marker.length);
-  // The snapshot follows after the header line, possibly with a blank line
-  const trimmed = after.replace(/^\s*\n/, "");
-  // Snapshot ends at the next ## heading or end of text
-  const nextHeading = trimmed.indexOf("\n## ");
-  return nextHeading === -1
-    ? trimmed.trimEnd()
-    : trimmed.slice(0, nextHeading).trimEnd();
-}
-
 /** Format page metadata (TOON) + raw snapshot + suggestions. */
 function formatPageOutput(
   snapshot: string,
@@ -999,8 +981,10 @@ export function parseUid(arg: string): string {
 }
 
 /** Tag a freshly captured snapshot with a bumped generation marker. */
-async function stampFresh(snapshot: string): Promise<string> {
-  return stampFreshSnapshot(snapshot, callTool);
+async function stampFresh(): Promise<string> {
+  return captureFreshSnapshot(callTool, async () =>
+    stripSnapshotHeader(await callTool("take_snapshot")),
+  );
 }
 
 function throwStaleRef(
@@ -1033,21 +1017,12 @@ function isRecoverableOpenError(error: unknown): error is CdpError {
   );
 }
 
-/**
- * Call a tool with includeSnapshot:true and extract the snapshot.
- * Falls back to a separate take_snapshot() if parsing fails.
- */
 async function callWithSnapshot(
   name: string,
   args: Record<string, unknown>,
 ): Promise<string> {
-  const result = await callTool(name, { ...args, includeSnapshot: true });
-  const snapshot = parseSnapshotFromResponse(result);
-  if (snapshot && snapshot.length > 0) {
-    return await stampFresh(stripSnapshotHeader(snapshot));
-  }
-  // Fallback: take snapshot separately
-  return await stampFresh(stripSnapshotHeader(await callTool("take_snapshot")));
+  await callTool(name, args);
+  return stampFresh();
 }
 
 const SCROLL_FUNCTIONS: Record<string, string> = {
@@ -1073,16 +1048,12 @@ async function handleOpen(args: string[], full: boolean): Promise<string> {
     }
     await callTool("new_page", { url });
   }
-  const snapshot = await stampFresh(
-    stripSnapshotHeader(await callTool("take_snapshot")),
-  );
+  const snapshot = await stampFresh();
   return formatPageOutput(snapshot, "open", url, full);
 }
 
 async function handleSnapshot(full: boolean): Promise<string> {
-  const snapshot = await stampFresh(
-    stripSnapshotHeader(await callTool("take_snapshot")),
-  );
+  const snapshot = await stampFresh();
   return formatPageOutput(snapshot, "snapshot", undefined, full);
 }
 
@@ -1160,9 +1131,7 @@ async function handleType(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("type_text", { text });
-  const snapshot = await stampFresh(
-    stripSnapshotHeader(await callTool("take_snapshot")),
-  );
+  const snapshot = await stampFresh();
   return formatPageOutput(snapshot, "type", undefined, full);
 }
 
@@ -1176,17 +1145,13 @@ async function handleScroll(args: string[], full: boolean): Promise<string> {
   }
 
   await callTool("evaluate_script", { function: fn });
-  const snapshot = await stampFresh(
-    stripSnapshotHeader(await callTool("take_snapshot")),
-  );
+  const snapshot = await stampFresh();
   return formatPageOutput(snapshot, "scroll", undefined, full);
 }
 
 async function handleBack(full: boolean): Promise<string> {
   await callTool("navigate_page", { type: "back" });
-  const snapshot = await stampFresh(
-    stripSnapshotHeader(await callTool("take_snapshot")),
-  );
+  const snapshot = await stampFresh();
   return formatPageOutput(snapshot, "back", undefined, full);
 }
 
@@ -1305,9 +1270,7 @@ async function handleNewPage(args: string[], full: boolean): Promise<string> {
   const toolArgs: Record<string, unknown> = { url };
   if (background) toolArgs.background = true;
   await callTool("new_page", toolArgs);
-  const snapshot = await stampFresh(
-    stripSnapshotHeader(await callTool("take_snapshot")),
-  );
+  const snapshot = await stampFresh();
   return formatPageOutput(snapshot, "newpage", url, full);
 }
 
@@ -1328,9 +1291,7 @@ async function handleSelectPage(
     ]);
   }
   await callTool("select_page", { pageId });
-  const snapshot = await stampFresh(
-    stripSnapshotHeader(await callTool("take_snapshot")),
-  );
+  const snapshot = await stampFresh();
   return formatPageOutput(snapshot, "selectpage", undefined, full);
 }
 
@@ -1623,7 +1584,7 @@ async function handleHome(_full: boolean): Promise<string> {
       renderHelp(["Run `chrome-devtools-axi open <url>` to start browsing"]),
     ]);
   }
-  const snapshot = await stampFresh(stripSnapshotHeader(result));
+  const snapshot = stripSnapshotHeader(result);
   const title = extractTitle(snapshot);
   const refs = countRefs(snapshot);
   const page: Record<string, unknown> = {};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,11 +8,7 @@ import {
   stopBridge,
 } from "./client.js";
 import { getCurrentGeneration } from "./generation.js";
-import {
-  readStdin,
-  runScript,
-  wrapJsExpression,
-} from "./run.js";
+import { readStdin, runScript, wrapJsExpression } from "./run.js";
 
 export { wrapJsExpression };
 import {
@@ -270,19 +266,19 @@ Pipe a script via heredoc or stdin — no file path needed.
 script API (available as global \`page\`):
   await page.open(url)              Navigate, returns { url, status }
   await page.eval(jsOrFn)           Evaluate JS in the page, returns the value
-  await page.snapshot()             Get the accessibility tree as text
+  await page.snapshot()             Get the generation-tagged accessibility tree
   await page.wait(ms)               Wait by duration
   await page.wait(selector)         Wait for CSS selector (30s timeout)
   await page.wait(selector, ms)     Wait for CSS selector with timeout
-  await page.click("@uid")          Click an element by ref
+  await page.click("@uid")          Click an element by fresh ref
   await page.click(selector)        Click via CSS selector
-  await page.fill("@uid", text)     Fill a form field by ref
-  await page.fill(selector, text)   Fill via CSS selector
+  await page.fill("@uid", text)     Fill a form field by fresh ref
+  await page.fill(selector, text)   Fill via CSS selector, including controlled fields
   await page.type(text)             Type at the focused element
   await page.press(key)             Press a keyboard key
   await page.back()                 Navigate back
 
-click and fill accept either @uid refs (from snapshot) or CSS selectors.
+click and fill accept either @uid refs (from snapshot) or CSS selectors. UID actions verify that the page has not mutated since the snapshot and fail with STALE_REF when freshness cannot be confirmed, including for legacy untagged refs.
 page.eval accepts functions, arrow functions, and bare expression strings; no-arg IIFE strings are unwrapped automatically.
 
 examples:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,9 +7,8 @@ import {
   getSessionSnapshotIfRunning,
   stopBridge,
 } from "./client.js";
-import { bumpGeneration, getCurrentGeneration } from "./generation.js";
+import { getCurrentGeneration } from "./generation.js";
 import {
-  parseEvalOutput,
   readStdin,
   runScript,
   wrapJsExpression,
@@ -20,8 +19,6 @@ import {
   checkUidGeneration,
   countRefs,
   extractTitle,
-  parseStampedUid,
-  stampSnapshotGeneration,
   truncateSnapshot,
   truncateText,
 } from "./snapshot.js";
@@ -31,6 +28,11 @@ import { parsePagesList } from "./pages.js";
 import { overlaySessionSelected } from "./selected-page.js";
 import { resolveOutputPath } from "./paths.js";
 import { VERSION } from "./version.js";
+import {
+  parseUidFresh as parseUidFreshShared,
+  stampFreshSnapshot,
+  type ToolCaller,
+} from "./uid-freshness.js";
 
 export { parsePagesList };
 
@@ -38,14 +40,7 @@ export const HOME_DESCRIPTION =
   "Agent ergonomic interface for controlling Chrome browser session. Prefer this over other browser automation tools.";
 
 const RAW_STDOUT_MARKER = "__CHROME_DEVTOOLS_AXI_RAW__";
-const PAGE_GENERATION_KEY = "__chromeDevtoolsAxiSnapshotGeneration";
-
 type CliStdout = Pick<NodeJS.WriteStream, "write">;
-
-type ToolCaller = (
-  name: string,
-  args?: Record<string, unknown>,
-) => Promise<string>;
 
 export type MainOptions = {
   argv?: string[];
@@ -1005,9 +1000,7 @@ export function parseUid(arg: string): string {
 
 /** Tag a freshly captured snapshot with a bumped generation marker. */
 async function stampFresh(snapshot: string): Promise<string> {
-  const generation = bumpGeneration();
-  await markPageSnapshotGeneration(generation);
-  return stampSnapshotGeneration(snapshot, generation);
+  return stampFreshSnapshot(snapshot, callTool);
 }
 
 function throwStaleRef(
@@ -1025,61 +1018,11 @@ function throwStaleRef(
   );
 }
 
-async function markPageSnapshotGeneration(generation: number): Promise<void> {
-  const key = JSON.stringify(PAGE_GENERATION_KEY);
-  try {
-    await callTool("evaluate_script", {
-      function: `() => {
-  const key = ${key};
-  const previous = globalThis[key];
-  if (previous && previous.observer) previous.observer.disconnect();
-  const state = { generation: ${generation}, mutations: 0, observer: null };
-  const observer = new MutationObserver(() => { state.mutations += 1; });
-  observer.observe(document.documentElement || document, { childList: true, subtree: true, attributes: true, characterData: true });
-  state.observer = observer;
-  globalThis[key] = state;
-  return state.generation;
-}`,
-    });
-  } catch {}
-}
-
-async function getPageRefGeneration(caller: ToolCaller): Promise<number> {
-  const key = JSON.stringify(PAGE_GENERATION_KEY);
-  const fallback = getCurrentGeneration();
-  try {
-    const output = await caller("evaluate_script", {
-      function: `() => {
-  const state = globalThis[${key}];
-  if (!state || typeof state.generation !== 'number') return ${fallback};
-  const mutations = typeof state.mutations === 'number' ? state.mutations : 0;
-  return state.generation + mutations;
-}`,
-    });
-    const parsed = parseEvalOutput(output);
-    return typeof parsed === "number" && Number.isFinite(parsed)
-      ? parsed
-      : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
 export async function parseUidFresh(
   arg: string,
   caller: ToolCaller = callTool,
 ): Promise<string> {
-  const { generation } = parseStampedUid(arg);
-  const snapshotGeneration = getCurrentGeneration();
-  const current = await getPageRefGeneration(caller);
-  if (generation === null && current !== snapshotGeneration) {
-    throwStaleRef(arg, snapshotGeneration, current);
-  }
-  const check = checkUidGeneration(arg, current);
-  if (check.stale) {
-    throwStaleRef(arg, check.refGeneration, current);
-  }
-  return check.uid;
+  return parseUidFreshShared(arg, caller);
 }
 
 function isRecoverableOpenError(error: unknown): error is CdpError {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1070,10 +1070,11 @@ export async function parseUidFresh(
   caller: ToolCaller = callTool,
 ): Promise<string> {
   const { generation } = parseStampedUid(arg);
-  const current =
-    generation === null
-      ? getCurrentGeneration()
-      : await getPageRefGeneration(caller);
+  const snapshotGeneration = getCurrentGeneration();
+  const current = await getPageRefGeneration(caller);
+  if (generation === null && current !== snapshotGeneration) {
+    throwStaleRef(arg, snapshotGeneration, current);
+  }
   const check = checkUidGeneration(arg, current);
   if (check.stale) {
     throwStaleRef(arg, check.refGeneration, current);

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,7 @@ import { mkdtempSync, writeFileSync, unlinkSync, rmdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CdpError } from "./client.js";
-import { parseUidFresh, stampFreshSnapshot } from "./uid-freshness.js";
+import { captureFreshSnapshot, parseUidFresh } from "./uid-freshness.js";
 
 type CallTool = (
   name: string,
@@ -235,8 +235,9 @@ export function createPageHelper(callTool: CallTool): PageHelper {
     },
 
     async snapshot(): Promise<string> {
-      const result = await callTool("take_snapshot");
-      return stampFreshSnapshot(stripSnapshotHeader(result), callTool);
+      return captureFreshSnapshot(callTool, async () =>
+        stripSnapshotHeader(await callTool("take_snapshot")),
+      );
     },
 
     async click(refOrSelector: string): Promise<void> {

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,7 @@ import { mkdtempSync, writeFileSync, unlinkSync, rmdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CdpError } from "./client.js";
-import { parseStampedUid } from "./snapshot.js";
+import { parseUidFresh, stampFreshSnapshot } from "./uid-freshness.js";
 
 type CallTool = (
   name: string,
@@ -125,11 +125,6 @@ function stripSnapshotHeader(text: string): string {
   return text.replace(/^[\s\S]*?##\s+Latest page snapshot\s*\n/, "");
 }
 
-/** Strip leading @ from uid ref string. */
-function parseUid(ref: string): string {
-  return parseStampedUid(ref).uid;
-}
-
 /** Check if an open error is recoverable by falling back to new_page. */
 function isRecoverableOpenError(error: unknown): boolean {
   if (!(error instanceof CdpError)) return false;
@@ -241,12 +236,14 @@ export function createPageHelper(callTool: CallTool): PageHelper {
 
     async snapshot(): Promise<string> {
       const result = await callTool("take_snapshot");
-      return stripSnapshotHeader(result);
+      return stampFreshSnapshot(stripSnapshotHeader(result), callTool);
     },
 
     async click(refOrSelector: string): Promise<void> {
       if (isUidRef(refOrSelector)) {
-        await callTool("click", { uid: parseUid(refOrSelector) });
+        await callTool("click", {
+          uid: await parseUidFresh(refOrSelector, callTool),
+        });
       } else {
         const sel = JSON.stringify(refOrSelector);
         await callTool("evaluate_script", {
@@ -262,7 +259,10 @@ export function createPageHelper(callTool: CallTool): PageHelper {
 
     async fill(refOrSelector: string, text: string): Promise<void> {
       if (isUidRef(refOrSelector)) {
-        await callTool("fill", { uid: parseUid(refOrSelector), value: text });
+        await callTool("fill", {
+          uid: await parseUidFresh(refOrSelector, callTool),
+          value: text,
+        });
       } else {
         const sel = JSON.stringify(refOrSelector);
         const val = JSON.stringify(text);

--- a/src/run.ts
+++ b/src/run.ts
@@ -271,7 +271,10 @@ export function createPageHelper(callTool: CallTool): PageHelper {
   const el = document.querySelector(${sel});
   if (!el) throw new Error('Element not found: ' + ${sel});
   el.focus();
-  el.value = ${val};
+  const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype
+    : el instanceof HTMLSelectElement ? HTMLSelectElement.prototype
+    : HTMLInputElement.prototype;
+  Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, ${val});
   el.dispatchEvent(new Event('input', { bubbles: true }));
   el.dispatchEvent(new Event('change', { bubbles: true }));
 })()`,

--- a/src/uid-freshness.ts
+++ b/src/uid-freshness.ts
@@ -97,10 +97,9 @@ async function getPageRefState(
 }`,
     });
     const jsonBlock = output.match(/```json\n([\s\S]*?)\n```/);
-    const raw = jsonBlock?.[1] ?? output.replace(
-      /^Script ran on page and returned:\s*/,
-      "",
-    );
+    const raw =
+      jsonBlock?.[1] ??
+      output.replace(/^Script ran on page and returned:\s*/, "");
     const parsed: unknown = JSON.parse(raw.trim());
     if (
       typeof parsed !== "object" ||

--- a/src/uid-freshness.ts
+++ b/src/uid-freshness.ts
@@ -17,10 +17,12 @@ export async function captureFreshSnapshot(
   caller: ToolCaller,
   capture: () => Promise<string>,
 ): Promise<string> {
-  const generation = bumpGeneration();
-  await markPageSnapshotGeneration(generation, caller);
-  const snapshot = await capture();
-  return stampSnapshotGeneration(snapshot, generation);
+  const first = await captureSnapshot(caller, capture);
+  const fresh =
+    first.state?.generation === first.generation && first.state.mutations > 0
+      ? await captureSnapshot(caller, capture)
+      : first;
+  return stampSnapshotGeneration(fresh.snapshot, fresh.generation);
 }
 
 function throwStaleRef(
@@ -64,6 +66,22 @@ async function markPageSnapshotGeneration(
 interface PageRefState {
   generation: number;
   mutations: number;
+}
+
+interface CapturedSnapshot {
+  generation: number;
+  snapshot: string;
+  state: PageRefState | null;
+}
+
+async function captureSnapshot(
+  caller: ToolCaller,
+  capture: () => Promise<string>,
+): Promise<CapturedSnapshot> {
+  const generation = bumpGeneration();
+  await markPageSnapshotGeneration(generation, caller);
+  const snapshot = await capture();
+  return { generation, snapshot, state: await getPageRefState(caller) };
 }
 
 async function getPageRefState(

--- a/src/uid-freshness.ts
+++ b/src/uid-freshness.ts
@@ -13,12 +13,13 @@ export type ToolCaller = (
 
 export const PAGE_GENERATION_KEY = "__chromeDevtoolsAxiSnapshotGeneration";
 
-export async function stampFreshSnapshot(
-  snapshot: string,
+export async function captureFreshSnapshot(
   caller: ToolCaller,
+  capture: () => Promise<string>,
 ): Promise<string> {
   const generation = bumpGeneration();
   await markPageSnapshotGeneration(generation, caller);
+  const snapshot = await capture();
   return stampSnapshotGeneration(snapshot, generation);
 }
 

--- a/src/uid-freshness.ts
+++ b/src/uid-freshness.ts
@@ -1,0 +1,123 @@
+import { CdpError } from "./client.js";
+import { bumpGeneration, getCurrentGeneration } from "./generation.js";
+import {
+  checkUidGeneration,
+  parseStampedUid,
+  stampSnapshotGeneration,
+} from "./snapshot.js";
+
+export type ToolCaller = (
+  name: string,
+  args?: Record<string, unknown>,
+) => Promise<string>;
+
+export const PAGE_GENERATION_KEY = "__chromeDevtoolsAxiSnapshotGeneration";
+
+export async function stampFreshSnapshot(
+  snapshot: string,
+  caller: ToolCaller,
+): Promise<string> {
+  const generation = bumpGeneration();
+  await markPageSnapshotGeneration(generation, caller);
+  return stampSnapshotGeneration(snapshot, generation);
+}
+
+function throwStaleRef(
+  arg: string,
+  refGeneration: number | null,
+  currentGeneration: number | null,
+): never {
+  const refRaw = arg.startsWith("@") ? arg.slice(1) : arg;
+  const current = currentGeneration ?? "unavailable";
+  throw new CdpError(
+    `Stale ref @${refRaw}: from snapshot generation ${refGeneration}, current is ${current}. Re-snapshot to get fresh refs.`,
+    "STALE_REF",
+    [
+      "Run `chrome-devtools-axi snapshot` to capture current refs, then retry the action",
+    ],
+  );
+}
+
+async function markPageSnapshotGeneration(
+  generation: number,
+  caller: ToolCaller,
+): Promise<void> {
+  const key = JSON.stringify(PAGE_GENERATION_KEY);
+  try {
+    await caller("evaluate_script", {
+      function: `() => {
+  const key = ${key};
+  const previous = globalThis[key];
+  if (previous && previous.observer) previous.observer.disconnect();
+  const state = { generation: ${generation}, mutations: 0, observer: null };
+  const observer = new MutationObserver(() => { state.mutations += 1; });
+  observer.observe(document.documentElement || document, { childList: true, subtree: true, attributes: true, characterData: true });
+  state.observer = observer;
+  globalThis[key] = state;
+  return state.generation;
+}`,
+    });
+  } catch {}
+}
+
+interface PageRefState {
+  generation: number;
+  mutations: number;
+}
+
+async function getPageRefState(
+  caller: ToolCaller,
+): Promise<PageRefState | null> {
+  const key = JSON.stringify(PAGE_GENERATION_KEY);
+  try {
+    const output = await caller("evaluate_script", {
+      function: `() => {
+  const state = globalThis[${key}];
+  if (!state || typeof state.generation !== 'number' || typeof state.mutations !== 'number' || !state.observer) return null;
+  return { generation: state.generation, mutations: state.mutations };
+}`,
+    });
+    const jsonBlock = output.match(/```json\n([\s\S]*?)\n```/);
+    const raw = jsonBlock?.[1] ?? output.replace(
+      /^Script ran on page and returned:\s*/,
+      "",
+    );
+    const parsed: unknown = JSON.parse(raw.trim());
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as PageRefState).generation !== "number" ||
+      typeof (parsed as PageRefState).mutations !== "number"
+    ) {
+      return null;
+    }
+    return parsed as PageRefState;
+  } catch {
+    return null;
+  }
+}
+
+export async function parseUidFresh(
+  arg: string,
+  caller: ToolCaller,
+): Promise<string> {
+  const snapshotGeneration = getCurrentGeneration();
+  const check = checkUidGeneration(arg, snapshotGeneration);
+  if (check.stale) {
+    throwStaleRef(arg, check.refGeneration, snapshotGeneration);
+  }
+
+  const state = await getPageRefState(caller);
+  if (
+    !state ||
+    state.generation !== snapshotGeneration ||
+    state.mutations !== 0
+  ) {
+    throwStaleRef(
+      arg,
+      parseStampedUid(arg).generation ?? snapshotGeneration,
+      state ? state.generation + state.mutations : null,
+    );
+  }
+  return check.uid;
+}

--- a/test/interaction.test.ts
+++ b/test/interaction.test.ts
@@ -130,7 +130,22 @@ describe("parseUidFresh", () => {
     async (ref) => {
       const callTool = vi
         .fn()
-        .mockResolvedValue("Script ran on page and returned:\n```json\n8\n```");
+        .mockResolvedValue(
+          'Script ran on page and returned:\n```json\n{"generation":7,"mutations":1}\n```',
+        );
+
+      await expect(parseUidFresh(ref, callTool)).rejects.toMatchObject({
+        code: "STALE_REF",
+      });
+    },
+  );
+
+  it.each(["@g7:237_15", "@237_15"])(
+    "throws STALE_REF when the page freshness marker is unavailable for %s",
+    async (ref) => {
+      const callTool = vi
+        .fn()
+        .mockResolvedValue("Script ran on page and returned:\n```json\nnull\n```");
 
       await expect(parseUidFresh(ref, callTool)).rejects.toMatchObject({
         code: "STALE_REF",

--- a/test/interaction.test.ts
+++ b/test/interaction.test.ts
@@ -125,13 +125,16 @@ describe("parseUidFresh", () => {
     vi.restoreAllMocks();
   });
 
-  it("throws STALE_REF when page mutations advance the current ref generation", async () => {
-    const callTool = vi
-      .fn()
-      .mockResolvedValue("Script ran on page and returned:\n```json\n8\n```");
+  it.each(["@g7:237_15", "@237_15"])(
+    "throws STALE_REF when page mutations advance the current ref generation for %s",
+    async (ref) => {
+      const callTool = vi
+        .fn()
+        .mockResolvedValue("Script ran on page and returned:\n```json\n8\n```");
 
-    await expect(parseUidFresh("@g7:237_15", callTool)).rejects.toMatchObject({
-      code: "STALE_REF",
-    });
-  });
+      await expect(parseUidFresh(ref, callTool)).rejects.toMatchObject({
+        code: "STALE_REF",
+      });
+    },
+  );
 });

--- a/test/interaction.test.ts
+++ b/test/interaction.test.ts
@@ -145,7 +145,9 @@ describe("parseUidFresh", () => {
     async (ref) => {
       const callTool = vi
         .fn()
-        .mockResolvedValue("Script ran on page and returned:\n```json\nnull\n```");
+        .mockResolvedValue(
+          "Script ran on page and returned:\n```json\nnull\n```",
+        );
 
       await expect(parseUidFresh(ref, callTool)).rejects.toMatchObject({
         code: "STALE_REF",

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -280,13 +280,10 @@ describe("main", () => {
       ["new_page", { url: "https://airlockhq.com" }],
       [
         "evaluate_script",
-        {
-          function: expect.stringContaining(
-            "__chromeDevtoolsAxiSnapshotGeneration",
-          ),
-        },
+        expect.any(Object),
       ],
       ["take_snapshot"],
+      ["evaluate_script", expect.any(Object)],
     ]);
     expect(String(write.mock.calls[0]?.[0])).toContain("title: Airlock");
     expect(String(write.mock.calls[0]?.[0])).toContain(
@@ -313,13 +310,10 @@ describe("main", () => {
       ["new_page", { url: "https://airlockhq.com" }],
       [
         "evaluate_script",
-        {
-          function: expect.stringContaining(
-            "__chromeDevtoolsAxiSnapshotGeneration",
-          ),
-        },
+        expect.any(Object),
       ],
       ["take_snapshot"],
+      ["evaluate_script", expect.any(Object)],
     ]);
     expect(String(write.mock.calls[0]?.[0])).toContain("title: Airlock");
     expect(process.exitCode).toBeUndefined();

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -270,6 +270,7 @@ describe("main", () => {
     callTool
       .mockRejectedValueOnce(new CdpError("Not connected", "BROWSER_ERROR"))
       .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("")
       .mockResolvedValueOnce('RootWebArea "Airlock"\n  uid=1 link "Sign in"');
 
     await main(["open", "https://airlockhq.com"]);
@@ -277,7 +278,6 @@ describe("main", () => {
     expect(callTool.mock.calls).toEqual([
       ["navigate_page", { type: "url", url: "https://airlockhq.com" }],
       ["new_page", { url: "https://airlockhq.com" }],
-      ["take_snapshot"],
       [
         "evaluate_script",
         {
@@ -286,6 +286,7 @@ describe("main", () => {
           ),
         },
       ],
+      ["take_snapshot"],
     ]);
     expect(String(write.mock.calls[0]?.[0])).toContain("title: Airlock");
     expect(String(write.mock.calls[0]?.[0])).toContain(
@@ -302,6 +303,7 @@ describe("main", () => {
     callTool
       .mockRejectedValueOnce(await reconnectClearedError())
       .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("")
       .mockResolvedValueOnce('RootWebArea "Airlock"\n  uid=1 link "Sign in"');
 
     await main(["open", "https://airlockhq.com"]);
@@ -309,7 +311,6 @@ describe("main", () => {
     expect(callTool.mock.calls).toEqual([
       ["navigate_page", { type: "url", url: "https://airlockhq.com" }],
       ["new_page", { url: "https://airlockhq.com" }],
-      ["take_snapshot"],
       [
         "evaluate_script",
         {
@@ -318,6 +319,7 @@ describe("main", () => {
           ),
         },
       ],
+      ["take_snapshot"],
     ]);
     expect(String(write.mock.calls[0]?.[0])).toContain("title: Airlock");
     expect(process.exitCode).toBeUndefined();

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -278,10 +278,7 @@ describe("main", () => {
     expect(callTool.mock.calls).toEqual([
       ["navigate_page", { type: "url", url: "https://airlockhq.com" }],
       ["new_page", { url: "https://airlockhq.com" }],
-      [
-        "evaluate_script",
-        expect.any(Object),
-      ],
+      ["evaluate_script", expect.any(Object)],
       ["take_snapshot"],
       ["evaluate_script", expect.any(Object)],
     ]);
@@ -308,10 +305,7 @@ describe("main", () => {
     expect(callTool.mock.calls).toEqual([
       ["navigate_page", { type: "url", url: "https://airlockhq.com" }],
       ["new_page", { url: "https://airlockhq.com" }],
-      [
-        "evaluate_script",
-        expect.any(Object),
-      ],
+      ["evaluate_script", expect.any(Object)],
       ["take_snapshot"],
       ["evaluate_script", expect.any(Object)],
     ]);

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -26,6 +26,7 @@ vi.mock("../src/client.js", () => ({
 
 import { main } from "../src/cli.js";
 import { CdpError, getSessionSnapshotIfRunning } from "../src/client.js";
+import * as generation from "../src/generation.js";
 import { setSelectedPageId } from "../src/selected-page.js";
 
 /**
@@ -162,7 +163,16 @@ describe("main", () => {
       const write = vi
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
-      callTool.mockResolvedValue("");
+      if (preflight) {
+        vi.spyOn(generation, "getCurrentGeneration").mockReturnValue(7);
+        callTool
+          .mockResolvedValueOnce(
+            'Script ran on page and returned:\n```json\n{"generation":7,"mutations":0}\n```',
+          )
+          .mockResolvedValue("");
+      } else {
+        callTool.mockResolvedValue("");
+      }
 
       await main(argv);
 
@@ -189,6 +199,7 @@ describe("main", () => {
       argv: ["upload", "@1", "-file"],
       tool: "upload_file",
       args: { uid: "1", filePath: "-file" },
+      preflight: true,
     },
     {
       argv: ["screenshot", "-shot.png"],
@@ -197,9 +208,18 @@ describe("main", () => {
     },
   ])(
     "passes dash-prefixed positional paths to $tool",
-    async ({ argv, tool, args }) => {
+    async ({ argv, tool, args, preflight }) => {
       vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-      callTool.mockResolvedValue("");
+      if (preflight) {
+        vi.spyOn(generation, "getCurrentGeneration").mockReturnValue(7);
+        callTool
+          .mockResolvedValueOnce(
+            'Script ran on page and returned:\n```json\n{"generation":7,"mutations":0}\n```',
+          )
+          .mockResolvedValue("");
+      } else {
+        callTool.mockResolvedValue("");
+      }
 
       await main(argv);
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -151,14 +151,14 @@ describe("main", () => {
   });
 
   it.each([
-    { argv: ["fill", "@1", "--literal"], tool: "fill" },
+    { argv: ["fill", "@1", "--literal"], tool: "fill", preflight: true },
     { argv: ["type", "--literal"], tool: "type_text" },
     { argv: ["wait", "--ready"], tool: "wait_for" },
     { argv: ["eval", "--counter"], tool: "evaluate_script" },
     { argv: ["dialog", "accept", "--ready"], tool: "handle_dialog" },
   ])(
     "keeps positional text beginning with -- for $tool",
-    async ({ argv, tool }) => {
+    async ({ argv, tool, preflight }) => {
       const write = vi
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
@@ -166,7 +166,15 @@ describe("main", () => {
 
       await main(argv);
 
-      expect(callTool.mock.calls[0]?.[0]).toBe(tool);
+      expect(callTool.mock.calls[0]?.[0]).toBe(
+        preflight ? "evaluate_script" : tool,
+      );
+      if (preflight) {
+        expect(callTool.mock.calls[1]).toEqual([
+          tool,
+          expect.objectContaining({ value: argv[argv.length - 1] }),
+        ]);
+      }
       expect(process.exitCode).toBeUndefined();
     },
   );

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -233,6 +233,36 @@ describe("createPageHelper", () => {
     expect(snap).toContain("uid=g7:1");
   });
 
+  it("page.snapshot recaptures after a mutation during capture", async () => {
+    vi.spyOn(generation, "bumpGeneration")
+      .mockReturnValueOnce(7)
+      .mockReturnValueOnce(8);
+    callTool
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce('RootWebArea "First"\n  uid=1 link "Home"')
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"generation":7,"mutations":1}\n```',
+      )
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce('RootWebArea "Second"\n  uid=2 link "Account"')
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"generation":8,"mutations":0}\n```',
+      );
+
+    const snap = await createPageHelper(callTool).snapshot();
+
+    expect(callTool.mock.calls.map(([name]) => name)).toEqual([
+      "evaluate_script",
+      "take_snapshot",
+      "evaluate_script",
+      "evaluate_script",
+      "take_snapshot",
+      "evaluate_script",
+    ]);
+    expect(snap).toContain('RootWebArea "Second"');
+    expect(snap).toContain("uid=g8:2");
+  });
+
   it("page.wait with number waits by duration", async () => {
     callTool.mockResolvedValueOnce("");
 

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -463,18 +463,24 @@ describe("createPageHelper", () => {
 
   it.each([
     ["click", (page: ReturnType<typeof createPageHelper>) => page.click("@12")],
-    ["fill", (page: ReturnType<typeof createPageHelper>) => page.fill("@12", "text")],
-  ])("page.%s rejects an unobserved uid before MCP acts", async (_name, action) => {
-    callTool.mockResolvedValueOnce(
-      "Script ran on page and returned:\n```json\nnull\n```",
-    );
+    [
+      "fill",
+      (page: ReturnType<typeof createPageHelper>) => page.fill("@12", "text"),
+    ],
+  ])(
+    "page.%s rejects an unobserved uid before MCP acts",
+    async (_name, action) => {
+      callTool.mockResolvedValueOnce(
+        "Script ran on page and returned:\n```json\nnull\n```",
+      );
 
-    await expect(action(createPageHelper(callTool))).rejects.toMatchObject({
-      code: "STALE_REF",
-    });
-    expect(callTool).not.toHaveBeenCalledWith("click", expect.anything());
-    expect(callTool).not.toHaveBeenCalledWith("fill", expect.anything());
-  });
+      await expect(action(createPageHelper(callTool))).rejects.toMatchObject({
+        code: "STALE_REF",
+      });
+      expect(callTool).not.toHaveBeenCalledWith("click", expect.anything());
+      expect(callTool).not.toHaveBeenCalledWith("fill", expect.anything());
+    },
+  );
 
   it("page.type calls type_text", async () => {
     callTool.mockResolvedValueOnce("");

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AxiError } from "axi-sdk-js";
 
 // --- Mock the client layer ---
@@ -31,6 +31,7 @@ import {
   parseEvalOutput,
   runScript,
 } from "../src/run.js";
+import * as generation from "../src/generation.js";
 
 /** Mock response for the evaluate_script call that page.open() makes to read url+status. */
 const OPEN_INFO_RESPONSE =
@@ -55,6 +56,7 @@ afterEach(() => {
   callTool.mockReset();
   process.exitCode = undefined;
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 // --- 1. No-args output teaches `run` ---
@@ -130,6 +132,10 @@ describe("parseEvalOutput", () => {
 // --- 4. Script helper object maps commands to bridge calls ---
 
 describe("createPageHelper", () => {
+  beforeEach(() => {
+    vi.spyOn(generation, "getCurrentGeneration").mockReturnValue(7);
+  });
+
   it("page.open calls navigate_page, falls back to new_page, returns { url, status }", async () => {
     callTool
       .mockRejectedValueOnce(new CdpError("not connected", "BROWSER_ERROR"))
@@ -208,8 +214,9 @@ describe("createPageHelper", () => {
     expect(result).toBe(3);
   });
 
-  it("page.snapshot strips header", async () => {
-    callTool.mockResolvedValueOnce(
+  it("page.snapshot stamps refs with its generation", async () => {
+    vi.spyOn(generation, "bumpGeneration").mockReturnValue(7);
+    callTool.mockResolvedValue(
       '## Latest page snapshot\nRootWebArea "Title"\n  uid=1 link "Home"',
     );
 
@@ -219,6 +226,7 @@ describe("createPageHelper", () => {
     expect(callTool).toHaveBeenCalledWith("take_snapshot");
     expect(snap).toContain("RootWebArea");
     expect(snap).not.toContain("## Latest");
+    expect(snap).toContain("uid=g7:1");
   });
 
   it("page.wait with number waits by duration", async () => {
@@ -256,8 +264,13 @@ describe("createPageHelper", () => {
     expect(fn).toContain("5000");
   });
 
-  it("page.click calls click with parsed uid", async () => {
-    callTool.mockResolvedValueOnce("");
+  it("page.click calls click with a fresh uid", async () => {
+    vi.spyOn(generation, "getCurrentGeneration").mockReturnValue(7);
+    callTool
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"generation":7,"mutations":0}\n```',
+      )
+      .mockResolvedValueOnce("");
 
     const page = createPageHelper(callTool);
     await page.click("@12");
@@ -266,7 +279,11 @@ describe("createPageHelper", () => {
   });
 
   it("page.click accepts uid without @", async () => {
-    callTool.mockResolvedValueOnce("");
+    callTool
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"generation":7,"mutations":0}\n```',
+      )
+      .mockResolvedValueOnce("");
 
     const page = createPageHelper(callTool);
     await page.click("5");
@@ -275,7 +292,11 @@ describe("createPageHelper", () => {
   });
 
   it("page.click accepts stamped uid refs", async () => {
-    callTool.mockResolvedValueOnce("");
+    callTool
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"generation":7,"mutations":0}\n```',
+      )
+      .mockResolvedValueOnce("");
 
     const page = createPageHelper(callTool);
     await page.click("@g7:12_3");
@@ -307,8 +328,13 @@ describe("createPageHelper", () => {
     expect(fn).toContain(".click()");
   });
 
-  it("page.fill calls fill with uid and value", async () => {
-    callTool.mockResolvedValueOnce("");
+  it("page.fill calls fill with a fresh uid and value", async () => {
+    vi.spyOn(generation, "getCurrentGeneration").mockReturnValue(7);
+    callTool
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"generation":7,"mutations":0}\n```',
+      )
+      .mockResolvedValueOnce("");
 
     const page = createPageHelper(callTool);
     await page.fill("@3", "hello");
@@ -317,7 +343,11 @@ describe("createPageHelper", () => {
   });
 
   it("page.fill accepts stamped uid refs", async () => {
-    callTool.mockResolvedValueOnce("");
+    callTool
+      .mockResolvedValueOnce(
+        'Script ran on page and returned:\n```json\n{"generation":7,"mutations":0}\n```',
+      )
+      .mockResolvedValueOnce("");
 
     const page = createPageHelper(callTool);
     await page.fill("@g7:3", "hello");
@@ -325,21 +355,72 @@ describe("createPageHelper", () => {
     expect(callTool).toHaveBeenCalledWith("fill", { uid: "3", value: "hello" });
   });
 
-  it("page.fill with CSS selector uses evaluate_script", async () => {
+  it("page.fill with CSS selector updates the native value and sends events", async () => {
     callTool.mockResolvedValueOnce("");
 
     const page = createPageHelper(callTool);
     await page.fill("input[name='search']", "query");
 
-    expect(callTool).toHaveBeenCalledWith("evaluate_script", {
-      function: expect.stringContaining("input[name='search']"),
-    });
     const fn = callTool.mock.calls[0][1].function;
-    expect(fn).toContain("query");
-    expect(fn).toContain("dispatchEvent");
-    expect(fn).toContain("HTMLInputElement.prototype");
-    expect(fn).toContain("Object.getOwnPropertyDescriptor(proto, 'value').set");
-    expect(fn).not.toContain("el.value =");
+    class Field {
+      currentValue = "";
+      readonly events: string[] = [];
+
+      focus(): void {}
+
+      dispatchEvent(event: { type: string }): boolean {
+        this.events.push(event.type);
+        return true;
+      }
+    }
+    class Input extends Field {}
+    class TextArea extends Field {}
+    class Select extends Field {}
+    for (const Element of [Input, TextArea, Select]) {
+      Object.defineProperty(Element.prototype, "value", {
+        get(this: Field): string {
+          return this.currentValue;
+        },
+        set(this: Field, value: string) {
+          this.currentValue = value;
+        },
+      });
+    }
+    class TestEvent {
+      constructor(public readonly type: string) {}
+    }
+    const elements = [new Input(), new TextArea(), new Select()];
+    let current = elements[0];
+    vi.stubGlobal("document", {
+      querySelector: (selector: string) =>
+        selector === "input[name='search']" ? current : null,
+    });
+    vi.stubGlobal("HTMLInputElement", Input);
+    vi.stubGlobal("HTMLTextAreaElement", TextArea);
+    vi.stubGlobal("HTMLSelectElement", Select);
+    vi.stubGlobal("Event", TestEvent);
+
+    for (const element of elements) {
+      current = element;
+      new Function(fn)();
+      expect(element.currentValue).toBe("query");
+      expect(element.events).toEqual(["input", "change"]);
+    }
+  });
+
+  it.each([
+    ["click", (page: ReturnType<typeof createPageHelper>) => page.click("@12")],
+    ["fill", (page: ReturnType<typeof createPageHelper>) => page.fill("@12", "text")],
+  ])("page.%s rejects an unobserved uid before MCP acts", async (_name, action) => {
+    callTool.mockResolvedValueOnce(
+      "Script ran on page and returned:\n```json\nnull\n```",
+    );
+
+    await expect(action(createPageHelper(callTool))).rejects.toMatchObject({
+      code: "STALE_REF",
+    });
+    expect(callTool).not.toHaveBeenCalledWith("click", expect.anything());
+    expect(callTool).not.toHaveBeenCalledWith("fill", expect.anything());
   });
 
   it("page.type calls type_text", async () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -337,6 +337,9 @@ describe("createPageHelper", () => {
     const fn = callTool.mock.calls[0][1].function;
     expect(fn).toContain("query");
     expect(fn).toContain("dispatchEvent");
+    expect(fn).toContain("HTMLInputElement.prototype");
+    expect(fn).toContain("Object.getOwnPropertyDescriptor(proto, 'value').set");
+    expect(fn).not.toContain("el.value =");
   });
 
   it("page.type calls type_text", async () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -223,6 +223,10 @@ describe("createPageHelper", () => {
     const page = createPageHelper(callTool);
     const snap = await page.snapshot();
 
+    expect(callTool.mock.calls.slice(0, 2).map(([name]) => name)).toEqual([
+      "evaluate_script",
+      "take_snapshot",
+    ]);
     expect(callTool).toHaveBeenCalledWith("take_snapshot");
     expect(snap).toContain("RootWebArea");
     expect(snap).not.toContain("## Latest");
@@ -364,11 +368,18 @@ describe("createPageHelper", () => {
     const fn = callTool.mock.calls[0][1].function;
     class Field {
       currentValue = "";
+      trackerValue = "";
       readonly events: string[] = [];
+      readonly observedExternalValues: boolean[] = [];
 
       focus(): void {}
 
       dispatchEvent(event: { type: string }): boolean {
+        if (event.type === "input") {
+          const changed = this.currentValue !== this.trackerValue;
+          this.observedExternalValues.push(changed);
+          if (changed) this.trackerValue = this.currentValue;
+        }
         this.events.push(event.type);
         return true;
       }
@@ -401,10 +412,22 @@ describe("createPageHelper", () => {
     vi.stubGlobal("Event", TestEvent);
 
     for (const element of elements) {
+      const proto = Object.getPrototypeOf(element);
+      const nativeValue = Object.getOwnPropertyDescriptor(proto, "value")!;
+      Object.defineProperty(element, "value", {
+        get(this: Field): string {
+          return nativeValue.get!.call(this);
+        },
+        set(this: Field, value: string) {
+          nativeValue.set!.call(this, value);
+          this.trackerValue = value;
+        },
+      });
       current = element;
       new Function(fn)();
       expect(element.currentValue).toBe("query");
       expect(element.events).toEqual(["input", "change"]);
+      expect(element.observedExternalValues).toEqual([true]);
     }
   });
 
@@ -566,9 +589,11 @@ describe("page.open fallback", () => {
 
 describe("page.snapshot header stripping", () => {
   it("strips MCP preamble from snapshot", async () => {
-    callTool.mockResolvedValueOnce(
-      'Page snapshot captured.\n\n## Latest page snapshot\n\nRootWebArea "Hi"\n  uid=1 button "OK"',
-    );
+    callTool
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(
+        'Page snapshot captured.\n\n## Latest page snapshot\n\nRootWebArea "Hi"\n  uid=1 button "OK"',
+      );
 
     const page = createPageHelper(callTool);
     const snap = await page.snapshot();


### PR DESCRIPTION
## Intent

Restore chrome-devtools-axi's promised default UI interaction behavior for issue #98: selector-based fill must update React-controlled inputs instead of reporting false success, and stale untagged UID actions must fail loudly rather than silently target a re-rendered element. Keep uid fill on the existing MCP path, use the native DOM value setter for selector fill, and add no CDP typing capability or new browser powers.

## What Changed

- Updated selector-based `fill` to call the native value setter before dispatching input and change events, so controlled form fields receive updates.
- Centralized snapshot freshness tracking; CLI and script UID actions now reject missing, stale, or untracked page state with `STALE_REF`.
- Documented generation-tagged refs and the freshness rules for legacy untagged UID actions.

## Risk Assessment

✅ Low: The change is bounded to the requested selector-fill and UID-freshness paths; the shared capture/preflight lifecycle now fails closed on missing or mutated marker state and preserves the existing MCP UID fill path.

## Testing

Targeted Vitest validation passed for shared snapshot freshness, run-helper UID actions, selector fill, and open recovery. The run-API transcript demonstrates native controlled-input updates and input/change events, preserves UID fill on MCP after freshness preflight, and rejects an unobserved untagged UID with STALE_REF before MCP fill. No screenshot applies: the changed end-user surface is the CLI/run API.

<details>
<summary>Evidence: Issue #98 run API transcript</summary>

`Selector fill set native value "axi", emitted input/change, and registered a native update. Fresh UID fill used MCP; missing-marker UID fill returned STALE_REF before MCP dispatch.`

```text
{"scenario":"selector-fill-for-controlled-input","script_stdout":"selector-fill-complete","native_value":"axi","input_saw_native_update":true,"events":["input","change"],"bridge_tools":["evaluate_script"]}
{"scenario":"fresh-uid-fill-remains-mcp","script_stdout":"uid-fill-complete","bridge_calls":[{"name":"evaluate_script","args":{"function":"() => {\n  const state = globalThis[\"__chromeDevtoolsAxiSnapshotGeneration\"];\n  if (!state || typeof state.generation !== 'number' || typeof state.mutations !== 'number' || !state.observer) return null;\n  return { generation: state.generation, mutations: state.mutations };\n}"}},{"name":"fill","args":{"uid":"12","value":"axi"}}]}
{"scenario":"untagged-uid-with-missing-marker","error_code":"STALE_REF","bridge_tools":["evaluate_script"],"mcp_fill_dispatched":false}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"03feffa13e4b362f7473daaafaba5331198861a6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (5) ✅</summary>

- 🚨 `src/cli.ts:1075` - Required criterion “stale untagged UID actions must fail loudly rather than silently target a re-rendered element” remains violated when the page marker is absent. After snapshot generation 7, a navigation/re-render that clears `globalThis[PAGE_GENERATION_KEY]` makes the preflight return its local fallback 7; the new `current !== snapshotGeneration` check passes and `@12` is sent to MCP. Treat missing/unusable observer state as unavailable and fail the untagged ref closed with `STALE_REF`.
- 🚨 `src/run.ts:249` - Required criterion “stale untagged UID actions must fail loudly” is still absent from the documented `run` API. `page.snapshot()` returns unstamped refs and, after a DOM re-render, `page.fill(&#39;@12&#39;, &#39;x&#39;)`/`page.click(&#39;@12&#39;)` only strip the UID and call MCP, so they can silently act on the replacement element. Route run snapshots and UID actions through the same freshness lifecycle as CLI actions.
- ⚠️ `test/run.test.ts:340` - The added assertions only inspect generated JavaScript strings. They do not execute the forwarded selector-fill function, so they can pass while its native-setter call fails or does not update observable element state. Replace/refine this same-pattern test with a minimal executable DOM-shaped harness that asserts the value and input/change events.

🔧 Fix: Harden stale UID freshness checks
1 error still open:

- 🚨 `test/main.test.ts:165` - This changed test now makes `fill` perform an `evaluate_script` freshness preflight, but its shared `mockResolvedValue(&#34;&#34;)` parses as no marker and throws `STALE_REF`. The asserted `fill` call and successful exit are therefore unreachable; return `{ &#34;generation&#34;: 7, &#34;mutations&#34;: 0 }` for that preflight before the fill response.

🔧 Fix: Fix UID preflight test fixtures
2 issues (1 error, 1 warning) still open:

- 🚨 `src/uid-freshness.ts:20` - The observer starts only after `take_snapshot` has returned. A React re-render can occur in that gap: the old tree is stamped `gN`, the marker is then installed on the replacement DOM with `mutations: 0`, and the subsequent UID action passes freshness checks and reaches MCP. Start the marker/generation before capturing the snapshot at the shared snapshot boundary, so every post-snapshot mutation is observable.
- ⚠️ `test/run.test.ts:358` - The executable selector-fill test does not model the React-controlled failure: all fake elements expose only a prototype `value` setter, so both the new native-setter path and the old direct `el.value = ...` path produce the same value and events. Add an instance-level tracker setter like React&#39;s and assert the dispatched input event observes a changed native value; the test should fail with the original assignment.

🔧 Fix: Close snapshot freshness race
1 error still open:

- 🚨 `src/uid-freshness.ts:21` - `captureFreshSnapshot` now invokes `evaluate_script` before `take_snapshot`, but both open-recovery fixtures still queue the snapshot as the third response and expect the old reverse order. The marker call consumes that snapshot text; `take_snapshot` then receives `undefined`, so both tests render an error instead of their asserted successful output. Queue a marker response first and update the expected order.

🔧 Fix: Fix open recovery snapshot fixtures
2 issues (1 error, 1 warning) still open:

- 🚨 `src/uid-freshness.ts:21` - The marker begins before `take_snapshot`, but the snapshot is returned without checking whether a mutation happened during that interval. Concrete path: a timer/React update runs after line 21 installs generation 7 and before line 22 captures the tree; the returned tree is tagged `g7`, yet its marker already has `mutations: 1`, so the next UID action always throws `STALE_REF` even though its ref came from that latest snapshot. Fixing this needs a specified retry/recapture policy at the shared capture boundary, so that remedy needs authorization.
- ⚠️ `test/main.test.ts:284` - Both updated open-recovery fixtures assert that generated `evaluate_script` source contains the private marker key. This is source-content-only evidence and can pass with nonfunctional observer setup. Keep the observable call ordering/output assertions, but remove this inner-function substring assertion or replace it with an executable marker behavior check.

🔧 Fix: Recapture snapshots after observed mutations
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm test test/run.test.ts test/interaction.test.ts test/main.test.ts`
- <code>Executable `runScript` harness for controlled selector fill, fresh UID MCP fill, and missing-marker untagged UID rejection</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
